### PR TITLE
Feature/cbolles/adc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,7 +135,7 @@ set(CMAKE_CXX_FLAGS         "${EVT_COMMON_FLAGS} \
 # TODO: Check for platform to decide which linker script to use
 set(CMAKE_EXE_LINKER_FLAGS  "-mfloat-abi=hard -specs=nano.specs -specs=nosys.specs \
                             -T ${PROJECT_SOURCE_DIR}/libs/HALf3/STM32F302C8Tx_FLASH.ld \
-                            -lc -lm -lnosys")
+                            -lc -lm -lnosys -u _printf_float")
 
 ###############################################################################
 # Handle dependencies

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,10 +97,12 @@ add_library(${PROJECT_NAME} STATIC)
 
 # Add sources
 target_sources(${PROJECT_NAME} PRIVATE
+    src/io/ADC.cpp
     src/io/CAN.cpp
     src/io/GPIO.cpp
     src/io/PWM.cpp
     src/io/UART.cpp
+    src/io/platform/f3xx/f302x8/ADCf302x8.cpp
     src/io/platform/f3xx/f302x8/CANf302x8.cpp
     src/io/platform/f3xx/f302x8/GPIOf302x8.cpp
     src/io/platform/f3xx/f302x8/PWMf302x8.cpp

--- a/include/EVT/io/ADC.hpp
+++ b/include/EVT/io/ADC.hpp
@@ -1,0 +1,52 @@
+#ifndef _EVT_ADC_
+#define _EVT_ADC_
+
+#include <stdint.h>
+
+namespace EVT::core::IO {
+
+// Forward declarations:
+// The different pins are hardware specific. Forware declarationsto allow
+// at compilation time the decision of which pins should be used.
+enum class Pin;
+
+class ADC {
+
+public:
+    /**
+     * Setup the given pin for ADC (analog to digital) usage
+     *
+     * @param pin The pin to setup for ADC
+     */
+    ADC(Pin pin);
+
+    /**
+     * Reads the current voltage in volts on the ADC
+     *
+     * @return The voltage in volts
+     */
+    virtual float read() = 0;
+
+    /**
+     * Read the raw value from the ADC
+     *
+     * @return The raw value from the ADC
+     */
+    virtual uint32_t readRaw() = 0;
+
+    /**
+     * Read the value from the ADC as a percentage of the possible values
+     * from 0 to 1
+     *
+     * @return The ADC value as a percentage
+     */
+    virtual float readPercentage() = 0;
+
+protected:
+    /// The pin the ADC is attached to
+    Pin pin;
+};
+
+}  // namespace EVT::core::IO
+
+#endif

--- a/include/EVT/io/manager.hpp
+++ b/include/EVT/io/manager.hpp
@@ -3,11 +3,13 @@
 
 #include <stdint.h>
 
+#include <EVT/io/ADC.hpp>
 #include <EVT/io/CAN.hpp>
 #include <EVT/io/GPIO.hpp>
 #include <EVT/io/PWM.hpp>
 
 #ifdef STM32F302x8
+    #include <EVT/io/platform/f3xx/f302x8/ADCf302x8.hpp>
     #include <EVT/io/platform/f3xx/f302x8/CANf302x8.hpp>
     #include <EVT/io/platform/f3xx/f302x8/GPIOf302x8.hpp>
     #include <EVT/io/platform/f3xx/f302x8/PWMf302x8.hpp>
@@ -16,6 +18,19 @@
 
 namespace EVT::core::IO
 {
+
+/**
+ * Get an instance of an ADC channel
+ *
+ * @param pin The pin to use with the ADC
+ */
+template<Pin pin>
+ADC& getADC() {
+    #ifdef STM32F302x8
+        static ADCf302x8 adc(pin);
+        return adc;
+    #endif
+}
 
 /**
  * Get an instance of a CAN interface.

--- a/include/EVT/io/platform/f3xx/f302x8/ADCf302x8.hpp
+++ b/include/EVT/io/platform/f3xx/f302x8/ADCf302x8.hpp
@@ -56,7 +56,7 @@ private:
     static Pin channels[MAX_CHANNELS];
     /// Buffer for DMA where each spot represents the value read in from a
     /// channel
-    static uint32_t buffer[MAX_CHANNELS];
+    static uint16_t buffer[MAX_CHANNELS];
     static DMA_HandleTypeDef halDMA;
 
     /**

--- a/include/EVT/io/platform/f3xx/f302x8/ADCf302x8.hpp
+++ b/include/EVT/io/platform/f3xx/f302x8/ADCf302x8.hpp
@@ -1,0 +1,66 @@
+#ifndef _EVT_ADCf302x8_
+#define _EVT_ADCf302x8_
+
+#include <HALf3/stm32f3xx.h>
+#include <HALf3/stm32f3xx_hal.h>
+
+#include <EVT/io/ADC.hpp>
+
+namespace EVT::core::IO {
+
+class ADCf302x8 : public ADC {
+public:
+
+    /**
+     * Setup the given pin for ADC usage
+     *
+     * @param pin The pin to setup for ADC
+     */
+    ADCf302x8(Pin pin);
+
+    /**
+     * Read the value on the ADC in volts.
+     *
+     * @return The voltage in volts
+     */
+    float read();
+
+    /**
+     * Read the raw value from the ADC
+     *
+     * @return The raw value from the ADC
+     */
+    uint32_t readRaw();
+
+    /**
+     * Read the value from the ADC as a percentage of the possible values
+     * from 0 to 1
+     *
+     * @return The ADC value as a percentage
+     */
+    float readPercentage();
+
+
+private:
+    // Max number of channels supported by the ADC
+    static constexpr uint8_t MAX_CHANNELS = 15;
+    // Max voltage of the ADC
+    static constexpr float MAX_VOLTAGE = 3.6;
+    // Max value for a 12 bit ADC reading
+    static constexpr uint32_t MAX_RAW = 4095;
+    /// This is static since the STM32F3xx only has a single ADC which
+    /// supports muliple channels. The ADC will be initialized once then
+    /// each channel will be added on.
+    static ADC_HandleTypeDef halADC;
+    /// Static list of all channels supported by the ADC
+    static Pin channels[MAX_CHANNELS];
+    /// Buffer for DMA where each spot represents the value read in from a
+    /// channel
+    static uint32_t buffer[MAX_CHANNELS];
+    static DMA_HandleTypeDef halDMA;
+};
+
+
+}  // namespace EVT::core::IO
+
+#endif

--- a/include/EVT/io/platform/f3xx/f302x8/ADCf302x8.hpp
+++ b/include/EVT/io/platform/f3xx/f302x8/ADCf302x8.hpp
@@ -58,6 +58,24 @@ private:
     /// channel
     static uint32_t buffer[MAX_CHANNELS];
     static DMA_HandleTypeDef halDMA;
+
+    /**
+     * Initialize the HAL ADC handler. This should only have to be run once
+     */
+    void initADC();
+
+    /**
+     * Initialize the HALD DMA for the ADC, should only have to be run once
+     */
+    void initDMA();
+
+    /**
+     * Adds an ADC channel to the HAL ADC device.
+     *
+     * @param rank The "rank" which represents the order in which the channle
+     *      was added to the ADC starting at 1
+     */
+    void addChannel(uint8_t rank);
 };
 
 

--- a/libs/HALf3/include/HALf3/stm32f3xx_hal_adc.h
+++ b/libs/HALf3/include/HALf3/stm32f3xx_hal_adc.h
@@ -1,0 +1,273 @@
+/**
+  ******************************************************************************
+  * @file    stm32f3xx_hal_adc.h
+  * @author  MCD Application Team
+  * @brief   Header file containing functions prototypes of ADC HAL library.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) 2016 STMicroelectronics.
+  * All rights reserved.</center></h2>
+  *
+  * This software component is licensed by ST under BSD 3-Clause license,
+  * the "License"; You may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at:
+  *                        opensource.org/licenses/BSD-3-Clause
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32F3xx_ADC_H
+#define __STM32F3xx_ADC_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f3xx_hal_def.h"
+   
+/* Include ADC HAL Extended module */
+/* (include on top of file since ADC structures are defined in extended file) */
+#include "stm32f3xx_hal_adc_ex.h"
+   
+/** @addtogroup STM32F3xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup ADC
+  * @{
+  */ 
+
+/* Exported types ------------------------------------------------------------*/
+/** @defgroup ADC_Exported_Types ADC Exported Types
+  * @{
+  */
+/** 
+  * @brief  HAL ADC state machine: ADC states definition (bitfields)
+  * @note   ADC state machine is managed by bitfields, state must be compared
+  *         with bit by bit.
+  *         For example:                                                         
+  *           " if (HAL_IS_BIT_SET(HAL_ADC_GetState(hadc1), HAL_ADC_STATE_REG_BUSY)) "
+  *           " if (HAL_IS_BIT_SET(HAL_ADC_GetState(hadc1), HAL_ADC_STATE_AWD1)    ) "
+  */
+/* States of ADC global scope */
+#define HAL_ADC_STATE_RESET             (0x00000000U)    /*!< ADC not yet initialized or disabled */
+#define HAL_ADC_STATE_READY             (0x00000001U)    /*!< ADC peripheral ready for use */
+#define HAL_ADC_STATE_BUSY_INTERNAL     (0x00000002U)    /*!< ADC is busy to internal process (initialization, calibration) */
+#define HAL_ADC_STATE_TIMEOUT           (0x00000004U)    /*!< TimeOut occurrence */
+
+/* States of ADC errors */
+#define HAL_ADC_STATE_ERROR_INTERNAL    (0x00000010U)    /*!< Internal error occurrence */
+#define HAL_ADC_STATE_ERROR_CONFIG      (0x00000020U)    /*!< Configuration error occurrence */
+#define HAL_ADC_STATE_ERROR_DMA         (0x00000040U)    /*!< DMA error occurrence */
+
+/* States of ADC group regular */
+#define HAL_ADC_STATE_REG_BUSY          (0x00000100U)    /*!< A conversion on group regular is ongoing or can occur (either by continuous mode,
+                                                                       external trigger, low power auto power-on, multimode ADC master control) */
+#define HAL_ADC_STATE_REG_EOC           (0x00000200U)    /*!< Conversion data available on group regular */
+#define HAL_ADC_STATE_REG_OVR           (0x00000400U)    /*!< Overrun occurrence */
+#define HAL_ADC_STATE_REG_EOSMP         (0x00000800U)    /*!< End Of Sampling flag raised  */
+
+/* States of ADC group injected */
+#define HAL_ADC_STATE_INJ_BUSY          (0x00001000U)    /*!< A conversion on group injected is ongoing or can occur (either by auto-injection mode,
+                                                                       external trigger, low power auto power-on, multimode ADC master control) */
+#define HAL_ADC_STATE_INJ_EOC           (0x00002000U)    /*!< Conversion data available on group injected */
+#define HAL_ADC_STATE_INJ_JQOVF         (0x00004000U)    /*!< Injected queue overflow occurrence */
+
+/* States of ADC analog watchdogs */
+#define HAL_ADC_STATE_AWD1              (0x00010000U)    /*!< Out-of-window occurrence of analog watchdog 1 */
+#define HAL_ADC_STATE_AWD2              (0x00020000U)    /*!< Out-of-window occurrence of analog watchdog 2 */
+#define HAL_ADC_STATE_AWD3              (0x00040000U)    /*!< Out-of-window occurrence of analog watchdog 3 */
+
+/* States of ADC multi-mode */
+#define HAL_ADC_STATE_MULTIMODE_SLAVE   (0x00100000U)    /*!< ADC in multimode slave state, controlled by another ADC master ( */
+
+
+/** 
+  * @brief  ADC handle Structure definition  
+  */
+typedef struct __ADC_HandleTypeDef
+{
+  ADC_TypeDef                   *Instance;              /*!< Register base address */
+
+  ADC_InitTypeDef               Init;                   /*!< ADC required parameters */
+
+  DMA_HandleTypeDef             *DMA_Handle;            /*!< Pointer DMA Handler */
+
+  HAL_LockTypeDef               Lock;                   /*!< ADC locking object */
+
+  __IO uint32_t                 State;                  /*!< ADC communication state (bitmap of ADC states) */
+
+  __IO uint32_t                 ErrorCode;              /*!< ADC Error code */
+  
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+  ADC_InjectionConfigTypeDef    InjectionConfig ;       /*!< ADC injected channel configuration build-up structure */  
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+
+#if (USE_HAL_ADC_REGISTER_CALLBACKS == 1)
+  void (* ConvCpltCallback)(struct __ADC_HandleTypeDef *hadc);              /*!< ADC conversion complete callback */
+  void (* ConvHalfCpltCallback)(struct __ADC_HandleTypeDef *hadc);          /*!< ADC conversion DMA half-transfer callback */
+  void (* LevelOutOfWindowCallback)(struct __ADC_HandleTypeDef *hadc);      /*!< ADC analog watchdog 1 callback */
+  void (* ErrorCallback)(struct __ADC_HandleTypeDef *hadc);                 /*!< ADC error callback */
+  void (* InjectedConvCpltCallback)(struct __ADC_HandleTypeDef *hadc);      /*!< ADC group injected conversion complete callback */       /*!< ADC end of sampling callback */
+  void (* MspInitCallback)(struct __ADC_HandleTypeDef *hadc);               /*!< ADC Msp Init callback */
+  void (* MspDeInitCallback)(struct __ADC_HandleTypeDef *hadc);             /*!< ADC Msp DeInit callback */
+#endif /* USE_HAL_ADC_REGISTER_CALLBACKS */
+}ADC_HandleTypeDef;
+
+#if (USE_HAL_ADC_REGISTER_CALLBACKS == 1)
+/**
+  * @brief  HAL ADC Callback ID enumeration definition
+  */
+typedef enum
+{
+  HAL_ADC_CONVERSION_COMPLETE_CB_ID     = 0x00U,  /*!< ADC conversion complete callback ID */
+  HAL_ADC_CONVERSION_HALF_CB_ID         = 0x01U,  /*!< ADC conversion DMA half-transfer callback ID */
+  HAL_ADC_LEVEL_OUT_OF_WINDOW_1_CB_ID   = 0x02U,  /*!< ADC analog watchdog 1 callback ID */
+  HAL_ADC_ERROR_CB_ID                   = 0x03U,  /*!< ADC error callback ID */
+  HAL_ADC_INJ_CONVERSION_COMPLETE_CB_ID = 0x04U,  /*!< ADC group injected conversion complete callback ID */
+  HAL_ADC_MSPINIT_CB_ID                 = 0x09U,  /*!< ADC Msp Init callback ID          */
+  HAL_ADC_MSPDEINIT_CB_ID               = 0x0AU   /*!< ADC Msp DeInit callback ID        */
+} HAL_ADC_CallbackIDTypeDef;
+
+/**
+  * @brief  HAL ADC Callback pointer definition
+  */
+typedef  void (*pADC_CallbackTypeDef)(ADC_HandleTypeDef *hadc); /*!< pointer to a ADC callback function */
+
+#endif /* USE_HAL_ADC_REGISTER_CALLBACKS */
+
+/**
+  * @}
+  */
+
+/* Exported constants --------------------------------------------------------*/
+/* Exported macros -----------------------------------------------------------*/
+     
+/** @defgroup ADC_Exported_Macro ADC Exported Macros
+  * @{
+  */
+/** @brief  Reset ADC handle state
+  * @param  __HANDLE__ ADC handle
+  * @retval None
+  */
+#if (USE_HAL_ADC_REGISTER_CALLBACKS == 1)
+#define __HAL_ADC_RESET_HANDLE_STATE(__HANDLE__)                               \
+  do{                                                                          \
+     (__HANDLE__)->State = HAL_ADC_STATE_RESET;                                \
+     (__HANDLE__)->MspInitCallback = NULL;                                     \
+     (__HANDLE__)->MspDeInitCallback = NULL;                                   \
+    } while(0)
+#else
+#define __HAL_ADC_RESET_HANDLE_STATE(__HANDLE__)                               \
+  ((__HANDLE__)->State = HAL_ADC_STATE_RESET)
+#endif
+
+/**
+  * @}
+  */ 
+
+
+
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup ADC_Exported_Functions ADC Exported Functions
+  * @{
+  */ 
+
+/** @addtogroup ADC_Exported_Functions_Group1 Initialization and de-initialization functions 
+ * @{
+ */ 
+/* Initialization and de-initialization functions  **********************************/
+HAL_StatusTypeDef       HAL_ADC_Init(ADC_HandleTypeDef* hadc);
+HAL_StatusTypeDef       HAL_ADC_DeInit(ADC_HandleTypeDef *hadc);
+void                    HAL_ADC_MspInit(ADC_HandleTypeDef* hadc);
+void                    HAL_ADC_MspDeInit(ADC_HandleTypeDef* hadc);
+
+#if (USE_HAL_ADC_REGISTER_CALLBACKS == 1)
+/* Callbacks Register/UnRegister functions  ***********************************/
+HAL_StatusTypeDef HAL_ADC_RegisterCallback(ADC_HandleTypeDef *hadc, HAL_ADC_CallbackIDTypeDef CallbackID, pADC_CallbackTypeDef pCallback);
+HAL_StatusTypeDef HAL_ADC_UnRegisterCallback(ADC_HandleTypeDef *hadc, HAL_ADC_CallbackIDTypeDef CallbackID);
+#endif /* USE_HAL_ADC_REGISTER_CALLBACKS */
+/**
+  * @}
+  */
+
+/** @addtogroup ADC_Exported_Functions_Group2 Input and Output operation functions
+ * @{
+ */ 
+/* Blocking mode: Polling */
+HAL_StatusTypeDef       HAL_ADC_Start(ADC_HandleTypeDef* hadc);
+HAL_StatusTypeDef       HAL_ADC_Stop(ADC_HandleTypeDef* hadc);
+HAL_StatusTypeDef       HAL_ADC_PollForConversion(ADC_HandleTypeDef* hadc, uint32_t Timeout);
+HAL_StatusTypeDef       HAL_ADC_PollForEvent(ADC_HandleTypeDef* hadc, uint32_t EventType, uint32_t Timeout);
+
+/* Non-blocking mode: Interruption */
+HAL_StatusTypeDef       HAL_ADC_Start_IT(ADC_HandleTypeDef* hadc);
+HAL_StatusTypeDef       HAL_ADC_Stop_IT(ADC_HandleTypeDef* hadc);
+
+/* Non-blocking mode: DMA */
+HAL_StatusTypeDef       HAL_ADC_Start_DMA(ADC_HandleTypeDef* hadc, uint32_t* pData, uint32_t Length);
+HAL_StatusTypeDef       HAL_ADC_Stop_DMA(ADC_HandleTypeDef* hadc);
+
+/* ADC retrieve conversion value intended to be used with polling or interruption */
+uint32_t                HAL_ADC_GetValue(ADC_HandleTypeDef* hadc);
+
+/* ADC IRQHandler and Callbacks used in non-blocking modes (Interruption and DMA) */
+void                    HAL_ADC_IRQHandler(ADC_HandleTypeDef* hadc);
+void                    HAL_ADC_ConvCpltCallback(ADC_HandleTypeDef* hadc);
+void                    HAL_ADC_ConvHalfCpltCallback(ADC_HandleTypeDef* hadc);
+void                    HAL_ADC_LevelOutOfWindowCallback(ADC_HandleTypeDef* hadc);
+void                    HAL_ADC_ErrorCallback(ADC_HandleTypeDef *hadc);
+/**
+  * @}
+  */
+
+/** @addtogroup ADC_Exported_Functions_Group3 Peripheral Control functions
+ * @{
+ */ 
+/* Peripheral Control functions ***********************************************/
+HAL_StatusTypeDef       HAL_ADC_ConfigChannel(ADC_HandleTypeDef* hadc, ADC_ChannelConfTypeDef* sConfig);
+HAL_StatusTypeDef       HAL_ADC_AnalogWDGConfig(ADC_HandleTypeDef* hadc, ADC_AnalogWDGConfTypeDef* AnalogWDGConfig);
+/**
+  * @}
+  */
+
+/** @defgroup ADC_Exported_Functions_Group4 Peripheral State functions
+ *  @brief   ADC Peripheral State functions 
+ * @{
+ */ 
+/* Peripheral State functions *************************************************/
+uint32_t                HAL_ADC_GetState(ADC_HandleTypeDef* hadc);
+uint32_t                HAL_ADC_GetError(ADC_HandleTypeDef *hadc);
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*__STM32F3xx_ADC_H */
+
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libs/HALf3/include/HALf3/stm32f3xx_hal_adc_ex.h
+++ b/libs/HALf3/include/HALf3/stm32f3xx_hal_adc_ex.h
@@ -1,0 +1,3967 @@
+/**
+  ******************************************************************************
+  * @file    stm32f3xx_hal_adc_ex.h
+  * @author  MCD Application Team
+  * @brief   Header file containing functions prototypes of ADC HAL library.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) 2016 STMicroelectronics.
+  * All rights reserved.</center></h2>
+  *
+  * This software component is licensed by ST under BSD 3-Clause license,
+  * the "License"; You may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at:
+  *                        opensource.org/licenses/BSD-3-Clause
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32F3xx_ADC_EX_H
+#define __STM32F3xx_ADC_EX_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f3xx_hal_def.h"
+   
+/** @addtogroup STM32F3xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup ADCEx ADCEx
+  * @{
+  */ 
+
+/* Exported types ------------------------------------------------------------*/
+/** @defgroup ADCEx_Exported_Types ADCEx Exported Types
+  * @{
+  */
+struct __ADC_HandleTypeDef;
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+/**
+  * @brief  Structure definition of ADC initialization and regular group  
+  * @note   Parameters of this structure are shared within 2 scopes:
+  *          - Scope entire ADC (affects regular and injected groups): ClockPrescaler, Resolution, DataAlign, 
+  *            ScanConvMode, EOCSelection, LowPowerAutoWait.
+  *          - Scope regular group: ContinuousConvMode, NbrOfConversion, DiscontinuousConvMode, NbrOfDiscConversion, ExternalTrigConvEdge, ExternalTrigConv, DMAContinuousRequests, Overrun.
+  * @note   The setting of these parameters with function HAL_ADC_Init() is conditioned to ADC state.
+  *         ADC state can be either:
+  *          - For all parameters: ADC disabled
+  *          - For all parameters except 'LowPowerAutoWait' and 'DMAContinuousRequests': ADC enabled without conversion on going on regular group.
+  *          - For parameters 'LowPowerAutoWait' and 'DMAContinuousRequests': ADC enabled without conversion on going on regular and injected groups.
+  *         If ADC is not in the appropriate state to modify some parameters, these parameters setting is bypassed
+  *         without error reporting (as it can be the expected behaviour in case of intended action to update another parameter (which fullfills the ADC state condition) on the fly).
+  */
+typedef struct
+{
+  uint32_t ClockPrescaler;                  /*!< Select ADC clock source (synchronous clock derived from AHB clock or asynchronous clock derived from ADC dedicated PLL 72MHz) and clock prescaler.
+                                                 The clock is common for all the ADCs.
+                                                 This parameter can be a value of @ref ADCEx_ClockPrescaler
+                                                 Note: In case of usage of channels on injected group, ADC frequency should be lower than AHB clock frequency /4 for resolution 12 or 10 bits, 
+                                                       AHB clock frequency /3 for resolution 8 bits, AHB clock frequency /2 for resolution 6 bits.
+                                                 Note: In case of usage of the ADC dedicated PLL clock, this clock must be preliminarily enabled and prescaler set at RCC top level. 
+                                                 Note: This parameter can be modified only if all ADCs of the common ADC group are disabled (for products with several ADCs) */
+  uint32_t Resolution;                      /*!< Configures the ADC resolution. 
+                                                 This parameter can be a value of @ref ADCEx_Resolution */
+  uint32_t DataAlign;                       /*!< Specifies ADC data alignment to right (for resolution 12 bits: MSB on register bit 11 and LSB on register bit 0U) (default setting)
+                                                 or to left (for resolution 12 bits, if offset disabled: MSB on register bit 15 and LSB on register bit 4U, if offset enabled: MSB on register bit 14 and LSB on register bit 3U).
+                                                 See reference manual for alignments with other resolutions.
+                                                 This parameter can be a value of @ref ADCEx_Data_align */
+  uint32_t ScanConvMode;                    /*!< Configures the sequencer of regular and injected groups.
+                                                 This parameter can be associated to parameter 'DiscontinuousConvMode' to have main sequence subdivided in successive parts.
+                                                 If disabled: Conversion is performed in single mode (one channel converted, the one defined in rank 1U).
+                                                              Parameters 'NbrOfConversion' and 'InjectedNbrOfConversion' are discarded (equivalent to set to 1U).
+                                                 If enabled:  Conversions are performed in sequence mode (multiple ranks defined by 'NbrOfConversion'/'InjectedNbrOfConversion' and each channel rank).
+                                                              Scan direction is upward: from rank1 to rank 'n'.
+                                                 This parameter can be a value of @ref ADCEx_Scan_mode */
+  uint32_t EOCSelection;                    /*!< Specifies what EOC (End Of Conversion) flag is used for conversion by polling and interruption: end of conversion of each rank or complete sequence.
+                                                 This parameter can be a value of @ref ADCEx_EOCSelection. */
+  FunctionalState LowPowerAutoWait;         /*!< Selects the dynamic low power Auto Delay: ADC conversions are performed only when necessary.
+                                                 New conversion starts only when the previous conversion (for regular group) or previous sequence (for injected group) has been treated by user software.
+                                                 This feature automatically adapts the speed of ADC to the speed of the system that reads the data. Moreover, this avoids risk of overrun for low frequency applications. 
+                                                 This parameter can be set to ENABLE or DISABLE.
+                                                 Note: It is not recommended to use with interruption or DMA (HAL_ADC_Start_IT(), HAL_ADC_Start_DMA()) since these modes have to clear immediately the EOC flag (by CPU to free the IRQ pending event or by DMA).
+                                                       Auto wait will work but fort a very short time, discarding its intended benefit (except specific case of high load of CPU or DMA transfers which can justify usage of auto wait).
+                                                       Do use with polling: 1. Start conversion with HAL_ADC_Start(), 2. Later on, when ADC conversion data is needed:
+                                                       and use HAL_ADC_GetValue() to retrieve conversion result and trig another conversion (in case of usage of injected group, use the equivalent functions HAL_ADCExInjected_Start(), HAL_ADCEx_InjectedGetValue(), ...). */
+  FunctionalState  ContinuousConvMode;      /*!< Specifies whether the conversion is performed in single mode (one conversion) or continuous mode for regular group,
+                                                 after the selected trigger occurred (software start or external trigger).
+                                                 This parameter can be set to ENABLE or DISABLE. */
+  uint32_t NbrOfConversion;                 /*!< Specifies the number of ranks that will be converted within the regular group sequencer.
+                                                 To use the regular group sequencer and convert several ranks, parameter 'ScanConvMode' must be enabled.
+                                                 This parameter must be a number between Min_Data = 1 and Max_Data = 16.
+                                                 Note: This parameter must be modified when no conversion is on going on regular group (ADC disabled, or ADC enabled without continuous mode or external trigger that could launch a conversion). */
+  FunctionalState DiscontinuousConvMode;    /*!< Specifies whether the conversions sequence of regular group is performed in Complete-sequence/Discontinuous-sequence (main sequence subdivided in successive parts).
+                                                 Discontinuous mode is used only if sequencer is enabled (parameter 'ScanConvMode'). If sequencer is disabled, this parameter is discarded.
+                                                 Discontinuous mode can be enabled only if continuous mode is disabled. If continuous mode is enabled, this parameter setting is discarded.
+                                                 This parameter can be set to ENABLE or DISABLE. */
+  uint32_t NbrOfDiscConversion;             /*!< Specifies the number of discontinuous conversions in which the  main sequence of regular group (parameter NbrOfConversion) will be subdivided.
+                                                 If parameter 'DiscontinuousConvMode' is disabled, this parameter is discarded.
+                                                 This parameter must be a number between Min_Data = 1 and Max_Data = 8. */
+  uint32_t ExternalTrigConv;                /*!< Selects the external event used to trigger the conversion start of regular group.
+                                                 If set to ADC_SOFTWARE_START, external triggers are disabled.
+                                                 This parameter can be a value of @ref ADCEx_External_trigger_source_Regular
+                                                 Caution: For devices with several ADCs, external trigger source is common to ADC common group (for example: ADC1&ADC2, ADC3&ADC4, if available)  */
+  uint32_t ExternalTrigConvEdge;            /*!< Selects the external trigger edge of regular group.
+                                                 If trigger is set to ADC_SOFTWARE_START, this parameter is discarded.
+                                                 This parameter can be a value of @ref ADCEx_External_trigger_edge_Regular */
+  FunctionalState DMAContinuousRequests;    /*!< Specifies whether the DMA requests are performed in one shot mode (DMA transfer stop when number of conversions is reached)
+                                                 or in Continuous mode (DMA transfer unlimited, whatever number of conversions).
+                                                 Note: In continuous mode, DMA must be configured in circular mode. Otherwise an overrun will be triggered when DMA buffer maximum pointer is reached.
+                                                 This parameter can be set to ENABLE or DISABLE.
+                                                 Note: This parameter must be modified when no conversion is on going on both regular and injected groups (ADC disabled, or ADC enabled without continuous mode or external trigger that could launch a conversion). */
+  uint32_t Overrun;                         /*!< Select the behaviour in case of overrun: data overwritten (default) or preserved.
+                                                 This parameter is for regular group only.
+                                                 This parameter can be a value of @ref ADCEx_Overrun
+                                                 Note: Case of overrun set to data preserved and usage with end on conversion interruption (HAL_Start_IT()): ADC IRQ handler has to clear end of conversion flags, this induces the release of the preserved data. If needed, this data can be saved into function HAL_ADC_ConvCpltCallback() (called before end of conversion flags clear).
+                                                 Note: Error reporting in function of conversion mode:
+                                                  - Usage with ADC conversion by polling for event or interruption: Error is reported only if overrun is set to data preserved. If overrun is set to data overwritten, user can willingly not read the conversion data each time, this is not considered as an erroneous case.
+                                                  - Usage with ADC conversion by DMA: Error is reported whatever overrun setting (DMA is expected to process all data from data register, any data missed would be abnormal). */
+}ADC_InitTypeDef;
+
+/** 
+  * @brief  Structure definition of ADC channel for regular group  
+  * @note   The setting of these parameters with function HAL_ADC_ConfigChannel() is conditioned to ADC state.
+  *         ADC state can be either:
+  *          - For all parameters: ADC disabled (this is the only possible ADC state to modify parameter 'SingleDiff')
+  *          - For all except parameters 'SamplingTime', 'Offset', 'OffsetNumber': ADC enabled without conversion on going on regular group.
+  *          - For parameters 'SamplingTime', 'Offset', 'OffsetNumber': ADC enabled without conversion on going on regular and injected groups.
+  *         If ADC is not in the appropriate state to modify some parameters, these parameters setting is bypassed
+  *         without error reporting (as it can be the expected behaviour in case of intended action to update another parameter (which fulfills the ADC state condition) on the fly).
+  */
+typedef struct 
+{
+  uint32_t Channel;                /*!< Specifies the channel to configure into ADC regular group.
+                                        This parameter can be a value of @ref ADCEx_channels
+                                        Note: Depending on devices, some channels may not be available on package pins. Refer to device datasheet for channels availability. */
+  uint32_t Rank;                   /*!< Specifies the rank in the regular group sequencer.
+                                        This parameter can be a value of @ref ADCEx_regular_rank
+                                        Note: In case of need to disable a channel or change order of conversion sequencer, rank containing a previous channel setting can be overwritten by the new channel setting (or parameter number of conversions can be adjusted) */
+  uint32_t SamplingTime;           /*!< Sampling time value to be set for the selected channel.
+                                        Unit: ADC clock cycles
+                                        Conversion time is the addition of sampling time and processing time (12.5 ADC clock cycles at ADC resolution 12 bits, 10.5 cycles at 10 bits, 8.5 cycles at 8 bits, 6.5 cycles at 6 bits).
+                                        This parameter can be a value of @ref ADCEx_sampling_times
+                                        Caution: This parameter updates the parameter property of the channel, that can be used into regular and/or injected groups.
+                                                 If this same channel has been previously configured in the other group (regular/injected), it will be updated to last setting.
+                                        Note: In case of usage of internal measurement channels (VrefInt/Vbat/TempSensor),
+                                              sampling time constraints must be respected (sampling time can be adjusted in function of ADC clock frequency and sampling time setting)
+                                              Refer to device datasheet for timings values, parameters TS_vrefint, TS_vbat, TS_temp (values rough order: 2.2us min). */
+  uint32_t SingleDiff;             /*!< Selection of single-ended or differential input.
+                                        In differential mode: Differential measurement is between the selected channel 'i' (positive input) and channel 'i+1' (negative input).
+                                                              Only channel 'i' has to be configured, channel 'i+1' is configured automatically.
+                                        This parameter must be a value of @ref ADCEx_SingleDifferential
+                                        Caution: This parameter updates the parameter property of the channel, that can be used into regular and/or injected groups.
+                                                 If this same channel has been previously configured in the other group (regular/injected), it will be updated to last setting.
+                                        Note: Channels 1 to 14 are available in differential mode. Channels 15U, 16U, 17U, 18 can be used only in single-ended mode.
+                                        Note: When configuring a channel 'i' in differential mode, the channel 'i+1' is not usable separately.
+                                        Note: This parameter must be modified when ADC is disabled (before ADC start conversion or after ADC stop conversion).
+                                              If ADC is enabled, this parameter setting is bypassed without error reporting (as it can be the expected behaviour in case of another parameter update on the fly) */
+  uint32_t OffsetNumber;           /*!< Selects the offset number
+                                        This parameter can be a value of @ref ADCEx_OffsetNumber
+                                        Caution: Only one channel is allowed per channel. If another channel was on this offset number, the offset will be changed to the new channel */
+  uint32_t Offset;                 /*!< Defines the offset to be subtracted from the raw converted data when convert channels.
+                                        Offset value must be a positive number.
+                                        Depending of ADC resolution selected (12U, 10U, 8 or 6 bits), this parameter must be a number between Min_Data = 0x000 and Max_Data = 0xFFFU, 0x3FFU, 0xFF or 0x3F respectively.
+                                        Note: This parameter must be modified when no conversion is on going on both regular and injected groups (ADC disabled, or ADC enabled without continuous mode or external trigger that could launch a conversion). */
+}ADC_ChannelConfTypeDef;
+
+/** 
+  * @brief  Structure definition of ADC injected group and ADC channel for injected group  
+  * @note   Parameters of this structure are shared within 2 scopes:
+  *          - Scope channel: InjectedChannel, InjectedRank, InjectedSamplingTime , InjectedSingleDiff, InjectedOffsetNumber, InjectedOffset
+  *          - Scope injected group (affects all channels of injected group): InjectedNbrOfConversion, InjectedDiscontinuousConvMode,
+  *            AutoInjectedConv, QueueInjectedContext, ExternalTrigInjecConvEdge, ExternalTrigInjecConv.
+  * @note   The setting of these parameters with function HAL_ADCEx_InjectedConfigChannel() is conditioned to ADC state.
+  *         ADC state can be either:
+  *          - For all parameters: ADC disabled (this is the only possible ADC state to modify parameter 'InjectedSingleDiff')
+  *          - For parameters 'InjectedDiscontinuousConvMode', 'QueueInjectedContext': ADC enabled without conversion on going on injected group.
+  *          - For parameters 'InjectedSamplingTime', 'InjectedOffset', 'InjectedOffsetNumber', 'AutoInjectedConv': ADC enabled without conversion on going on regular and injected groups.
+  *          - For parameters 'InjectedChannel', 'InjectedRank', 'InjectedNbrOfConversion', 'ExternalTrigInjecConv', 'ExternalTrigInjecConvEdge': ADC enabled and while conversion on going on regular and injected groups.
+  *         If ADC is not in the appropriate state to modify some parameters, these parameters setting is bypassed
+  *         without error reporting (as it can be the expected behaviour in case of intended action to update another parameter (which fulfills the ADC state condition) on the fly).
+  */
+typedef struct 
+{
+  uint32_t InjectedChannel;                         /*!< Configure the ADC injected channel
+                                                         This parameter can be a value of @ref ADCEx_channels
+                                                         Note: Depending on devices, some channels may not be available on package pins. Refer to device datasheet for channels availability. */
+  uint32_t InjectedRank;                            /*!< The rank in the regular group sequencer
+                                                         This parameter must be a value of @ref ADCEx_injected_rank
+                                                         Note: In case of need to disable a channel or change order of conversion sequencer, rank containing a previous channel setting can be overwritten by the new channel setting (or parameter number of conversions can be adjusted) */
+  uint32_t InjectedSamplingTime;                    /*!< Sampling time value to be set for the selected channel.
+                                                         Unit: ADC clock cycles
+                                                         Conversion time is the addition of sampling time and processing time (12.5 ADC clock cycles at ADC resolution 12 bits, 10.5 cycles at 10 bits, 8.5 cycles at 8 bits, 6.5 cycles at 6 bits).
+                                                         This parameter can be a value of @ref ADCEx_sampling_times
+                                                         Caution: This parameter updates the parameter property of the channel, that can be used into regular and/or injected groups.
+                                                                  If this same channel has been previously configured in the other group (regular/injected), it will be updated to last setting.
+                                                         Note: In case of usage of internal measurement channels (VrefInt/Vbat/TempSensor),
+                                                               sampling time constraints must be respected (sampling time can be adjusted in function of ADC clock frequency and sampling time setting)
+                                                               Refer to device datasheet for timings values, parameters TS_vrefint, TS_vbat, TS_temp (values rough order: 2.2us min). */
+  uint32_t InjectedSingleDiff;                      /*!< Selection of single-ended or differential input.
+                                                         In differential mode: Differential measurement is between the selected channel 'i' (positive input) and channel 'i+1' (negative input).
+                                                                        Only channel 'i' has to be configured, channel 'i+1' is configured automatically.
+                                                         This parameter must be a value of @ref ADCEx_SingleDifferential
+                                                         Caution: This parameter updates the parameter property of the channel, that can be used into regular and/or injected groups.
+                                                                  If this same channel has been previously configured in the other group (regular/injected), it will be updated to last setting.
+                                                         Note: Channels 1 to 14 are available in differential mode. Channels 15U, 16U, 17U, 18 can be used only in single-ended mode.
+                                                         Note: When configuring a channel 'i' in differential mode, the channel 'i-1' is not usable separately.
+                                                         Note: This parameter must be modified when ADC is disabled (before ADC start conversion or after ADC stop conversion).
+                                                               If ADC is enabled, this parameter setting is bypassed without error reporting (as it can be the expected behaviour in case of another parameter update on the fly) */
+  uint32_t InjectedOffsetNumber;                    /*!< Selects the offset number
+                                                         This parameter can be a value of @ref ADCEx_OffsetNumber
+                                                         Caution: Only one channel is allowed per offset number. If another channel was on this offset number, the offset will be changed to the new channel. */
+  uint32_t InjectedOffset;                          /*!< Defines the offset to be subtracted from the raw converted data.
+                                                         Offset value must be a positive number.
+                                                         Depending of ADC resolution selected (12U, 10U, 8 or 6 bits),
+                                                         this parameter must be a number between Min_Data = 0x000 and Max_Data = 0xFFFU, 0x3FFU, 0xFF or 0x3F respectively. */
+  uint32_t InjectedNbrOfConversion;                 /*!< Specifies the number of ranks that will be converted within the injected group sequencer.
+                                                         To use the injected group sequencer and convert several ranks, parameter 'ScanConvMode' must be enabled.
+                                                         This parameter must be a number between Min_Data = 1 and Max_Data = 4.
+                                                         Caution: this setting impacts the entire injected group. Therefore, call of HAL_ADCEx_InjectedConfigChannel() to 
+                                                                  configure a channel on injected group can impact the configuration of other channels previously set. */
+  FunctionalState InjectedDiscontinuousConvMode;    /*!< Specifies whether the conversions sequence of injected group is performed in Complete-sequence/Discontinuous-sequence (main sequence subdivided in successive parts).
+                                                         Discontinuous mode is used only if sequencer is enabled (parameter 'ScanConvMode'). If sequencer is disabled, this parameter is discarded.
+                                                         Discontinuous mode can be enabled only if continuous mode is disabled. If continuous mode is enabled, this parameter setting is discarded.
+                                                         This parameter can be set to ENABLE or DISABLE.
+                                                         Note: This parameter must be modified when ADC is disabled (before ADC start conversion or after ADC stop conversion).
+                                                         Note: For injected group, number of discontinuous ranks increment is fixed to one-by-one.
+                                                         Caution: this setting impacts the entire injected group. Therefore, call of HAL_ADCEx_InjectedConfigChannel() to 
+                                                                  configure a channel on injected group can impact the configuration of other channels previously set. */
+  FunctionalState AutoInjectedConv;                 /*!< Enables or disables the selected ADC automatic injected group conversion after regular one
+                                                         This parameter can be set to ENABLE or DISABLE.      
+                                                         Note: To use Automatic injected conversion, discontinuous mode must be disabled ('DiscontinuousConvMode' and 'InjectedDiscontinuousConvMode' set to DISABLE)
+                                                         Note: To use Automatic injected conversion, injected group external triggers must be disabled ('ExternalTrigInjecConv' set to ADC_SOFTWARE_START)
+                                                         Note: In case of DMA used with regular group: if DMA configured in normal mode (single shot) JAUTO will be stopped upon DMA transfer complete.
+                                                               To maintain JAUTO always enabled, DMA must be configured in circular mode.
+                                                         Caution: this setting impacts the entire injected group. Therefore, call of HAL_ADCEx_InjectedConfigChannel() to 
+                                                                  configure a channel on injected group can impact the configuration of other channels previously set. */
+  FunctionalState QueueInjectedContext;             /*!< Specifies whether the context queue feature is enabled.
+                                                         This parameter can be set to ENABLE or DISABLE.
+                                                         If context queue is enabled, injected sequencer&channels configurations are queued on up to 2 contexts. If a
+                                                         new injected context is set when queue is full, error is triggered by interruption and through function 'HAL_ADCEx_InjectedQueueOverflowCallback'.
+                                                         Caution: This feature request that the sequence is fully configured before injected conversion start.
+                                                                  Therefore, configure channels with HAL_ADCEx_InjectedConfigChannel() as many times as value of 'InjectedNbrOfConversion' parameter.
+                                                         Caution: this setting impacts the entire injected group. Therefore, call of HAL_ADCEx_InjectedConfigChannel() to 
+                                                                  configure a channel on injected group can impact the configuration of other channels previously set.
+                                                         Note: This parameter must be modified when ADC is disabled (before ADC start conversion or after ADC stop conversion). */
+  uint32_t ExternalTrigInjecConv;                   /*!< Selects the external event used to trigger the conversion start of injected group.
+                                                         If set to ADC_INJECTED_SOFTWARE_START, external triggers are disabled.
+                                                         This parameter can be a value of @ref ADCEx_External_trigger_source_Injected
+                                                         Caution: this setting impacts the entire injected group. Therefore, call of HAL_ADCEx_InjectedConfigChannel() to 
+                                                                  configure a channel on injected group can impact the configuration of other channels previously set. */
+  uint32_t ExternalTrigInjecConvEdge;               /*!< Selects the external trigger edge of injected group.
+                                                         This parameter can be a value of @ref ADCEx_External_trigger_edge_Injected.
+                                                         If trigger is set to ADC_INJECTED_SOFTWARE_START, this parameter is discarded.
+                                                         Caution: this setting impacts the entire injected group. Therefore, call of HAL_ADCEx_InjectedConfigChannel() to 
+                                                                  configure a channel on injected group can impact the configuration of other channels previously set. */
+}ADC_InjectionConfTypeDef;
+
+/** 
+  * @brief  ADC Injection Configuration 
+  */
+typedef struct
+{
+  uint32_t ContextQueue;                 /*!< Injected channel configuration context: build-up over each 
+                                              HAL_ADCEx_InjectedConfigChannel() call to finally initialize
+                                              JSQR register at HAL_ADCEx_InjectedConfigChannel() last call */
+                                               
+  uint32_t ChannelCount;                 /*!< Number of channels in the injected sequence */                                        
+}ADC_InjectionConfigTypeDef;
+
+/** 
+  * @brief  Structure definition of ADC analog watchdog
+  * @note   The setting of these parameters with function HAL_ADC_AnalogWDGConfig() is conditioned to ADC state.
+  *         ADC state can be either: ADC disabled or ADC enabled without conversion on going on regular and injected groups.
+  */
+typedef struct
+{
+  uint32_t WatchdogNumber;           /*!< Selects which ADC analog watchdog to apply to the selected channel.
+                                          For Analog Watchdog 1: Only 1 channel can be monitored (or overall group of channels by setting parameter 'WatchdogMode')
+                                          For Analog Watchdog 2 and 3: Several channels can be monitored (by successive calls of 'HAL_ADC_AnalogWDGConfig()' for each channel)
+                                          This parameter can be a value of @ref ADCEx_analog_watchdog_number. */
+  uint32_t WatchdogMode;             /*!< For Analog Watchdog 1: Configures the ADC analog watchdog mode: single channel/overall group of channels, regular/injected group.
+                                          For Analog Watchdog 2 and 3: There is no configuration for overall group of channels as AWD1. Set value 'ADC_ANALOGWATCHDOG_NONE' to reset channels group programmed with parameter 'Channel', set any other value to not use this parameter.
+                                          This parameter can be a value of @ref ADCEx_analog_watchdog_mode. */
+  uint32_t Channel;                  /*!< Selects which ADC channel to monitor by analog watchdog.
+                                          For Analog Watchdog 1: this parameter has an effect only if parameter 'WatchdogMode' is configured on single channel. Only 1 channel can be monitored.
+                                          For Analog Watchdog 2 and 3: Several channels can be monitored (successive calls of HAL_ADC_AnalogWDGConfig() must be done, one for each channel.
+                                                                       Channels group reset can be done by setting WatchdogMode to 'ADC_ANALOGWATCHDOG_NONE').
+                                          This parameter can be a value of @ref ADCEx_channels. */
+  FunctionalState ITMode;            /*!< Specifies whether the analog watchdog is configured in interrupt or polling mode.
+                                          This parameter can be set to ENABLE or DISABLE */
+  uint32_t HighThreshold;            /*!< Configures the ADC analog watchdog High threshold value.
+                                          Depending of ADC resolution selected (12U, 10U, 8 or 6 bits), this parameter must be a number between Min_Data = 0x000 and Max_Data = 0xFFFU, 0x3FFU, 0xFF or 0x3F respectively.
+                                          Note: Analog watchdog 2 and 3 are limited to a resolution of 8 bits: if ADC resolution is 12 bits 
+                                                the 4 LSB are ignored, if ADC resolution is 10 bits the 2 LSB are ignored. */
+  uint32_t LowThreshold;             /*!< Configures the ADC analog watchdog High threshold value.
+                                          Depending of ADC resolution selected (12U, 10U, 8 or 6 bits), this parameter must be a number between Min_Data = 0x000 and Max_Data = 0xFFFU, 0x3FFU, 0xFF or 0x3F respectively.
+                                          Note: Analog watchdog 2 and 3 are limited to a resolution of 8 bits: if ADC resolution is 12 bits 
+                                                the 4 LSB are ignored, if ADC resolution is 10 bits the 2 LSB are ignored. */
+}ADC_AnalogWDGConfTypeDef;
+
+/** 
+  * @brief  Structure definition of ADC multimode
+  * @note   The setting of these parameters with function HAL_ADCEx_MultiModeConfigChannel() is conditioned to ADCs state (both ADCs of the common group).
+  *         ADC state can be either:
+  *          - For all parameters: ADC disabled (this is the only possible ADC state to modify parameter 'DMAAccessMode')
+  *          - For parameter 'DMAAccessMode': ADC enabled without conversion on going on regular group.
+  *         If ADC is not in the appropriate state to modify some parameters, these parameters setting is bypassed
+  *         without error reporting (as it can be the expected behaviour in case of intended action to update another parameter (which fulfills the ADC state condition) on the fly).
+  */
+typedef struct
+{
+  uint32_t Mode;              /*!< Configures the ADC to operate in independent or multi mode. 
+                                   This parameter can be a value of @ref ADCEx_Common_mode */
+  uint32_t DMAAccessMode;     /*!< Configures the DMA mode for multi ADC mode:
+                                   selection whether 2 DMA channels (each ADC use its own DMA channel) or 1 DMA channel (one DMA channel for both ADC, DMA of ADC master)
+                                   This parameter can be a value of @ref ADCEx_Direct_memory_access_mode_for_multimode
+                                   Caution: Limitations with multimode DMA access enabled (1 DMA channel used): In case of dual mode in high speed (more than 5Msps) or high activity of DMA by other peripherals, there is a risk of DMA overrun.
+                                            Therefore, it is recommended to disable multimode DMA access: each ADC uses its own DMA channel.
+                                            Refer to device errata sheet for more details. */
+  uint32_t TwoSamplingDelay;  /*!< Configures the Delay between 2 sampling phases.
+                                   This parameter can be a value of @ref ADCEx_delay_between_2_sampling_phases
+                                   Delay range depends on selected resolution: from 1 to 12 clock cycles for 12 bits, from 1 to 10 clock cycles for 10 bits
+                                                                               from 1 to 8 clock cycles for 8 bits, from 1 to 6 clock cycles for 6 bits     */
+}ADC_MultiModeTypeDef;
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+
+
+#if defined(STM32F373xC) || defined(STM32F378xx)
+/** 
+  * @brief  Structure definition of ADC and regular group initialization 
+  * @note   Parameters of this structure are shared within 2 scopes:
+  *          - Scope entire ADC (affects regular and injected groups): DataAlign, ScanConvMode.
+  *          - Scope regular group: ContinuousConvMode, NbrOfConversion, DiscontinuousConvMode, NbrOfDiscConversion, ExternalTrigConvEdge, ExternalTrigConv.
+  * @note   The setting of these parameters with function HAL_ADC_Init() is conditioned to ADC state.
+  *         ADC can be either disabled or enabled without conversion on going on regular group.
+  */
+typedef struct
+{
+  uint32_t DataAlign;                      /*!< Specifies ADC data alignment to right (MSB on register bit 11 and LSB on register bit 0U) (default setting)
+                                                or to left (if regular group: MSB on register bit 15 and LSB on register bit 4U, if injected group (MSB kept as signed value due to potential negative value after offset application): MSB on register bit 14 and LSB on register bit 3U).
+                                                This parameter can be a value of @ref ADCEx_Data_align */
+  uint32_t ScanConvMode;                   /*!< Configures the sequencer of regular and injected groups.
+                                                This parameter can be associated to parameter 'DiscontinuousConvMode' to have main sequence subdivided in successive parts.
+                                                If disabled: Conversion is performed in single mode (one channel converted, the one defined in rank 1U).
+                                                             Parameters 'NbrOfConversion' and 'InjectedNbrOfConversion' are discarded (equivalent to set to 1U).
+                                                If enabled:  Conversions are performed in sequence mode (multiple ranks defined by 'NbrOfConversion'/'InjectedNbrOfConversion' and each channel rank).
+                                                             Scan direction is upward: from rank1 to rank 'n'.
+                                                This parameter can be a value of @ref ADCEx_Scan_mode
+                                                Note: For regular group, this parameter should be enabled in conversion either by polling (HAL_ADC_Start with Discontinuous mode and NbrOfDiscConversion=1U)
+                                                      or by DMA (HAL_ADC_Start_DMA), but not by interruption (HAL_ADC_Start_IT): in scan mode, interruption is triggered only on the
+                                                      the last conversion of the sequence. All previous conversions would be overwritten by the last one.
+                                                      Injected group used with scan mode has not this constraint: each rank has its own result register, no data is overwritten. */
+  FunctionalState ContinuousConvMode;      /*!< Specifies whether the conversion is performed in single mode (one conversion) or continuous mode for regular group,
+                                                after the selected trigger occurred (software start or external trigger).
+                                                This parameter can be set to ENABLE or DISABLE. */
+  uint32_t NbrOfConversion;                /*!< Specifies the number of ranks that will be converted within the regular group sequencer.
+                                                To use regular group sequencer and convert several ranks, parameter 'ScanConvMode' must be enabled.
+                                                This parameter must be a number between Min_Data = 1 and Max_Data = 16. */
+  FunctionalState DiscontinuousConvMode;   /*!< Specifies whether the conversions sequence of regular group is performed in Complete-sequence/Discontinuous-sequence (main sequence subdivided in successive parts).
+                                                Discontinuous mode is used only if sequencer is enabled (parameter 'ScanConvMode'). If sequencer is disabled, this parameter is discarded.
+                                                Discontinuous mode can be enabled only if continuous mode is disabled. If continuous mode is enabled, this parameter setting is discarded.
+                                                This parameter can be set to ENABLE or DISABLE. */
+  uint32_t NbrOfDiscConversion;            /*!< Specifies the number of discontinuous conversions in which the  main sequence of regular group (parameter NbrOfConversion) will be subdivided.
+                                                If parameter 'DiscontinuousConvMode' is disabled, this parameter is discarded.
+                                                This parameter must be a number between Min_Data = 1 and Max_Data = 8. */
+  uint32_t ExternalTrigConv;               /*!< Selects the external event used to trigger the conversion start of regular group.
+                                                If set to ADC_SOFTWARE_START, external triggers are disabled.
+                                                If set to external trigger source, triggering is on event rising edge.
+                                                This parameter can be a value of @ref ADCEx_External_trigger_source_Regular */
+}ADC_InitTypeDef;
+
+/** 
+  * @brief  Structure definition of ADC channel for regular group   
+  * @note   The setting of these parameters with function HAL_ADC_ConfigChannel() is conditioned to ADC state.
+  *         ADC can be either disabled or enabled without conversion on going on regular group.
+  */ 
+typedef struct 
+{
+  uint32_t Channel;                /*!< Specifies the channel to configure into ADC regular group.
+                                        This parameter can be a value of @ref ADCEx_channels
+                                        Note: Depending on devices, some channels may not be available on package pins. Refer to device datasheet for channels availability. */
+  uint32_t Rank;                   /*!< Specifies the rank in the regular group sequencer 
+                                        This parameter can be a value of @ref ADCEx_regular_rank
+                                        Note: In case of need to disable a channel or change order of conversion sequencer, rank containing a previous channel setting can be overwritten by the new channel setting (or parameter number of conversions can be adjusted) */
+  uint32_t SamplingTime;           /*!< Sampling time value to be set for the selected channel.
+                                        Unit: ADC clock cycles
+                                        Conversion time is the addition of sampling time and processing time (12.5 ADC clock cycles at ADC resolution 12 bits).
+                                        This parameter can be a value of @ref ADCEx_sampling_times
+                                        Caution: This parameter updates the parameter property of the channel, that can be used into regular and/or injected groups.
+                                                 If this same channel has been previously configured in the other group (regular/injected), it will be updated to last setting.
+                                        Note: In case of usage of internal measurement channels (VrefInt/Vbat/TempSensor),
+                                              sampling time constraints must be respected (sampling time can be adjusted in function of ADC clock frequency and sampling time setting)
+                                              Refer to device datasheet for timings values, parameters TS_vrefint, TS_vbat, TS_temp (values rough order: 5us to 17.1us min). */
+}ADC_ChannelConfTypeDef;
+
+/** 
+  * @brief  ADC Configuration injected Channel structure definition
+  * @note   Parameters of this structure are shared within 2 scopes:
+  *          - Scope channel: InjectedChannel, InjectedRank, InjectedSamplingTime, InjectedOffset
+  *          - Scope injected group (affects all channels of injected group): InjectedNbrOfConversion, InjectedDiscontinuousConvMode,
+  *            AutoInjectedConv, ExternalTrigInjecConvEdge, ExternalTrigInjecConv.
+  * @note   The setting of these parameters with function HAL_ADCEx_InjectedConfigChannel() is conditioned to ADC state.
+  *         ADC state can be either:
+  *          - For all parameters: ADC disabled (this is the only possible ADC state to modify parameter 'ExternalTrigInjecConv')
+  *          - For all except parameters 'ExternalTrigInjecConv': ADC enabled without conversion on going on injected group.
+  */
+typedef struct 
+{
+  uint32_t InjectedChannel;                         /*!< Selection of ADC channel to configure
+                                                         This parameter can be a value of @ref ADCEx_channels
+                                                         Note: Depending on devices, some channels may not be available on package pins. Refer to device datasheet for channels availability. */
+  uint32_t InjectedRank;                            /*!< Rank in the injected group sequencer
+                                                         This parameter must be a value of @ref ADCEx_injected_rank
+                                                         Note: In case of need to disable a channel or change order of conversion sequencer, rank containing a previous channel setting can be overwritten by the new channel setting (or parameter number of conversions can be adjusted) */
+  uint32_t InjectedSamplingTime;                    /*!< Sampling time value to be set for the selected channel.
+                                                         Unit: ADC clock cycles
+                                                         Conversion time is the addition of sampling time and processing time (12.5 ADC clock cycles at ADC resolution 12 bits).
+                                                         This parameter can be a value of @ref ADCEx_sampling_times
+                                                         Caution: This parameter updates the parameter property of the channel, that can be used into regular and/or injected groups.
+                                                                  If this same channel has been previously configured in the other group (regular/injected), it will be updated to last setting.
+                                                         Note: In case of usage of internal measurement channels (VrefInt/Vbat/TempSensor),
+                                                               sampling time constraints must be respected (sampling time can be adjusted in function of ADC clock frequency and sampling time setting)
+                                                               Refer to device datasheet for timings values, parameters TS_vrefint, TS_vbat, TS_temp (values rough order: 5us to 17.1us min). */
+  uint32_t InjectedOffset;                          /*!< Defines the offset to be subtracted from the raw converted data (for channels set on injected group only).
+                                                         Offset value must be a positive number.
+                                                         Depending of ADC resolution selected (12U, 10U, 8 or 6 bits),
+                                                         this parameter must be a number between Min_Data = 0x000 and Max_Data = 0xFFFU, 0x3FFU, 0xFF or 0x3F respectively. */
+  uint32_t InjectedNbrOfConversion;                 /*!< Specifies the number of ranks that will be converted within the injected group sequencer.
+                                                         To use the injected group sequencer and convert several ranks, parameter 'ScanConvMode' must be enabled.
+                                                         This parameter must be a number between Min_Data = 1 and Max_Data = 4.
+                                                         Caution: this setting impacts the entire injected group. Therefore, call of HAL_ADCEx_InjectedConfigChannel() to 
+                                                                  configure a channel on injected group can impact the configuration of other channels previously set. */
+  FunctionalState InjectedDiscontinuousConvMode;    /*!< Specifies whether the conversions sequence of injected group is performed in Complete-sequence/Discontinuous-sequence (main sequence subdivided in successive parts).
+                                                         Discontinuous mode is used only if sequencer is enabled (parameter 'ScanConvMode'). If sequencer is disabled, this parameter is discarded.
+                                                         Discontinuous mode can be enabled only if continuous mode is disabled. If continuous mode is enabled, this parameter setting is discarded.
+                                                         This parameter can be set to ENABLE or DISABLE.
+                                                         Note: For injected group, number of discontinuous ranks increment is fixed to one-by-one.
+                                                         Caution: this setting impacts the entire injected group. Therefore, call of HAL_ADCEx_InjectedConfigChannel() to 
+                                                                  configure a channel on injected group can impact the configuration of other channels previously set. */
+  FunctionalState AutoInjectedConv;                 /*!< Enables or disables the selected ADC automatic injected group conversion after regular one
+                                                         This parameter can be set to ENABLE or DISABLE.      
+                                                         Note: To use Automatic injected conversion, discontinuous mode must be disabled ('DiscontinuousConvMode' and 'InjectedDiscontinuousConvMode' set to DISABLE)
+                                                         Note: To use Automatic injected conversion, injected group external triggers must be disabled ('ExternalTrigInjecConv' set to ADC_SOFTWARE_START)
+                                                         Note: In case of DMA used with regular group: if DMA configured in normal mode (single shot) JAUTO will be stopped upon DMA transfer complete.
+                                                               To maintain JAUTO always enabled, DMA must be configured in circular mode.
+                                                         Caution: this setting impacts the entire injected group. Therefore, call of HAL_ADCEx_InjectedConfigChannel() to
+                                                                  configure a channel on injected group can impact the configuration of other channels previously set. */
+  uint32_t ExternalTrigInjecConv;                   /*!< Selects the external event used to trigger the conversion start of injected group.
+                                                         If set to ADC_INJECTED_SOFTWARE_START, external triggers are disabled.
+                                                         If set to external trigger source, triggering is on event rising edge.
+                                                         This parameter can be a value of @ref ADCEx_External_trigger_source_Injected
+                                                         Note: This parameter must be modified when ADC is disabled (before ADC start conversion or after ADC stop conversion).
+                                                               If ADC is enabled, this parameter setting is bypassed without error reporting (as it can be the expected behaviour in case of another parameter update on the fly)
+                                                         Caution: this setting impacts the entire injected group. Therefore, call of HAL_ADCEx_InjectedConfigChannel() to
+                                                                  configure a channel on injected group can impact the configuration of other channels previously set. */
+}ADC_InjectionConfTypeDef;
+
+/**
+  * @brief  ADC Configuration analog watchdog definition
+  * @note   The setting of these parameters with function is conditioned to ADC state.
+  *         ADC state can be either disabled or enabled without conversion on going on regular and injected groups.
+  */
+typedef struct
+{
+  uint32_t WatchdogMode;             /*!< Configures the ADC analog watchdog mode: single/all channels, regular/injected group.
+                                          This parameter can be a value of @ref ADCEx_analog_watchdog_mode. */
+  uint32_t Channel;                  /*!< Selects which ADC channel to monitor by analog watchdog.
+                                          This parameter has an effect only if watchdog mode is configured on single channel (parameter WatchdogMode)
+                                          This parameter can be a value of @ref ADCEx_channels. */
+  FunctionalState ITMode;            /*!< Specifies whether the analog watchdog is configured in interrupt or polling mode.
+                                          This parameter can be set to ENABLE or DISABLE */
+  uint32_t HighThreshold;            /*!< Configures the ADC analog watchdog High threshold value.
+                                          This parameter must be a number between Min_Data = 0x000 and Max_Data = 0xFFF. */
+  uint32_t LowThreshold;             /*!< Configures the ADC analog watchdog High threshold value.
+                                          This parameter must be a number between Min_Data = 0x000 and Max_Data = 0xFFF. */
+  uint32_t WatchdogNumber;           /*!< Reserved for future use, can be set to 0U */
+}ADC_AnalogWDGConfTypeDef;
+#endif /* STM32F373xC || STM32F378xx */
+/**
+  * @}
+  */
+
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup ADCEx_Exported_Constants ADCEx Exported Constants
+  * @{
+  */
+
+/** @defgroup ADCEx_Error_Code ADC Extended Error Code
+  * @{
+  */
+#define HAL_ADC_ERROR_NONE        (0x00U)   /*!< No error                                              */
+#define HAL_ADC_ERROR_INTERNAL    (0x01U)   /*!< ADC IP internal error: if problem of clocking,
+                                                          enable/disable, erroneous state                       */
+#define HAL_ADC_ERROR_OVR         (0x02U)   /*!< Overrun error                                         */
+#define HAL_ADC_ERROR_DMA         (0x04U)   /*!< DMA transfer error                                    */
+#define HAL_ADC_ERROR_JQOVF       (0x08U)   /*!< Injected context queue overflow error                 */
+#if (USE_HAL_ADC_REGISTER_CALLBACKS == 1)
+#define HAL_ADC_ERROR_INVALID_CALLBACK  (0x10U)   /*!< Invalid Callback error */
+#endif /* USE_HAL_ADC_REGISTER_CALLBACKS */
+/**
+  * @}
+  */
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+/** @defgroup ADCEx_ClockPrescaler ADC Extended Clock Prescaler
+  * @{
+  */
+#define ADC_CLOCK_ASYNC_DIV1          (0x00000000U)          /*!< ADC asynchronous clock derived from ADC dedicated PLL */
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
+#define ADC_CLOCK_SYNC_PCLK_DIV1      ((uint32_t)ADC12_CCR_CKMODE_0)  /*!< ADC synchronous clock derived from AHB clock without prescaler */
+#define ADC_CLOCK_SYNC_PCLK_DIV2      ((uint32_t)ADC12_CCR_CKMODE_1)  /*!< ADC synchronous clock derived from AHB clock divided by a prescaler of 2U */
+#define ADC_CLOCK_SYNC_PCLK_DIV4      ((uint32_t)ADC12_CCR_CKMODE)    /*!< ADC synchronous clock derived from AHB clock divided by a prescaler of 4U */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx    */
+
+#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+#define ADC_CLOCK_SYNC_PCLK_DIV1      ((uint32_t)ADC1_CCR_CKMODE_0)   /*!< ADC synchronous clock derived from AHB clock without prescaler */
+#define ADC_CLOCK_SYNC_PCLK_DIV2      ((uint32_t)ADC1_CCR_CKMODE_1)   /*!< ADC synchronous clock derived from AHB clock divided by a prescaler of 2U */
+#define ADC_CLOCK_SYNC_PCLK_DIV4      ((uint32_t)ADC1_CCR_CKMODE)     /*!< ADC synchronous clock derived from AHB clock divided by a prescaler of 4U */
+#endif /* STM32F301x8 || STM32F318xx || STM32F302x8 */
+
+#define IS_ADC_CLOCKPRESCALER(ADC_CLOCK) (((ADC_CLOCK) == ADC_CLOCK_ASYNC_DIV1)     || \
+                                          ((ADC_CLOCK) == ADC_CLOCK_SYNC_PCLK_DIV1) || \
+                                          ((ADC_CLOCK) == ADC_CLOCK_SYNC_PCLK_DIV2) || \
+                                          ((ADC_CLOCK) == ADC_CLOCK_SYNC_PCLK_DIV4)   )
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_Resolution ADC Extended Resolution
+  * @{
+  */
+#define ADC_RESOLUTION_12B      (0x00000000U)          /*!<  ADC 12-bit resolution */
+#define ADC_RESOLUTION_10B      ((uint32_t)ADC_CFGR_RES_0)      /*!<  ADC 10-bit resolution */
+#define ADC_RESOLUTION_8B       ((uint32_t)ADC_CFGR_RES_1)      /*!<  ADC 8-bit resolution */
+#define ADC_RESOLUTION_6B       ((uint32_t)ADC_CFGR_RES)        /*!<  ADC 6-bit resolution */
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_Data_align ADC Extended Data Alignment
+  * @{
+  */
+#define ADC_DATAALIGN_RIGHT      (0x00000000U)
+#define ADC_DATAALIGN_LEFT       ((uint32_t)ADC_CFGR_ALIGN)
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_Scan_mode ADC Extended Scan Mode
+  * @{
+  */
+#define ADC_SCAN_DISABLE         (0x00000000U)
+#define ADC_SCAN_ENABLE          (0x00000001U)
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_External_trigger_edge_Regular ADC Extended External trigger enable and polarity selection for regular group
+  * @{
+  */
+#define ADC_EXTERNALTRIGCONVEDGE_NONE           (0x00000000U)
+#define ADC_EXTERNALTRIGCONVEDGE_RISING         ((uint32_t)ADC_CFGR_EXTEN_0)
+#define ADC_EXTERNALTRIGCONVEDGE_FALLING        ((uint32_t)ADC_CFGR_EXTEN_1)
+#define ADC_EXTERNALTRIGCONVEDGE_RISINGFALLING  ((uint32_t)ADC_CFGR_EXTEN)
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_External_trigger_source_Regular ADC Extended External trigger selection for regular group
+  * @{
+  */
+#if defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F303xC) || defined(STM32F358xx)
+/*!< List of external triggers with generic trigger name, independently of    */
+/* ADC target (caution: applies to other ADCs sharing the same common group), */
+/* sorted by trigger name:                                                    */
+
+/*!< External triggers of regular group for ADC1&ADC2 only */
+#define ADC_EXTERNALTRIGCONV_T1_CC1         ADC1_2_EXTERNALTRIG_T1_CC1
+#define ADC_EXTERNALTRIGCONV_T1_CC2         ADC1_2_EXTERNALTRIG_T1_CC2
+#define ADC_EXTERNALTRIGCONV_T2_CC2         ADC1_2_EXTERNALTRIG_T2_CC2
+#define ADC_EXTERNALTRIGCONV_T3_CC4         ADC1_2_EXTERNALTRIG_T3_CC4
+#define ADC_EXTERNALTRIGCONV_T4_CC4         ADC1_2_EXTERNALTRIG_T4_CC4
+#define ADC_EXTERNALTRIGCONV_T6_TRGO        ADC1_2_EXTERNALTRIG_T6_TRGO
+#define ADC_EXTERNALTRIGCONV_EXT_IT11       ADC1_2_EXTERNALTRIG_EXT_IT11
+
+/*!< External triggers of regular group for ADC3&ADC4 only */
+#define ADC_EXTERNALTRIGCONV_T2_CC1         ADC3_4_EXTERNALTRIG_T2_CC1
+#define ADC_EXTERNALTRIGCONV_T2_CC3         ADC3_4_EXTERNALTRIG_T2_CC3
+#define ADC_EXTERNALTRIGCONV_T3_CC1         ADC3_4_EXTERNALTRIG_T3_CC1
+#define ADC_EXTERNALTRIGCONV_T4_CC1         ADC3_4_EXTERNALTRIG_T4_CC1
+#define ADC_EXTERNALTRIGCONV_T7_TRGO        ADC3_4_EXTERNALTRIG_T7_TRGO
+#define ADC_EXTERNALTRIGCONV_T8_CC1         ADC3_4_EXTERNALTRIG_T8_CC1
+#define ADC_EXTERNALTRIGCONV_EXT_IT2        ADC3_4_EXTERNALTRIG_EXT_IT2
+
+/*!< External triggers of regular group for ADC1&ADC2, ADC3&ADC4 */
+/* Note: Triggers affected to group ADC1_2 by default, redirected to group    */
+/*       ADC3_4 by driver when needed.                                        */
+#define ADC_EXTERNALTRIGCONV_T1_CC3         ADC1_2_EXTERNALTRIG_T1_CC3
+#define ADC_EXTERNALTRIGCONV_T1_TRGO        ADC1_2_EXTERNALTRIG_T1_TRGO
+#define ADC_EXTERNALTRIGCONV_T1_TRGO2       ADC1_2_EXTERNALTRIG_T1_TRGO2
+#define ADC_EXTERNALTRIGCONV_T2_TRGO        ADC1_2_EXTERNALTRIG_T2_TRGO
+#define ADC_EXTERNALTRIGCONV_T3_TRGO        ADC1_2_EXTERNALTRIG_T3_TRGO
+#define ADC_EXTERNALTRIGCONV_T4_TRGO        ADC1_2_EXTERNALTRIG_T4_TRGO
+#define ADC_EXTERNALTRIGCONV_T8_TRGO        ADC1_2_EXTERNALTRIG_T8_TRGO
+#define ADC_EXTERNALTRIGCONV_T8_TRGO2       ADC1_2_EXTERNALTRIG_T8_TRGO2
+#define ADC_EXTERNALTRIGCONV_T15_TRGO       ADC1_2_EXTERNALTRIG_T15_TRGO
+
+#define ADC_SOFTWARE_START                  (0x00000001U)
+
+#if defined(STM32F303xE) || defined(STM32F398xx)
+/* ADC external triggers specific to device STM303xE: mask to differentiate   */
+/* standard triggers from specific timer 20U, needed for reallocation of       */
+/* triggers common to ADC1&2U/ADC3&4 and to avoid mixing with standard         */
+/* triggers without remap.                                                    */
+#define ADC_EXTERNALTRIGCONV_T20_MASK       0x1000
+
+/*!< List of external triggers specific to device STM303xE: using Timer20     */
+/* with ADC trigger input remap.                                              */
+/* To remap ADC trigger from other timers/ExtLine to timer20: use macro       */
+/* " __HAL_REMAPADCTRIGGER_ENABLE(...) " with parameters described below:     */
+
+/*!< External triggers of regular group for ADC1&ADC2 only, specific to       */
+/* device STM303xE: : using Timer20 with ADC trigger input remap              */
+#define ADC_EXTERNALTRIGCONV_T20_CC2        ADC_EXTERNALTRIGCONV_T6_TRGO /*!< Remap trigger using macro __HAL_REMAPADCTRIGGER_ENABLE(HAL_REMAPADCTRIGGER_ADC12_EXT13U) */
+#define ADC_EXTERNALTRIGCONV_T20_CC3        ADC_EXTERNALTRIGCONV_T3_CC4  /*!< Remap trigger using macro __HAL_REMAPADCTRIGGER_ENABLE(HAL_REMAPADCTRIGGER_ADC12_EXT15U) */
+
+/*!< External triggers of regular group for ADC3&ADC4 only, specific to       */
+/* device STM303xE: : using Timer20 with ADC trigger input remap              */
+/* None */
+
+/*!< External triggers of regular group for ADC1&ADC2, ADC3&ADC4, specific to */
+/* device STM303xE: : using Timer20 with ADC trigger input remap              */
+/* Note: Triggers affected to group ADC1_2 by default, redirected to group    */
+/*       ADC3_4 by driver when needed.                                        */
+#define ADC_EXTERNALTRIGCONV_T20_CC1        (ADC_EXTERNALTRIGCONV_T4_CC4 | ADC_EXTERNALTRIGCONV_T20_MASK) /*!< For ADC1&ADC2: Remap trigger using macro __HAL_REMAPADCTRIGGER_ENABLE(HAL_REMAPADCTRIGGER_ADC12_EXT5) */
+                                                                                                          /*!< For ADC3&ADC4: Remap trigger using macro __HAL_REMAPADCTRIGGER_ENABLE(HAL_REMAPADCTRIGGER_ADC34_EXT15U) */
+#define ADC_EXTERNALTRIGCONV_T20_TRGO       (ADC_EXTERNALTRIGCONV_T1_CC3 | ADC_EXTERNALTRIGCONV_T20_MASK) /*!< For ADC1&ADC2: Remap trigger using macro __HAL_REMAPADCTRIGGER_ENABLE(HAL_REMAPADCTRIGGER_ADC12_EXT2) */
+                                                                                                          /*!< For ADC3&ADC4: Remap trigger using macro __HAL_REMAPADCTRIGGER_ENABLE(HAL_REMAPADCTRIGGER_ADC34_EXT5) */
+#define ADC_EXTERNALTRIGCONV_T20_TRGO2      (ADC_EXTERNALTRIGCONV_T2_CC2 | ADC_EXTERNALTRIGCONV_T20_MASK) /*!< For ADC1&ADC2: Remap trigger using macro __HAL_REMAPADCTRIGGER_ENABLE(HAL_REMAPADCTRIGGER_ADC12_EXT3) */
+                                                                                                          /*!< For ADC3&ADC4: Remap trigger using macro __HAL_REMAPADCTRIGGER_ENABLE(HAL_REMAPADCTRIGGER_ADC34_EXT6) */
+#endif /* STM32F303xE || STM32F398xx */
+
+#endif /* STM32F303xE || STM32F398xx || */
+       /* STM32F303xC || STM32F358xx    */
+
+#if defined(STM32F302xE) || \
+    defined(STM32F302xC)
+/*!< List of external triggers with generic trigger name, independently of    */
+/* ADC target (caution: applies to other ADCs sharing the same common group), */
+/* sorted by trigger name:                                                    */
+
+/*!< External triggers of regular group for ADC1&ADC2 */
+#define ADC_EXTERNALTRIGCONV_T1_CC1         ADC1_2_EXTERNALTRIG_T1_CC1
+#define ADC_EXTERNALTRIGCONV_T1_CC2         ADC1_2_EXTERNALTRIG_T1_CC2
+#define ADC_EXTERNALTRIGCONV_T1_CC3         ADC1_2_EXTERNALTRIG_T1_CC3
+#define ADC_EXTERNALTRIGCONV_T1_TRGO        ADC1_2_EXTERNALTRIG_T1_TRGO
+#define ADC_EXTERNALTRIGCONV_T1_TRGO2       ADC1_2_EXTERNALTRIG_T1_TRGO2
+#define ADC_EXTERNALTRIGCONV_T2_CC2         ADC1_2_EXTERNALTRIG_T2_CC2
+#define ADC_EXTERNALTRIGCONV_T2_TRGO        ADC1_2_EXTERNALTRIG_T2_TRGO
+#define ADC_EXTERNALTRIGCONV_T3_CC4         ADC1_2_EXTERNALTRIG_T3_CC4
+#define ADC_EXTERNALTRIGCONV_T3_TRGO        ADC1_2_EXTERNALTRIG_T3_TRGO
+#define ADC_EXTERNALTRIGCONV_T4_CC4         ADC1_2_EXTERNALTRIG_T4_CC4
+#define ADC_EXTERNALTRIGCONV_T4_TRGO        ADC1_2_EXTERNALTRIG_T4_TRGO
+#define ADC_EXTERNALTRIGCONV_T6_TRGO        ADC1_2_EXTERNALTRIG_T6_TRGO
+#define ADC_EXTERNALTRIGCONV_T15_TRGO       ADC1_2_EXTERNALTRIG_T15_TRGO
+#define ADC_EXTERNALTRIGCONV_EXT_IT11       ADC1_2_EXTERNALTRIG_EXT_IT11
+#define ADC_SOFTWARE_START                  (0x00000001U)
+
+#if defined(STM32F302xE)
+/* ADC external triggers specific to device STM302xE: mask to differentiate   */
+/* standard triggers from specific timer 20U, needed for reallocation of       */
+/* triggers common to ADC1&2 and to avoind mixing with standard               */
+/* triggers without remap.                                                    */
+#define ADC_EXTERNALTRIGCONV_T20_MASK       0x1000
+
+/*!< List of external triggers specific to device STM302xE: using Timer20     */
+/* with ADC trigger input remap.                                              */
+/* To remap ADC trigger from other timers/ExtLine to timer20: use macro       */
+/* " __HAL_REMAPADCTRIGGER_ENABLE(...) " with parameters described below:     */
+
+/*!< External triggers of regular group for ADC1&ADC2 only, specific to       */
+/* device STM302xE: : using Timer20 with ADC trigger input remap              */
+#define ADC_EXTERNALTRIGCONV_T20_CC2        ADC_EXTERNALTRIGCONV_T6_TRGO /*!< Remap trigger using macro __HAL_REMAPADCTRIGGER_ENABLE(HAL_REMAPADCTRIGGER_ADC12_EXT13U) */
+#define ADC_EXTERNALTRIGCONV_T20_CC3        ADC_EXTERNALTRIGCONV_T3_CC4  /*!< Remap trigger using macro __HAL_REMAPADCTRIGGER_ENABLE(HAL_REMAPADCTRIGGER_ADC12_EXT15U) */
+#endif /* STM32F302xE */
+
+#endif /* STM32F302xE || */
+       /* STM32F302xC    */
+
+#if defined(STM32F303x8) || defined(STM32F328xx)
+/*!< List of external triggers with generic trigger name, independently of    */
+/* ADC target (caution: applies to other ADCs sharing the same common group), */
+/* sorted by trigger name:                                                    */
+
+/*!< External triggers of regular group for ADC1&ADC2 */
+#define ADC_EXTERNALTRIGCONV_T1_CC1         ADC1_2_EXTERNALTRIG_T1_CC1
+#define ADC_EXTERNALTRIGCONV_T1_CC2         ADC1_2_EXTERNALTRIG_T1_CC2
+#define ADC_EXTERNALTRIGCONV_T1_CC3         ADC1_2_EXTERNALTRIG_T1_CC3
+#define ADC_EXTERNALTRIGCONV_T1_TRGO        ADC1_2_EXTERNALTRIG_T1_TRGO
+#define ADC_EXTERNALTRIGCONV_T1_TRGO2       ADC1_2_EXTERNALTRIG_T1_TRGO2
+#define ADC_EXTERNALTRIGCONV_T2_CC2         ADC1_2_EXTERNALTRIG_T2_CC2
+#define ADC_EXTERNALTRIGCONV_T2_TRGO        ADC1_2_EXTERNALTRIG_T2_TRGO
+#define ADC_EXTERNALTRIGCONV_T3_CC4         ADC1_2_EXTERNALTRIG_T3_CC4
+#define ADC_EXTERNALTRIGCONV_T3_TRGO        ADC1_2_EXTERNALTRIG_T3_TRGO
+#define ADC_EXTERNALTRIGCONV_T4_CC4         ADC1_2_EXTERNALTRIG_T4_CC4
+#define ADC_EXTERNALTRIGCONV_T4_TRGO        ADC1_2_EXTERNALTRIG_T4_TRGO
+#define ADC_EXTERNALTRIGCONV_T8_TRGO        ADC1_2_EXTERNALTRIG_T8_TRGO
+#define ADC_EXTERNALTRIGCONV_T8_TRGO2       ADC1_2_EXTERNALTRIG_T8_TRGO2
+#define ADC_EXTERNALTRIGCONV_T6_TRGO        ADC1_2_EXTERNALTRIG_T6_TRGO
+#define ADC_EXTERNALTRIGCONV_T15_TRGO       ADC1_2_EXTERNALTRIG_T15_TRGO
+#define ADC_EXTERNALTRIGCONV_EXT_IT11       ADC1_2_EXTERNALTRIG_EXT_IT11
+#define ADC_SOFTWARE_START                  (0x00000001U)
+
+#endif /* STM32F303x8 || STM32F328xx */
+
+#if defined(STM32F334x8)
+/*!< List of external triggers with generic trigger name, independently of    */
+/* ADC target (caution: applies to other ADCs sharing the same common group), */
+/* sorted by trigger name:                                                    */
+
+/*!< External triggers of regular group for ADC1&ADC2 */
+#define ADC_EXTERNALTRIGCONV_T1_CC1         ADC1_2_EXTERNALTRIG_T1_CC1
+#define ADC_EXTERNALTRIGCONV_T1_CC2         ADC1_2_EXTERNALTRIG_T1_CC2
+#define ADC_EXTERNALTRIGCONV_T1_CC3         ADC1_2_EXTERNALTRIG_T1_CC3
+#define ADC_EXTERNALTRIGCONV_T1_TRGO        ADC1_2_EXTERNALTRIG_T1_TRGO
+#define ADC_EXTERNALTRIGCONV_T1_TRGO2       ADC1_2_EXTERNALTRIG_T1_TRGO2
+#define ADC_EXTERNALTRIGCONV_T2_CC2         ADC1_2_EXTERNALTRIG_T2_CC2
+#define ADC_EXTERNALTRIGCONV_T2_TRGO        ADC1_2_EXTERNALTRIG_T2_TRGO
+#define ADC_EXTERNALTRIGCONV_T3_CC4         ADC1_2_EXTERNALTRIG_T3_CC4
+#define ADC_EXTERNALTRIGCONV_T3_TRGO        ADC1_2_EXTERNALTRIG_T3_TRGO
+#define ADC_EXTERNALTRIGCONV_T6_TRGO        ADC1_2_EXTERNALTRIG_T6_TRGO
+#define ADC_EXTERNALTRIGCONV_T15_TRGO       ADC1_2_EXTERNALTRIG_T15_TRGO
+#define ADC_EXTERNALTRIGCONVHRTIM_TRG1      ADC1_2_EXTERNALTRIG_HRTIM_TRG1
+#define ADC_EXTERNALTRIGCONVHRTIM_TRG3      ADC1_2_EXTERNALTRIG_HRTIM_TRG3
+#define ADC_EXTERNALTRIGCONV_EXT_IT11       ADC1_2_EXTERNALTRIG_EXT_IT11
+#define ADC_SOFTWARE_START                  (0x00000001U)
+#endif /* STM32F334x8 */
+
+#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+/* List of external triggers with generic trigger name, sorted by trigger     */
+/* name:                                                                      */
+
+/* External triggers of regular group for ADC1 */
+#define ADC_EXTERNALTRIGCONV_T1_CC1         ADC1_EXTERNALTRIG_T1_CC1
+#define ADC_EXTERNALTRIGCONV_T1_CC2         ADC1_EXTERNALTRIG_T1_CC2
+#define ADC_EXTERNALTRIGCONV_T1_CC3         ADC1_EXTERNALTRIG_T1_CC3
+#define ADC_EXTERNALTRIGCONV_T2_CC2         ADC1_EXTERNALTRIG_T2_CC2
+#define ADC_EXTERNALTRIGCONV_EXT_IT11       ADC1_EXTERNALTRIG_EXT_IT11
+#define ADC_EXTERNALTRIGCONV_T1_TRGO        ADC1_EXTERNALTRIG_T1_TRGO
+#define ADC_EXTERNALTRIGCONV_T1_TRGO2       ADC1_EXTERNALTRIG_T1_TRGO2
+#define ADC_EXTERNALTRIGCONV_T2_TRGO        ADC1_EXTERNALTRIG_T2_TRGO
+#define ADC_EXTERNALTRIGCONV_T6_TRGO        ADC1_EXTERNALTRIG_T6_TRGO
+#define ADC_EXTERNALTRIGCONV_T15_TRGO       ADC1_EXTERNALTRIG_T15_TRGO
+#define ADC_SOFTWARE_START                  (0x00000001U)
+#endif /* STM32F301x8 || STM32F302x8 || STM32F318xx */
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_EOCSelection ADC Extended End of Regular Sequence/Conversion 
+  * @{
+  */
+#define ADC_EOC_SINGLE_CONV         ((uint32_t) ADC_ISR_EOC)
+#define ADC_EOC_SEQ_CONV            ((uint32_t) ADC_ISR_EOS)
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_Overrun ADC Extended overrun
+  * @{
+  */
+#define ADC_OVR_DATA_OVERWRITTEN    (0x00000000U)   /*!< Default setting, to be used for compatibility with other STM32 devices */
+#define ADC_OVR_DATA_PRESERVED      (0x00000001U)
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_channels ADC Extended Channels
+  * @{
+  */
+/* Note: Depending on devices, some channels may not be available on package  */
+/*       pins. Refer to device datasheet for channels availability.           */
+#define ADC_CHANNEL_1           ((uint32_t)(ADC_SQR3_SQ10_0))
+#define ADC_CHANNEL_2           ((uint32_t)(ADC_SQR3_SQ10_1))
+#define ADC_CHANNEL_3           ((uint32_t)(ADC_SQR3_SQ10_1 | ADC_SQR3_SQ10_0))
+#define ADC_CHANNEL_4           ((uint32_t)(ADC_SQR3_SQ10_2))
+#define ADC_CHANNEL_5           ((uint32_t)(ADC_SQR3_SQ10_2 | ADC_SQR3_SQ10_0))
+#define ADC_CHANNEL_6           ((uint32_t)(ADC_SQR3_SQ10_2 | ADC_SQR3_SQ10_1))
+#define ADC_CHANNEL_7           ((uint32_t)(ADC_SQR3_SQ10_2 | ADC_SQR3_SQ10_1 | ADC_SQR3_SQ10_0))
+#define ADC_CHANNEL_8           ((uint32_t)(ADC_SQR3_SQ10_3))
+#define ADC_CHANNEL_9           ((uint32_t)(ADC_SQR3_SQ10_3 | ADC_SQR3_SQ10_0))
+#define ADC_CHANNEL_10          ((uint32_t)(ADC_SQR3_SQ10_3 | ADC_SQR3_SQ10_1))
+#define ADC_CHANNEL_11          ((uint32_t)(ADC_SQR3_SQ10_3 | ADC_SQR3_SQ10_1 | ADC_SQR3_SQ10_0))
+#define ADC_CHANNEL_12          ((uint32_t)(ADC_SQR3_SQ10_3 | ADC_SQR3_SQ10_2))
+#define ADC_CHANNEL_13          ((uint32_t)(ADC_SQR3_SQ10_3 | ADC_SQR3_SQ10_2 | ADC_SQR3_SQ10_0))
+#define ADC_CHANNEL_14          ((uint32_t)(ADC_SQR3_SQ10_3 | ADC_SQR3_SQ10_2 | ADC_SQR3_SQ10_1))
+#define ADC_CHANNEL_15          ((uint32_t)(ADC_SQR3_SQ10_3 | ADC_SQR3_SQ10_2 | ADC_SQR3_SQ10_1 | ADC_SQR3_SQ10_0))
+#define ADC_CHANNEL_16          ((uint32_t)(ADC_SQR3_SQ10_4))
+#define ADC_CHANNEL_17          ((uint32_t)(ADC_SQR3_SQ10_4 | ADC_SQR3_SQ10_0))
+#define ADC_CHANNEL_18          ((uint32_t)(ADC_SQR3_SQ10_4 | ADC_SQR3_SQ10_1))
+
+/* Note: Vopamp1, TempSensor and Vbat internal channels available on ADC1 only */
+#define ADC_CHANNEL_VOPAMP1     ADC_CHANNEL_15
+#define ADC_CHANNEL_TEMPSENSOR  ADC_CHANNEL_16
+#define ADC_CHANNEL_VBAT        ADC_CHANNEL_17
+
+/* Note: Vopamp2/3U/4 internal channels available on ADC2/3U/4 respectively     */
+#define ADC_CHANNEL_VOPAMP2     ADC_CHANNEL_17
+#define ADC_CHANNEL_VOPAMP3     ADC_CHANNEL_17
+#define ADC_CHANNEL_VOPAMP4     ADC_CHANNEL_17
+
+/* Note: VrefInt internal channels available on all ADCs, but only            */
+/*       one ADC is allowed to be connected to VrefInt at the same time.      */
+#define ADC_CHANNEL_VREFINT     ((uint32_t)ADC_CHANNEL_18)
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_sampling_times ADC Extended Sampling Times
+  * @{
+  */
+#define ADC_SAMPLETIME_1CYCLE_5       (0x00000000U)                              /*!< Sampling time 1.5 ADC clock cycle */
+#define ADC_SAMPLETIME_2CYCLES_5      ((uint32_t)ADC_SMPR2_SMP10_0)                       /*!< Sampling time 2.5 ADC clock cycles */
+#define ADC_SAMPLETIME_4CYCLES_5      ((uint32_t)ADC_SMPR2_SMP10_1)                       /*!< Sampling time 4.5 ADC clock cycles */
+#define ADC_SAMPLETIME_7CYCLES_5      ((uint32_t)(ADC_SMPR2_SMP10_1 | ADC_SMPR2_SMP10_0)) /*!< Sampling time 7.5 ADC clock cycles */
+#define ADC_SAMPLETIME_19CYCLES_5     ((uint32_t)ADC_SMPR2_SMP10_2)                       /*!< Sampling time 19.5 ADC clock cycles */
+#define ADC_SAMPLETIME_61CYCLES_5     ((uint32_t)(ADC_SMPR2_SMP10_2 | ADC_SMPR2_SMP10_0)) /*!< Sampling time 61.5 ADC clock cycles */
+#define ADC_SAMPLETIME_181CYCLES_5    ((uint32_t)(ADC_SMPR2_SMP10_2 | ADC_SMPR2_SMP10_1)) /*!< Sampling time 181.5 ADC clock cycles */
+#define ADC_SAMPLETIME_601CYCLES_5    ((uint32_t)ADC_SMPR2_SMP10)                         /*!< Sampling time 601.5 ADC clock cycles */
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_SingleDifferential ADC Extended Single-ended/Differential input mode
+  * @{
+  */
+#define ADC_SINGLE_ENDED                (0x00000000U)
+#define ADC_DIFFERENTIAL_ENDED          (0x00000001U)
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_OffsetNumber ADC Extended Offset Number
+  * @{
+  */
+#define ADC_OFFSET_NONE               (0x00U)
+#define ADC_OFFSET_1                  (0x01U)
+#define ADC_OFFSET_2                  (0x02U)
+#define ADC_OFFSET_3                  (0x03U)
+#define ADC_OFFSET_4                  (0x04U)
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_regular_rank ADC Extended rank into regular group
+  * @{
+  */
+#define ADC_REGULAR_RANK_1    (0x00000001U)
+#define ADC_REGULAR_RANK_2    (0x00000002U)
+#define ADC_REGULAR_RANK_3    (0x00000003U)
+#define ADC_REGULAR_RANK_4    (0x00000004U)
+#define ADC_REGULAR_RANK_5    (0x00000005U)
+#define ADC_REGULAR_RANK_6    (0x00000006U)
+#define ADC_REGULAR_RANK_7    (0x00000007U)
+#define ADC_REGULAR_RANK_8    (0x00000008U)
+#define ADC_REGULAR_RANK_9    (0x00000009U)
+#define ADC_REGULAR_RANK_10   (0x0000000AU)
+#define ADC_REGULAR_RANK_11   (0x0000000BU)
+#define ADC_REGULAR_RANK_12   (0x0000000CU)
+#define ADC_REGULAR_RANK_13   (0x0000000DU)
+#define ADC_REGULAR_RANK_14   (0x0000000EU)
+#define ADC_REGULAR_RANK_15   (0x0000000FU)
+#define ADC_REGULAR_RANK_16   (0x00000010U)
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_injected_rank ADC Extended Injected Channel Rank
+  * @{
+  */
+#define ADC_INJECTED_RANK_1    (0x00000001U)
+#define ADC_INJECTED_RANK_2    (0x00000002U)
+#define ADC_INJECTED_RANK_3    (0x00000003U)
+#define ADC_INJECTED_RANK_4    (0x00000004U)
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_External_trigger_edge_Injected External Trigger Edge of Injected Group
+  * @{
+  */
+#define ADC_EXTERNALTRIGINJECCONV_EDGE_NONE           (0x00000000U)
+#define ADC_EXTERNALTRIGINJECCONV_EDGE_RISING         ((uint32_t)ADC_JSQR_JEXTEN_0)
+#define ADC_EXTERNALTRIGINJECCONV_EDGE_FALLING        ((uint32_t)ADC_JSQR_JEXTEN_1)
+#define ADC_EXTERNALTRIGINJECCONV_EDGE_RISINGFALLING  ((uint32_t)ADC_JSQR_JEXTEN)
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_External_trigger_source_Injected External Trigger Source of Injected Group
+  * @{
+  */
+#if defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F303xC) || defined(STM32F358xx)
+/* List of external triggers with generic trigger name, independently of ADC  */
+/* target (caution: applies to other ADCs sharing the same common group),     */
+/* sorted by trigger name:                                                    */
+
+/* External triggers of injected group for ADC1&ADC2 only */
+#define ADC_EXTERNALTRIGINJECCONV_T2_CC1    ADC1_2_EXTERNALTRIGINJEC_T2_CC1
+#define ADC_EXTERNALTRIGINJECCONV_T3_CC1    ADC1_2_EXTERNALTRIGINJEC_T3_CC1
+#define ADC_EXTERNALTRIGINJECCONV_T3_CC3    ADC1_2_EXTERNALTRIGINJEC_T3_CC3
+#define ADC_EXTERNALTRIGINJECCONV_T3_CC4    ADC1_2_EXTERNALTRIGINJEC_T3_CC4
+#define ADC_EXTERNALTRIGINJECCONV_T6_TRGO   ADC1_2_EXTERNALTRIGINJEC_T6_TRGO
+#define ADC_EXTERNALTRIGINJECCONV_EXT_IT15  ADC1_2_EXTERNALTRIGINJEC_EXT_IT15
+
+/* External triggers of injected group for ADC3&ADC4 only */
+#define ADC_EXTERNALTRIGINJECCONV_T1_CC3    ADC3_4_EXTERNALTRIGINJEC_T1_CC3
+#define ADC_EXTERNALTRIGINJECCONV_T4_CC3    ADC3_4_EXTERNALTRIGINJEC_T4_CC3
+#define ADC_EXTERNALTRIGINJECCONV_T4_CC4    ADC3_4_EXTERNALTRIGINJEC_T4_CC4
+#define ADC_EXTERNALTRIGINJECCONV_T7_TRGO   ADC3_4_EXTERNALTRIGINJEC_T7_TRGO
+#define ADC_EXTERNALTRIGINJECCONV_T8_CC2    ADC3_4_EXTERNALTRIGINJEC_T8_CC2
+
+/* External triggers of injected group for ADC1&ADC2, ADC3&ADC4 */
+/* Note: Triggers affected to group ADC1_2 by default, redirected to group    */
+/*       ADC3_4 by driver when needed.                                        */
+#define ADC_EXTERNALTRIGINJECCONV_T1_CC4    ADC1_2_EXTERNALTRIGINJEC_T1_CC4
+#define ADC_EXTERNALTRIGINJECCONV_T1_TRGO   ADC1_2_EXTERNALTRIGINJEC_T1_TRGO
+#define ADC_EXTERNALTRIGINJECCONV_T1_TRGO2  ADC1_2_EXTERNALTRIGINJEC_T1_TRGO2
+#define ADC_EXTERNALTRIGINJECCONV_T2_TRGO   ADC1_2_EXTERNALTRIGINJEC_T2_TRGO
+#define ADC_EXTERNALTRIGINJECCONV_T3_TRGO   ADC1_2_EXTERNALTRIGINJEC_T3_TRGO
+#define ADC_EXTERNALTRIGINJECCONV_T4_TRGO   ADC1_2_EXTERNALTRIGINJEC_T4_TRGO
+#define ADC_EXTERNALTRIGINJECCONV_T8_CC4    ADC1_2_EXTERNALTRIGINJEC_T8_CC4
+#define ADC_EXTERNALTRIGINJECCONV_T8_TRGO   ADC1_2_EXTERNALTRIGINJEC_T8_TRGO
+#define ADC_EXTERNALTRIGINJECCONV_T8_TRGO2  ADC1_2_EXTERNALTRIGINJEC_T8_TRGO2
+#define ADC_EXTERNALTRIGINJECCONV_T15_TRGO  ADC1_2_EXTERNALTRIGINJEC_T15_TRGO
+
+#define ADC_INJECTED_SOFTWARE_START     (0x00000001U)
+
+#if defined(STM32F303xE) || defined(STM32F398xx)
+/*!< List of external triggers specific to device STM303xE: using Timer20     */
+/* with ADC trigger input remap.                                              */
+/* To remap ADC trigger from other timers/ExtLine to timer20: use macro       */
+/* " __HAL_REMAPADCTRIGGER_ENABLE(...) " with parameters described below:     */
+
+/*!< External triggers of injected group for ADC1&ADC2 only, specific to      */
+/* device STM303xE: : using Timer20 with ADC trigger input remap              */
+#define ADC_EXTERNALTRIGINJECCONV_T20_CC4        ADC_EXTERNALTRIGINJECCONV_T3_CC1  /*!< Remap trigger using macro __HAL_REMAPADCTRIGGER_ENABLE(HAL_REMAPADCTRIGGER_ADC12_JEXT13U) */
+
+/*!< External triggers of injected group for ADC3&ADC4 only, specific to      */
+/* device STM303xE: : using Timer20 with ADC trigger input remap              */
+#define ADC_EXTERNALTRIGINJECCONV_T20_CC2        ADC_EXTERNALTRIGINJECCONV_T7_TRGO /*!< Remap trigger using macro __HAL_REMAPADCTRIGGER_ENABLE(HAL_REMAPADCTRIGGER_ADC34_JEXT14U) */
+
+/*!< External triggers of regular group for ADC1&ADC2, ADC3&ADC4, specific to */
+/* device STM303xE: : using Timer20 with ADC trigger input remap              */
+/* Note: Triggers affected to group ADC1_2 by default, redirected to group    */
+/*       ADC3_4 by driver when needed.                                        */
+#define ADC_EXTERNALTRIGINJECCONV_T20_TRGO       (ADC_EXTERNALTRIGINJECCONV_T2_CC1 | ADC_EXTERNALTRIGCONV_T20_MASK)   /*!< For ADC1&ADC2: Remap trigger using macro __HAL_REMAPADCTRIGGER_ENABLE(HAL_REMAPADCTRIGGER_ADC12_JEXT3) */
+                                                                                                                      /*!< For ADC3&ADC4: Remap trigger using macro __HAL_REMAPADCTRIGGER_ENABLE(HAL_REMAPADCTRIGGER_ADC34_JEXT5) */
+#define ADC_EXTERNALTRIGINJECCONV_T20_TRGO2      (ADC_EXTERNALTRIGINJECCONV_EXT_IT15 | ADC_EXTERNALTRIGCONV_T20_MASK) /*!< For ADC1&ADC2: Remap trigger using macro __HAL_REMAPADCTRIGGER_ENABLE(HAL_REMAPADCTRIGGER_ADC12_JEXT6) */
+                                                                                                                      /*!< For ADC3&ADC4: Remap trigger using macro __HAL_REMAPADCTRIGGER_ENABLE(HAL_REMAPADCTRIGGER_ADC34_JEXT11U) */
+#endif /* STM32F303xE || STM32F398xx */
+
+#if defined(STM32F303xC) || defined(STM32F358xx)
+#define IS_ADC_EXTTRIGINJEC(INJTRIG) (((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T2_CC1)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T3_CC1)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T3_CC4)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T6_TRGO)  || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_EXT_IT15) || \
+                                                                                           \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T4_CC3)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T4_CC4)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T7_TRGO)  || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T8_CC2)   || \
+                                                                                           \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T1_CC4)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T1_TRGO)  || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T1_TRGO2) || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T2_TRGO)  || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T3_CC3)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T3_TRGO)  || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T4_TRGO)  || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T8_CC4)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T8_TRGO)  || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T8_TRGO2) || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T15_TRGO) || \
+                                                                                           \
+                                      ((INJTRIG) == ADC_INJECTED_SOFTWARE_START)          )
+#endif /* STM32F303xC || STM32F358xx */
+
+#if defined(STM32F303xE) || defined(STM32F398xx)
+#define IS_ADC_EXTTRIGINJEC(INJTRIG) (((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T2_CC1)    || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T3_CC1)    || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T3_CC4)    || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T6_TRGO)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_EXT_IT15)  || \
+                                                                                            \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T4_CC3)    || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T4_CC4)    || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T7_TRGO)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T8_CC2)    || \
+                                                                                            \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T1_CC4)    || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T1_TRGO)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T1_TRGO2)  || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T2_TRGO)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T3_CC3)    || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T3_TRGO)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T4_TRGO)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T8_CC4)    || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T8_TRGO)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T8_TRGO2)  || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T15_TRGO)  || \
+                                                                                            \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T20_CC4)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T20_CC2)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T20_TRGO)  || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T20_TRGO2) || \
+                                                                                            \
+                                      ((INJTRIG) == ADC_INJECTED_SOFTWARE_START)           )
+#endif /* STM32F303xE || STM32F398xx */
+
+#endif /* STM32F303xC || STM32F303xE || STM32F398xx || STM32F358xx */
+
+#if defined(STM32F302xE) || \
+    defined(STM32F302xC)
+/*!< List of external triggers with generic trigger name, independently of    */
+/* ADC target (caution: applies to other ADCs sharing the same common group), */
+/* sorted by trigger name:                                                    */
+
+/* External triggers of injected group for ADC1&ADC2 */
+#define ADC_EXTERNALTRIGINJECCONV_T1_CC4    ADC1_2_EXTERNALTRIGINJEC_T1_CC4
+#define ADC_EXTERNALTRIGINJECCONV_T1_TRGO   ADC1_2_EXTERNALTRIGINJEC_T1_TRGO
+#define ADC_EXTERNALTRIGINJECCONV_T1_TRGO2  ADC1_2_EXTERNALTRIGINJEC_T1_TRGO2
+#define ADC_EXTERNALTRIGINJECCONV_T2_CC1    ADC1_2_EXTERNALTRIGINJEC_T2_CC1
+#define ADC_EXTERNALTRIGINJECCONV_T2_TRGO   ADC1_2_EXTERNALTRIGINJEC_T2_TRGO
+#define ADC_EXTERNALTRIGINJECCONV_T3_CC1    ADC1_2_EXTERNALTRIGINJEC_T3_CC1
+#define ADC_EXTERNALTRIGINJECCONV_T3_CC3    ADC1_2_EXTERNALTRIGINJEC_T3_CC3
+#define ADC_EXTERNALTRIGINJECCONV_T3_CC4    ADC1_2_EXTERNALTRIGINJEC_T3_CC4
+#define ADC_EXTERNALTRIGINJECCONV_T3_TRGO   ADC1_2_EXTERNALTRIGINJEC_T3_TRGO
+#define ADC_EXTERNALTRIGINJECCONV_T4_TRGO   ADC1_2_EXTERNALTRIGINJEC_T4_TRGO
+#define ADC_EXTERNALTRIGINJECCONV_T6_TRGO   ADC1_2_EXTERNALTRIGINJEC_T6_TRGO
+#define ADC_EXTERNALTRIGINJECCONV_T15_TRGO  ADC1_2_EXTERNALTRIGINJEC_T15_TRGO
+#define ADC_EXTERNALTRIGINJECCONV_EXT_IT15  ADC1_2_EXTERNALTRIGINJEC_EXT_IT15
+
+#define ADC_INJECTED_SOFTWARE_START     (0x00000001U)
+
+#if defined(STM32F302xE)
+/*!< List of external triggers specific to device STM302xE: using Timer20     */
+/* with ADC trigger input remap.                                              */
+/* To remap ADC trigger from other timers/ExtLine to timer20: use macro       */
+/* " __HAL_REMAPADCTRIGGER_ENABLE(...) " with parameters described below:     */
+
+/*!< External triggers of injected group for ADC1&ADC2 only, specific to      */
+/* device STM302xE: : using Timer20 with ADC trigger input remap              */
+#define ADC_EXTERNALTRIGINJECCONV_T20_CC4        ADC_EXTERNALTRIGINJECCONV_T3_CC1  /*!< Remap trigger using macro __HAL_REMAPADCTRIGGER_ENABLE(HAL_REMAPADCTRIGGER_ADC12_JEXT13U) */
+#define ADC_EXTERNALTRIGINJECCONV_T20_TRGO       (ADC_EXTERNALTRIGINJECCONV_T2_CC1 | ADC_EXTERNALTRIGCONV_T20_MASK)   /*!< For ADC1&ADC2: Remap trigger using macro __HAL_REMAPADCTRIGGER_ENABLE(HAL_REMAPADCTRIGGER_ADC12_JEXT3) */
+#define ADC_EXTERNALTRIGINJECCONV_T20_TRGO2      (ADC_EXTERNALTRIGINJECCONV_EXT_IT15 | ADC_EXTERNALTRIGCONV_T20_MASK) /*!< For ADC1&ADC2: Remap trigger using macro __HAL_REMAPADCTRIGGER_ENABLE(HAL_REMAPADCTRIGGER_ADC12_JEXT6) */
+#endif /* STM32F302xE */
+
+#endif /* STM32F302xE || */
+       /* STM32F302xC    */
+
+#if defined(STM32F303x8) || defined(STM32F328xx)
+/*!< List of external triggers with generic trigger name, independently of    */
+/* ADC target (caution: applies to other ADCs sharing the same common group), */
+/* sorted by trigger name:                                                    */
+
+/* External triggers of injected group for ADC1&ADC2 */
+#define ADC_EXTERNALTRIGINJECCONV_T1_CC4       ADC1_2_EXTERNALTRIGINJEC_T1_CC4
+#define ADC_EXTERNALTRIGINJECCONV_T1_TRGO      ADC1_2_EXTERNALTRIGINJEC_T1_TRGO
+#define ADC_EXTERNALTRIGINJECCONV_T1_TRGO2     ADC1_2_EXTERNALTRIGINJEC_T1_TRGO2
+#define ADC_EXTERNALTRIGINJECCONV_T2_CC1       ADC1_2_EXTERNALTRIGINJEC_T2_CC1
+#define ADC_EXTERNALTRIGINJECCONV_T2_TRGO      ADC1_2_EXTERNALTRIGINJEC_T2_TRGO
+#define ADC_EXTERNALTRIGINJECCONV_T3_CC1       ADC1_2_EXTERNALTRIGINJEC_T3_CC1
+#define ADC_EXTERNALTRIGINJECCONV_T3_CC3       ADC1_2_EXTERNALTRIGINJEC_T3_CC3
+#define ADC_EXTERNALTRIGINJECCONV_T3_CC4       ADC1_2_EXTERNALTRIGINJEC_T3_CC4
+#define ADC_EXTERNALTRIGINJECCONV_T3_TRGO      ADC1_2_EXTERNALTRIGINJEC_T3_TRGO
+#define ADC_EXTERNALTRIGINJECCONV_T4_TRGO      ADC1_2_EXTERNALTRIGINJEC_T4_TRGO
+#define ADC_EXTERNALTRIGINJECCONV_T6_TRGO      ADC1_2_EXTERNALTRIGINJEC_T6_TRGO
+#define ADC_EXTERNALTRIGINJECCONV_T8_CC4       ADC1_2_EXTERNALTRIGINJEC_T8_CC4
+#define ADC_EXTERNALTRIGINJECCONV_T8_TRGO      ADC1_2_EXTERNALTRIGINJEC_T8_TRGO
+#define ADC_EXTERNALTRIGINJECCONV_T8_TRGO2     ADC1_2_EXTERNALTRIGINJEC_T8_TRGO2
+#define ADC_EXTERNALTRIGINJECCONV_T15_TRGO     ADC1_2_EXTERNALTRIGINJEC_T15_TRGO
+#define ADC_EXTERNALTRIGINJECCONV_EXT_IT15     ADC1_2_EXTERNALTRIGINJEC_EXT_IT15
+
+#define ADC_INJECTED_SOFTWARE_START     (0x00000001U)
+#endif /* STM32F303x8 || STM32F328xx */
+
+#if defined(STM32F334x8)
+/*!< List of external triggers with generic trigger name, independently of    */
+/* ADC target (caution: applies to other ADCs sharing the same common group), */
+/* sorted by trigger name:                                                    */
+
+/* External triggers of injected group for ADC1&ADC2 */
+#define ADC_EXTERNALTRIGINJECCONV_T1_CC4       ADC1_2_EXTERNALTRIGINJEC_T1_CC4
+#define ADC_EXTERNALTRIGINJECCONV_T1_TRGO      ADC1_2_EXTERNALTRIGINJEC_T1_TRGO
+#define ADC_EXTERNALTRIGINJECCONV_T1_TRGO2     ADC1_2_EXTERNALTRIGINJEC_T1_TRGO2
+#define ADC_EXTERNALTRIGINJECCONV_T2_CC1       ADC1_2_EXTERNALTRIGINJEC_T2_CC1
+#define ADC_EXTERNALTRIGINJECCONV_T2_TRGO      ADC1_2_EXTERNALTRIGINJEC_T2_TRGO
+#define ADC_EXTERNALTRIGINJECCONV_T3_CC1       ADC1_2_EXTERNALTRIGINJEC_T3_CC1
+#define ADC_EXTERNALTRIGINJECCONV_T3_CC3       ADC1_2_EXTERNALTRIGINJEC_T3_CC3
+#define ADC_EXTERNALTRIGINJECCONV_T3_CC4       ADC1_2_EXTERNALTRIGINJEC_T3_CC4
+#define ADC_EXTERNALTRIGINJECCONV_T3_TRGO      ADC1_2_EXTERNALTRIGINJEC_T3_TRGO
+#define ADC_EXTERNALTRIGINJECCONV_T6_TRGO      ADC1_2_EXTERNALTRIGINJEC_T6_TRGO
+#define ADC_EXTERNALTRIGINJECCONV_T15_TRGO     ADC1_2_EXTERNALTRIGINJEC_T15_TRGO
+#define ADC_EXTERNALTRIGINJECCONV_HRTIM_TRG2   ADC1_2_EXTERNALTRIGINJEC_HRTIM_TRG2
+#define ADC_EXTERNALTRIGINJECCONV_HRTIM_TRG4   ADC1_2_EXTERNALTRIGINJEC_HRTIM_TRG4
+#define ADC_EXTERNALTRIGINJECCONV_EXT_IT15     ADC1_2_EXTERNALTRIGINJEC_EXT_IT15
+
+#define ADC_INJECTED_SOFTWARE_START     (0x00000001U)
+#endif /* STM32F334x8 */
+
+#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+/* List of external triggers with generic trigger name, sorted by trigger     */
+/* name:                                                                      */
+
+/* External triggers of injected group for ADC1 */
+#define ADC_EXTERNALTRIGINJECCONV_T1_CC4     ADC1_EXTERNALTRIGINJEC_T1_CC4
+#define ADC_EXTERNALTRIGINJECCONV_T1_TRGO    ADC1_EXTERNALTRIGINJEC_T1_TRGO
+#define ADC_EXTERNALTRIGINJECCONV_T1_TRGO2   ADC1_EXTERNALTRIGINJEC_T1_TRGO2
+#define ADC_EXTERNALTRIGINJECCONV_T2_CC1     ADC1_EXTERNALTRIGINJEC_T2_CC1
+#define ADC_EXTERNALTRIGINJECCONV_T2_TRGO    ADC1_EXTERNALTRIGINJEC_T2_TRGO
+#define ADC_EXTERNALTRIGINJECCONV_T6_TRGO    ADC1_EXTERNALTRIGINJEC_T6_TRGO
+#define ADC_EXTERNALTRIGINJECCONV_T15_TRGO   ADC1_EXTERNALTRIGINJEC_T15_TRGO
+#define ADC_EXTERNALTRIGINJECCONV_EXT_IT15   ADC1_EXTERNALTRIGINJEC_EXT_IT15
+
+#define ADC_INJECTED_SOFTWARE_START     (0x00000001U)
+#endif /* STM32F301x8 || STM32F302x8 || STM32F318xx */
+/**
+  * @}
+  */
+
+
+/** @defgroup ADCEx_Common_mode ADC Extended Dual ADC Mode
+  * @{
+  */
+#define ADC_MODE_INDEPENDENT                  ((uint32_t)(0x00000000U))
+#define ADC_DUALMODE_REGSIMULT_INJECSIMULT    ((uint32_t)(ADC12_CCR_MULTI_0))
+#define ADC_DUALMODE_REGSIMULT_ALTERTRIG      ((uint32_t)(ADC12_CCR_MULTI_1))
+#define ADC_DUALMODE_REGINTERL_INJECSIMULT    ((uint32_t)(ADC12_CCR_MULTI_1 | ADC12_CCR_MULTI_0))
+#define ADC_DUALMODE_INJECSIMULT              ((uint32_t)(ADC12_CCR_MULTI_2 | ADC12_CCR_MULTI_0))
+#define ADC_DUALMODE_REGSIMULT                ((uint32_t)(ADC12_CCR_MULTI_2 | ADC12_CCR_MULTI_1))
+#define ADC_DUALMODE_INTERL                   ((uint32_t)(ADC12_CCR_MULTI_2 | ADC12_CCR_MULTI_1 | ADC12_CCR_MULTI_0))
+#define ADC_DUALMODE_ALTERTRIG                ((uint32_t)(ADC12_CCR_MULTI_3 | ADC12_CCR_MULTI_0))
+/**
+  * @}
+  */
+
+
+/** @defgroup ADCEx_Direct_memory_access_mode_for_multimode ADC Extended DMA Mode for Dual ADC Mode
+  * @{
+  */
+#define ADC_DMAACCESSMODE_DISABLED      (0x00000000U)         /*!< DMA multimode disabled: each ADC will use its own DMA channel */
+#define ADC_DMAACCESSMODE_12_10_BITS    ((uint32_t)ADC12_CCR_MDMA_1)   /*!< DMA multimode enabled (one DMA channel for both ADC, DMA of ADC master) for 12 and 10 bits resolution */
+#define ADC_DMAACCESSMODE_8_6_BITS      ((uint32_t)ADC12_CCR_MDMA)     /*!< DMA multimode enabled (one DMA channel for both ADC, DMA of ADC master) for 8 and 6 bits resolution */
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_delay_between_2_sampling_phases ADC Extended Delay Between 2 Sampling Phases
+  * @{
+  */
+#define ADC_TWOSAMPLINGDELAY_1CYCLE     ((uint32_t)(0x00000000U))
+#define ADC_TWOSAMPLINGDELAY_2CYCLES    ((uint32_t)(ADC12_CCR_DELAY_0))
+#define ADC_TWOSAMPLINGDELAY_3CYCLES    ((uint32_t)(ADC12_CCR_DELAY_1))
+#define ADC_TWOSAMPLINGDELAY_4CYCLES    ((uint32_t)(ADC12_CCR_DELAY_1 | ADC12_CCR_DELAY_0))
+#define ADC_TWOSAMPLINGDELAY_5CYCLES    ((uint32_t)(ADC12_CCR_DELAY_2))
+#define ADC_TWOSAMPLINGDELAY_6CYCLES    ((uint32_t)(ADC12_CCR_DELAY_2 | ADC12_CCR_DELAY_0))
+#define ADC_TWOSAMPLINGDELAY_7CYCLES    ((uint32_t)(ADC12_CCR_DELAY_2 | ADC12_CCR_DELAY_1))
+#define ADC_TWOSAMPLINGDELAY_8CYCLES    ((uint32_t)(ADC12_CCR_DELAY_2 | ADC12_CCR_DELAY_1 | ADC12_CCR_DELAY_0))
+#define ADC_TWOSAMPLINGDELAY_9CYCLES    ((uint32_t)(ADC12_CCR_DELAY_3))
+#define ADC_TWOSAMPLINGDELAY_10CYCLES   ((uint32_t)(ADC12_CCR_DELAY_3 | ADC12_CCR_DELAY_0))
+#define ADC_TWOSAMPLINGDELAY_11CYCLES   ((uint32_t)(ADC12_CCR_DELAY_3 | ADC12_CCR_DELAY_1))
+#define ADC_TWOSAMPLINGDELAY_12CYCLES   ((uint32_t)(ADC12_CCR_DELAY_3 | ADC12_CCR_DELAY_1 | ADC12_CCR_DELAY_0))
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_analog_watchdog_number ADC Extended Analog Watchdog Selection
+  * @{
+  */
+#define ADC_ANALOGWATCHDOG_1                    (0x00000001U)
+#define ADC_ANALOGWATCHDOG_2                    (0x00000002U)
+#define ADC_ANALOGWATCHDOG_3                    (0x00000003U)
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_analog_watchdog_mode ADC Extended Analog Watchdog Mode
+  * @{
+  */
+#define ADC_ANALOGWATCHDOG_NONE                 ( 0x00000000U)
+#define ADC_ANALOGWATCHDOG_SINGLE_REG           ((uint32_t)(ADC_CFGR_AWD1SGL | ADC_CFGR_AWD1EN))
+#define ADC_ANALOGWATCHDOG_SINGLE_INJEC         ((uint32_t)(ADC_CFGR_AWD1SGL | ADC_CFGR_JAWD1EN))
+#define ADC_ANALOGWATCHDOG_SINGLE_REGINJEC      ((uint32_t)(ADC_CFGR_AWD1SGL | ADC_CFGR_AWD1EN | ADC_CFGR_JAWD1EN))
+#define ADC_ANALOGWATCHDOG_ALL_REG              ((uint32_t) ADC_CFGR_AWD1EN)
+#define ADC_ANALOGWATCHDOG_ALL_INJEC            ((uint32_t) ADC_CFGR_JAWD1EN)
+#define ADC_ANALOGWATCHDOG_ALL_REGINJEC         ((uint32_t)(ADC_CFGR_AWD1EN | ADC_CFGR_JAWD1EN))
+/**
+  * @}
+  */
+
+/** @defgroup ADC_conversion_group ADC Conversion Group
+  * @{
+  */
+#define ADC_REGULAR_GROUP             ((uint32_t)(ADC_FLAG_EOC | ADC_FLAG_EOS))
+#define ADC_INJECTED_GROUP            ((uint32_t)(ADC_FLAG_JEOC | ADC_FLAG_JEOS))
+#define ADC_REGULAR_INJECTED_GROUP    ((uint32_t)(ADC_FLAG_EOC | ADC_FLAG_EOS | ADC_FLAG_JEOC | ADC_FLAG_JEOS))
+
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_Event_type ADC Extended Event Type
+  * @{
+  */
+#define ADC_AWD1_EVENT           ((uint32_t)ADC_FLAG_AWD1)  /*!< ADC Analog watchdog 1 event (main analog watchdog, present on all STM32 devices) */
+#define ADC_AWD2_EVENT           ((uint32_t)ADC_FLAG_AWD2)  /*!< ADC Analog watchdog 2 event (additional analog watchdog, not present on all STM32 families) */
+#define ADC_AWD3_EVENT           ((uint32_t)ADC_FLAG_AWD3)  /*!< ADC Analog watchdog 3 event (additional analog watchdog, not present on all STM32 families) */
+#define ADC_OVR_EVENT            ((uint32_t)ADC_FLAG_OVR)   /*!< ADC overrun event */
+#define ADC_JQOVF_EVENT          ((uint32_t)ADC_FLAG_JQOVF) /*!< ADC Injected Context Queue Overflow event */
+
+#define ADC_AWD_EVENT            ADC_AWD1_EVENT         /* ADC Analog watchdog 1 event: Alternate naming for compatibility with other STM32 devices having only 1 analog watchdog */
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_interrupts_definition ADC Extended Interrupts Definition
+  * @{
+  */
+#define ADC_IT_RDY           ADC_IER_RDY        /*!< ADC Ready (ADRDY) interrupt source */
+#define ADC_IT_EOSMP         ADC_IER_EOSMP      /*!< ADC End of Sampling interrupt source */
+#define ADC_IT_EOC           ADC_IER_EOC        /*!< ADC End of Regular Conversion interrupt source */
+#define ADC_IT_EOS           ADC_IER_EOS        /*!< ADC End of Regular sequence of Conversions interrupt source */
+#define ADC_IT_OVR           ADC_IER_OVR        /*!< ADC overrun interrupt source */
+#define ADC_IT_JEOC          ADC_IER_JEOC       /*!< ADC End of Injected Conversion interrupt source */
+#define ADC_IT_JEOS          ADC_IER_JEOS       /*!< ADC End of Injected sequence of Conversions interrupt source */
+#define ADC_IT_AWD1          ADC_IER_AWD1       /*!< ADC Analog watchdog 1 interrupt source (main analog watchdog, present on all STM32 devices) */
+#define ADC_IT_AWD2          ADC_IER_AWD2       /*!< ADC Analog watchdog 2 interrupt source (additional analog watchdog, present only on STM32F3 devices) */
+#define ADC_IT_AWD3          ADC_IER_AWD3       /*!< ADC Analog watchdog 3 interrupt source (additional analog watchdog, present only on STM32F3 devices) */
+#define ADC_IT_JQOVF         ADC_IER_JQOVF      /*!< ADC Injected Context Queue Overflow interrupt source */
+
+#define ADC_IT_AWD           ADC_IT_AWD1        /* ADC Analog watchdog 1 interrupt source: Alternate naming for compatibility with other STM32 devices having only 1 analog watchdog */
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_flags_definition ADC Extended Flags Definition
+  * @{
+  */
+#define ADC_FLAG_RDY           ADC_ISR_ADRD     /*!< ADC Ready (ADRDY) flag */
+#define ADC_FLAG_EOSMP         ADC_ISR_EOSMP    /*!< ADC End of Sampling flag */
+#define ADC_FLAG_EOC           ADC_ISR_EOC      /*!< ADC End of Regular Conversion flag */
+#define ADC_FLAG_EOS           ADC_ISR_EOS      /*!< ADC End of Regular sequence of Conversions flag */
+#define ADC_FLAG_OVR           ADC_ISR_OVR      /*!< ADC overrun flag */
+#define ADC_FLAG_JEOC          ADC_ISR_JEOC     /*!< ADC End of Injected Conversion flag */
+#define ADC_FLAG_JEOS          ADC_ISR_JEOS     /*!< ADC End of Injected sequence of Conversions flag */
+#define ADC_FLAG_AWD1          ADC_ISR_AWD1     /*!< ADC Analog watchdog 1 flag (main analog watchdog, present on all STM32 devices) */
+#define ADC_FLAG_AWD2          ADC_ISR_AWD2     /*!< ADC Analog watchdog 2 flag (additional analog watchdog, present only on STM32F3 devices) */
+#define ADC_FLAG_AWD3          ADC_ISR_AWD3     /*!< ADC Analog watchdog 3 flag (additional analog watchdog, present only on STM32F3 devices) */
+#define ADC_FLAG_JQOVF         ADC_ISR_JQOVF    /*!< ADC Injected Context Queue Overflow flag */
+
+#define ADC_FLAG_AWD           ADC_FLAG_AWD1    /* ADC Analog watchdog 1 flag: Alternate naming for compatibility with other STM32 devices having only 1 analog watchdog */
+/**
+  * @}
+  */
+
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+
+
+#if defined(STM32F373xC) || defined(STM32F378xx)
+/** @defgroup ADCEx_Data_align ADC Extended Data Alignment
+  * @{
+  */
+#define ADC_DATAALIGN_RIGHT      (0x00000000U)
+#define ADC_DATAALIGN_LEFT       ((uint32_t)ADC_CR2_ALIGN)
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_Scan_mode ADC Extended Scan Mode
+  * @{
+  */
+#define ADC_SCAN_DISABLE         (0x00000000U)
+#define ADC_SCAN_ENABLE          ((uint32_t)ADC_CR1_SCAN)
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_External_trigger_edge_Regular ADC Extended External trigger enable for regular group
+  * @{
+  */
+#define ADC_EXTERNALTRIGCONVEDGE_NONE           (0x00000000U)
+#define ADC_EXTERNALTRIGCONVEDGE_RISING         ((uint32_t)ADC_CR2_EXTTRIG)
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_External_trigger_source_Regular ADC Extended External trigger selection for regular group
+  * @{
+  */
+/* List of external triggers with generic trigger name, sorted by trigger     */
+/* name:                                                                      */
+
+/* External triggers of regular group for ADC1 */
+#define ADC_EXTERNALTRIGCONV_T2_CC2      ADC_EXTERNALTRIG_T2_CC2
+#define ADC_EXTERNALTRIGCONV_T3_TRGO     ADC_EXTERNALTRIG_T3_TRGO
+#define ADC_EXTERNALTRIGCONV_T4_CC4      ADC_EXTERNALTRIG_T4_CC4
+#define ADC_EXTERNALTRIGCONV_T19_TRGO    ADC_EXTERNALTRIG_T19_TRGO
+#define ADC_EXTERNALTRIGCONV_T19_CC3     ADC_EXTERNALTRIG_T19_CC3
+#define ADC_EXTERNALTRIGCONV_T19_CC4     ADC_EXTERNALTRIG_T19_CC4
+#define ADC_EXTERNALTRIGCONV_EXT_IT11    ADC_EXTERNALTRIG_EXT_IT11
+#define ADC_SOFTWARE_START               ADC_SWSTART
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_channels ADC Extended Channels
+  * @{
+  */
+/* Note: Depending on devices, some channels may not be available on package  */
+/*       pins. Refer to device datasheet for channels availability.           */
+#define ADC_CHANNEL_0           (0x00000000U)
+#define ADC_CHANNEL_1           ((uint32_t)(ADC_SQR3_SQ1_0))
+#define ADC_CHANNEL_2           ((uint32_t)(ADC_SQR3_SQ1_1))
+#define ADC_CHANNEL_3           ((uint32_t)(ADC_SQR3_SQ1_1 | ADC_SQR3_SQ1_0))
+#define ADC_CHANNEL_4           ((uint32_t)(ADC_SQR3_SQ1_2))
+#define ADC_CHANNEL_5           ((uint32_t)(ADC_SQR3_SQ1_2 | ADC_SQR3_SQ1_0))
+#define ADC_CHANNEL_6           ((uint32_t)(ADC_SQR3_SQ1_2 | ADC_SQR3_SQ1_1))
+#define ADC_CHANNEL_7           ((uint32_t)(ADC_SQR3_SQ1_2 | ADC_SQR3_SQ1_1 | ADC_SQR3_SQ1_0))
+#define ADC_CHANNEL_8           ((uint32_t)(ADC_SQR3_SQ1_3))
+#define ADC_CHANNEL_9           ((uint32_t)(ADC_SQR3_SQ1_3 | ADC_SQR3_SQ1_0))
+#define ADC_CHANNEL_10          ((uint32_t)(ADC_SQR3_SQ1_3 | ADC_SQR3_SQ1_1))
+#define ADC_CHANNEL_11          ((uint32_t)(ADC_SQR3_SQ1_3 | ADC_SQR3_SQ1_1 | ADC_SQR3_SQ1_0))
+#define ADC_CHANNEL_12          ((uint32_t)(ADC_SQR3_SQ1_3 | ADC_SQR3_SQ1_2))
+#define ADC_CHANNEL_13          ((uint32_t)(ADC_SQR3_SQ1_3 | ADC_SQR3_SQ1_2 | ADC_SQR3_SQ1_0))
+#define ADC_CHANNEL_14          ((uint32_t)(ADC_SQR3_SQ1_3 | ADC_SQR3_SQ1_2 | ADC_SQR3_SQ1_1))
+#define ADC_CHANNEL_15          ((uint32_t)(ADC_SQR3_SQ1_3 | ADC_SQR3_SQ1_2 | ADC_SQR3_SQ1_1 | ADC_SQR3_SQ1_0))
+#define ADC_CHANNEL_16          ((uint32_t)(ADC_SQR3_SQ1_4))
+#define ADC_CHANNEL_17          ((uint32_t)(ADC_SQR3_SQ1_4 | ADC_SQR3_SQ1_0))
+#define ADC_CHANNEL_18          ((uint32_t)(ADC_SQR3_SQ1_4 | ADC_SQR3_SQ1_1))
+
+#define ADC_CHANNEL_TEMPSENSOR  ADC_CHANNEL_16
+#define ADC_CHANNEL_VREFINT     ADC_CHANNEL_17
+#define ADC_CHANNEL_VBAT        ADC_CHANNEL_18
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_sampling_times ADC Extended Sampling Times
+  * @{
+  */
+#define ADC_SAMPLETIME_1CYCLE_5       (0x00000000U)                            /*!< Sampling time 1.5 ADC clock cycle */
+#define ADC_SAMPLETIME_7CYCLES_5      ((uint32_t) ADC_SMPR2_SMP0_0)                     /*!< Sampling time 7.5 ADC clock cycles */
+#define ADC_SAMPLETIME_13CYCLES_5     ((uint32_t) ADC_SMPR2_SMP0_1)                     /*!< Sampling time 13.5 ADC clock cycles */
+#define ADC_SAMPLETIME_28CYCLES_5     ((uint32_t)(ADC_SMPR2_SMP0_1 | ADC_SMPR2_SMP0_0)) /*!< Sampling time 28.5 ADC clock cycles */
+#define ADC_SAMPLETIME_41CYCLES_5     ((uint32_t) ADC_SMPR2_SMP0_2)                     /*!< Sampling time 41.5 ADC clock cycles */
+#define ADC_SAMPLETIME_55CYCLES_5     ((uint32_t)(ADC_SMPR2_SMP0_2 | ADC_SMPR2_SMP0_0)) /*!< Sampling time 55.5 ADC clock cycles */
+#define ADC_SAMPLETIME_71CYCLES_5     ((uint32_t)(ADC_SMPR2_SMP0_2 | ADC_SMPR2_SMP0_1)) /*!< Sampling time 71.5 ADC clock cycles */
+#define ADC_SAMPLETIME_239CYCLES_5    ((uint32_t) ADC_SMPR2_SMP0)                       /*!< Sampling time 239.5 ADC clock cycles */
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_regular_rank ADC Extended rank into regular group
+  * @{
+  */
+#define ADC_REGULAR_RANK_1    (0x00000001U)
+#define ADC_REGULAR_RANK_2    (0x00000002U)
+#define ADC_REGULAR_RANK_3    (0x00000003U)
+#define ADC_REGULAR_RANK_4    (0x00000004U)
+#define ADC_REGULAR_RANK_5    (0x00000005U)
+#define ADC_REGULAR_RANK_6    (0x00000006U)
+#define ADC_REGULAR_RANK_7    (0x00000007U)
+#define ADC_REGULAR_RANK_8    (0x00000008U)
+#define ADC_REGULAR_RANK_9    (0x00000009U)
+#define ADC_REGULAR_RANK_10   (0x0000000AU)
+#define ADC_REGULAR_RANK_11   (0x0000000BU)
+#define ADC_REGULAR_RANK_12   (0x0000000CU)
+#define ADC_REGULAR_RANK_13   (0x0000000DU)
+#define ADC_REGULAR_RANK_14   (0x0000000EU)
+#define ADC_REGULAR_RANK_15   (0x0000000FU)
+#define ADC_REGULAR_RANK_16   (0x00000010U)
+/**
+  * @}
+  */
+       
+/** @defgroup ADCEx_injected_rank ADC Extended Injected Channel Rank
+  * @{
+  */
+#define ADC_INJECTED_RANK_1    (0x00000001U)
+#define ADC_INJECTED_RANK_2    (0x00000002U)
+#define ADC_INJECTED_RANK_3    (0x00000003U)
+#define ADC_INJECTED_RANK_4    (0x00000004U)
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_External_trigger_edge_Injected External Trigger Edge of Injected Group
+  * @{
+  */
+#define ADC_EXTERNALTRIGINJECCONV_EDGE_NONE           (0x00000000U)
+#define ADC_EXTERNALTRIGINJECCONV_EDGE_RISING         ((uint32_t)ADC_CR2_JEXTTRIG)
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_External_trigger_source_Injected External Trigger Source of Injected Group
+  * @{
+  */
+/* External triggers for injected groups of ADC1 */
+#define ADC_EXTERNALTRIGINJECCONV_T2_CC1       ADC_EXTERNALTRIGINJEC_T2_CC1
+#define ADC_EXTERNALTRIGINJECCONV_T2_TRGO      ADC_EXTERNALTRIGINJEC_T2_TRGO
+#define ADC_EXTERNALTRIGINJECCONV_T3_CC4       ADC_EXTERNALTRIGINJEC_T3_CC4
+#define ADC_EXTERNALTRIGINJECCONV_T4_TRGO      ADC_EXTERNALTRIGINJEC_T4_TRGO
+#define ADC_EXTERNALTRIGINJECCONV_T19_CC1      ADC_EXTERNALTRIGINJEC_T19_CC1
+#define ADC_EXTERNALTRIGINJECCONV_T19_CC2      ADC_EXTERNALTRIGINJEC_T19_CC2
+#define ADC_EXTERNALTRIGINJECCONV_EXT_IT15     ADC_EXTERNALTRIGINJEC_EXT_IT15
+#define ADC_INJECTED_SOFTWARE_START            ADC_JSWSTART
+/**
+  * @}
+  */
+
+
+/** @defgroup ADCEx_analog_watchdog_mode ADC Extended analog watchdog mode
+  * @{
+  */
+#define ADC_ANALOGWATCHDOG_NONE                 (0x00000000U)
+#define ADC_ANALOGWATCHDOG_SINGLE_REG           ((uint32_t)(ADC_CR1_AWDSGL | ADC_CR1_AWDEN))
+#define ADC_ANALOGWATCHDOG_SINGLE_INJEC         ((uint32_t)(ADC_CR1_AWDSGL | ADC_CR1_JAWDEN))
+#define ADC_ANALOGWATCHDOG_SINGLE_REGINJEC      ((uint32_t)(ADC_CR1_AWDSGL | ADC_CR1_AWDEN | ADC_CR1_JAWDEN))
+#define ADC_ANALOGWATCHDOG_ALL_REG              ((uint32_t) ADC_CR1_AWDEN)
+#define ADC_ANALOGWATCHDOG_ALL_INJEC            ((uint32_t) ADC_CR1_JAWDEN)
+#define ADC_ANALOGWATCHDOG_ALL_REGINJEC         ((uint32_t)(ADC_CR1_AWDEN | ADC_CR1_JAWDEN))
+/**
+  * @}
+  */
+
+/** @defgroup ADC_conversion_group ADC Conversion Group
+  * @{
+  */
+#define ADC_REGULAR_GROUP             ((uint32_t)(ADC_FLAG_EOC))
+#define ADC_INJECTED_GROUP            ((uint32_t)(ADC_FLAG_JEOC))
+#define ADC_REGULAR_INJECTED_GROUP    ((uint32_t)(ADC_FLAG_EOC | ADC_FLAG_JEOC))
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_Event_type ADC Extended Event Type
+  * @{
+  */
+#define ADC_AWD_EVENT               ((uint32_t)ADC_FLAG_AWD)   /*!< ADC Analog watchdog event */
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_interrupts_definition ADC Extended Interrupts Definition
+  * @{
+  */
+#define ADC_IT_EOC           ADC_CR1_EOCIE        /*!< ADC End of Regular Conversion interrupt source */
+#define ADC_IT_JEOC          ADC_CR1_JEOCIE       /*!< ADC End of Injected Conversion interrupt source */
+#define ADC_IT_AWD           ADC_CR1_AWDIE        /*!< ADC Analog watchdog interrupt source */
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_flags_definition ADC Extended Flags Definition
+  * @{
+  */
+#define ADC_FLAG_AWD           ADC_SR_AWD      /*!< ADC Analog watchdog flag */
+#define ADC_FLAG_EOC           ADC_SR_EOC      /*!< ADC End of Regular conversion flag */
+#define ADC_FLAG_JEOC          ADC_SR_JEOC     /*!< ADC End of Injected conversion flag */
+#define ADC_FLAG_JSTRT         ADC_SR_JSTRT    /*!< ADC Injected group start flag */
+#define ADC_FLAG_STRT          ADC_SR_STRT     /*!< ADC Regular group start flag */
+
+/**
+  * @}
+  */
+#endif /* STM32F373xC || STM32F378xx */
+
+/**
+  * @}
+  */
+
+
+     
+/* Private constants ---------------------------------------------------------*/
+
+/** @addtogroup ADCEx_Private_Constants ADCEx Private Constants
+  * @{
+  */
+     
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+
+
+/** @defgroup ADCEx_Internal_HAL_driver_Ext_trig_src_Regular ADC Extended Internal HAL driver trigger selection for regular group
+  * @{
+  */
+#if defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F303xC) || defined(STM32F358xx)
+/* List of external triggers for common groups ADC1&ADC2 and/or ADC3&ADC4:    */
+/* (used internally by HAL driver. To not use into HAL structure parameters)  */
+
+/* External triggers of regular group for ADC1 & ADC2 */
+#define ADC1_2_EXTERNALTRIG_T1_CC1           (0x00000000U)
+#define ADC1_2_EXTERNALTRIG_T1_CC2           ((uint32_t)ADC_CFGR_EXTSEL_0)
+#define ADC1_2_EXTERNALTRIG_T1_CC3           ((uint32_t)ADC_CFGR_EXTSEL_1)
+#define ADC1_2_EXTERNALTRIG_T2_CC2           ((uint32_t)(ADC_CFGR_EXTSEL_1 | ADC_CFGR_EXTSEL_0))
+#define ADC1_2_EXTERNALTRIG_T3_TRGO          ((uint32_t)ADC_CFGR_EXTSEL_2)
+#define ADC1_2_EXTERNALTRIG_T4_CC4           ((uint32_t)(ADC_CFGR_EXTSEL_2 | ADC_CFGR_EXTSEL_0))
+#define ADC1_2_EXTERNALTRIG_EXT_IT11         ((uint32_t)(ADC_CFGR_EXTSEL_2 | ADC_CFGR_EXTSEL_1))
+#define ADC1_2_EXTERNALTRIG_T8_TRGO          ((uint32_t)(ADC_CFGR_EXTSEL_2 | ADC_CFGR_EXTSEL_1 | ADC_CFGR_EXTSEL_0))
+#define ADC1_2_EXTERNALTRIG_T8_TRGO2         ((uint32_t) ADC_CFGR_EXTSEL_3)
+#define ADC1_2_EXTERNALTRIG_T1_TRGO          ((uint32_t)(ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_0))
+#define ADC1_2_EXTERNALTRIG_T1_TRGO2         ((uint32_t)(ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_1))
+#define ADC1_2_EXTERNALTRIG_T2_TRGO          ((uint32_t)(ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_1 | ADC_CFGR_EXTSEL_0))
+#define ADC1_2_EXTERNALTRIG_T4_TRGO          ((uint32_t)(ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_2))
+#define ADC1_2_EXTERNALTRIG_T6_TRGO          ((uint32_t)(ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_2 | ADC_CFGR_EXTSEL_0))
+#define ADC1_2_EXTERNALTRIG_T15_TRGO         ((uint32_t)(ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_2 | ADC_CFGR_EXTSEL_1))
+#define ADC1_2_EXTERNALTRIG_T3_CC4           ((uint32_t)ADC_CFGR_EXTSEL)
+
+/* External triggers of regular group for ADC3 & ADC4 */
+#define ADC3_4_EXTERNALTRIG_T3_CC1           (0x00000000U)
+#define ADC3_4_EXTERNALTRIG_T2_CC3           ((uint32_t)ADC_CFGR_EXTSEL_0)
+#define ADC3_4_EXTERNALTRIG_T1_CC3           ((uint32_t)ADC_CFGR_EXTSEL_1)
+#define ADC3_4_EXTERNALTRIG_T8_CC1           ((uint32_t)(ADC_CFGR_EXTSEL_1 | ADC_CFGR_EXTSEL_0))
+#define ADC3_4_EXTERNALTRIG_T8_TRGO          ((uint32_t)ADC_CFGR_EXTSEL_2)
+#define ADC3_4_EXTERNALTRIG_EXT_IT2          ((uint32_t)(ADC_CFGR_EXTSEL_2 | ADC_CFGR_EXTSEL_0))
+#define ADC3_4_EXTERNALTRIG_T4_CC1           ((uint32_t)(ADC_CFGR_EXTSEL_2 | ADC_CFGR_EXTSEL_1))
+#define ADC3_4_EXTERNALTRIG_T2_TRGO          ((uint32_t)(ADC_CFGR_EXTSEL_2 | ADC_CFGR_EXTSEL_1 | ADC_CFGR_EXTSEL_0))
+#define ADC3_4_EXTERNALTRIG_T8_TRGO2         ((uint32_t)ADC_CFGR_EXTSEL_3)
+#define ADC3_4_EXTERNALTRIG_T1_TRGO          ((uint32_t)(ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_0))
+#define ADC3_4_EXTERNALTRIG_T1_TRGO2         ((uint32_t)(ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_1))
+#define ADC3_4_EXTERNALTRIG_T3_TRGO          ((uint32_t)(ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_1 | ADC_CFGR_EXTSEL_0))
+#define ADC3_4_EXTERNALTRIG_T4_TRGO          ((uint32_t)(ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_2))
+#define ADC3_4_EXTERNALTRIG_T7_TRGO          ((uint32_t)(ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_2 | ADC_CFGR_EXTSEL_0))
+#define ADC3_4_EXTERNALTRIG_T15_TRGO         ((uint32_t)(ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_2 | ADC_CFGR_EXTSEL_1))
+#define ADC3_4_EXTERNALTRIG_T2_CC1           ((uint32_t)ADC_CFGR_EXTSEL)
+#endif /* STM32F303xE || STM32F398xx || */
+       /* STM32F303xC || STM32F358xx    */
+
+#if defined(STM32F302xE) || \
+    defined(STM32F302xC)
+/* List of external triggers of common group ADC1&ADC2:                       */
+/* (used internally by HAL driver. To not use into HAL structure parameters)  */
+#define ADC1_2_EXTERNALTRIG_T1_CC1           (0x00000000U)
+#define ADC1_2_EXTERNALTRIG_T1_CC2           ((uint32_t)ADC_CFGR_EXTSEL_0)
+#define ADC1_2_EXTERNALTRIG_T1_CC3           ((uint32_t)ADC_CFGR_EXTSEL_1)
+#define ADC1_2_EXTERNALTRIG_T1_TRGO          ((uint32_t)(ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_0))
+#define ADC1_2_EXTERNALTRIG_T1_TRGO2         ((uint32_t)(ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_1))
+#define ADC1_2_EXTERNALTRIG_T2_CC2           ((uint32_t)(ADC_CFGR_EXTSEL_1 | ADC_CFGR_EXTSEL_0))
+#define ADC1_2_EXTERNALTRIG_T2_TRGO          ((uint32_t)(ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_1 | ADC_CFGR_EXTSEL_0))
+#define ADC1_2_EXTERNALTRIG_T3_CC4           ((uint32_t)ADC_CFGR_EXTSEL)
+#define ADC1_2_EXTERNALTRIG_T3_TRGO          ((uint32_t)ADC_CFGR_EXTSEL_2)
+#define ADC1_2_EXTERNALTRIG_T4_CC4           ((uint32_t)(ADC_CFGR_EXTSEL_2 | ADC_CFGR_EXTSEL_0))
+#define ADC1_2_EXTERNALTRIG_T4_TRGO          ((uint32_t)(ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_2))
+#define ADC1_2_EXTERNALTRIG_T6_TRGO          ((uint32_t)(ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_2 | ADC_CFGR_EXTSEL_0))
+#define ADC1_2_EXTERNALTRIG_T15_TRGO         ((uint32_t)(ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_2 | ADC_CFGR_EXTSEL_1))
+#define ADC1_2_EXTERNALTRIG_EXT_IT11         ((uint32_t)(ADC_CFGR_EXTSEL_2 | ADC_CFGR_EXTSEL_1))
+#endif /* STM32F302xE || */
+       /* STM32F302xC    */
+
+#if defined(STM32F303x8) || defined(STM32F328xx)
+/* List of external triggers of common group ADC1&ADC2:                       */
+/* (used internally by HAL driver. To not use into HAL structure parameters)  */
+#define ADC1_2_EXTERNALTRIG_T1_CC1           (0x00000000U)
+#define ADC1_2_EXTERNALTRIG_T1_CC2           ((uint32_t)ADC_CFGR_EXTSEL_0)
+#define ADC1_2_EXTERNALTRIG_T1_CC3           ((uint32_t)ADC_CFGR_EXTSEL_1)
+#define ADC1_2_EXTERNALTRIG_T2_CC2           ((uint32_t)(ADC_CFGR_EXTSEL_1 | ADC_CFGR_EXTSEL_0))
+#define ADC1_2_EXTERNALTRIG_T3_TRGO          ((uint32_t)ADC_CFGR_EXTSEL_2)
+#define ADC1_2_EXTERNALTRIG_T4_CC4           ((uint32_t)(ADC_CFGR_EXTSEL_2 | ADC_CFGR_EXTSEL_0))
+#define ADC1_2_EXTERNALTRIG_EXT_IT11         ((uint32_t)(ADC_CFGR_EXTSEL_2 | ADC_CFGR_EXTSEL_1))
+#define ADC1_2_EXTERNALTRIG_T8_TRGO          ((uint32_t)(ADC_CFGR_EXTSEL_2 | ADC_CFGR_EXTSEL_1 | ADC_CFGR_EXTSEL_0))
+#define ADC1_2_EXTERNALTRIG_T8_TRGO2         ((uint32_t) ADC_CFGR_EXTSEL_3)
+#define ADC1_2_EXTERNALTRIG_T1_TRGO          ((uint32_t)(ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_0))
+#define ADC1_2_EXTERNALTRIG_T1_TRGO2         ((uint32_t)(ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_1))
+#define ADC1_2_EXTERNALTRIG_T2_TRGO          ((uint32_t)(ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_1 | ADC_CFGR_EXTSEL_0))
+#define ADC1_2_EXTERNALTRIG_T4_TRGO          ((uint32_t)(ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_2))
+#define ADC1_2_EXTERNALTRIG_T6_TRGO          ((uint32_t)(ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_2 | ADC_CFGR_EXTSEL_0))
+#define ADC1_2_EXTERNALTRIG_T15_TRGO         ((uint32_t)(ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_2 | ADC_CFGR_EXTSEL_1))
+#define ADC1_2_EXTERNALTRIG_T3_CC4           ((uint32_t)ADC_CFGR_EXTSEL)
+#endif /* STM32F303x8 || STM32F328xx */
+
+#if defined(STM32F334x8)
+/* List of external triggers of common group ADC1&ADC2:                       */
+/* (used internally by HAL driver. To not use into HAL structure parameters)  */
+#define ADC1_2_EXTERNALTRIG_T1_CC1           (0x00000000U)
+#define ADC1_2_EXTERNALTRIG_T1_CC2           ((uint32_t)ADC_CFGR_EXTSEL_0)
+#define ADC1_2_EXTERNALTRIG_T1_CC3           ((uint32_t)ADC_CFGR_EXTSEL_1)
+#define ADC1_2_EXTERNALTRIG_T2_CC2           ((uint32_t)(ADC_CFGR_EXTSEL_1 | ADC_CFGR_EXTSEL_0))
+#define ADC1_2_EXTERNALTRIG_T3_TRGO          ((uint32_t)ADC_CFGR_EXTSEL_2)
+#define ADC1_2_EXTERNALTRIG_EXT_IT11         ((uint32_t)(ADC_CFGR_EXTSEL_2 | ADC_CFGR_EXTSEL_1))
+#define ADC1_2_EXTERNALTRIG_HRTIM_TRG1       ((uint32_t)(ADC_CFGR_EXTSEL_2 | ADC_CFGR_EXTSEL_1 | ADC_CFGR_EXTSEL_0))
+#define ADC1_2_EXTERNALTRIG_HRTIM_TRG3       ((uint32_t) ADC_CFGR_EXTSEL_3)
+#define ADC1_2_EXTERNALTRIG_T1_TRGO          ((uint32_t)(ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_0))
+#define ADC1_2_EXTERNALTRIG_T1_TRGO2         ((uint32_t)(ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_1))
+#define ADC1_2_EXTERNALTRIG_T2_TRGO          ((uint32_t)(ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_1 | ADC_CFGR_EXTSEL_0))
+#define ADC1_2_EXTERNALTRIG_T6_TRGO          ((uint32_t)(ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_2 | ADC_CFGR_EXTSEL_0))
+#define ADC1_2_EXTERNALTRIG_T15_TRGO         ((uint32_t)(ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_2 | ADC_CFGR_EXTSEL_1))
+#define ADC1_2_EXTERNALTRIG_T3_CC4           ((uint32_t)ADC_CFGR_EXTSEL)
+#endif /* STM32F334x8 */
+
+#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+/* List of external triggers of regular group for ADC1:                       */
+/* (used internally by HAL driver. To not use into HAL structure parameters)  */
+#define ADC1_EXTERNALTRIG_T1_CC1           (0x00000000U)
+#define ADC1_EXTERNALTRIG_T1_CC2           ((uint32_t)ADC_CFGR_EXTSEL_0)
+#define ADC1_EXTERNALTRIG_T1_CC3           ((uint32_t)ADC_CFGR_EXTSEL_1)
+#define ADC1_EXTERNALTRIG_T2_CC2           ((uint32_t)(ADC_CFGR_EXTSEL_1 | ADC_CFGR_EXTSEL_0))
+#define ADC1_EXTERNALTRIG_EXT_IT11         ((uint32_t)(ADC_CFGR_EXTSEL_2 | ADC_CFGR_EXTSEL_1))
+#define ADC1_EXTERNALTRIG_T1_TRGO          ((uint32_t)(ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_0))
+#define ADC1_EXTERNALTRIG_T1_TRGO2         ((uint32_t)(ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_1))
+#define ADC1_EXTERNALTRIG_T2_TRGO          ((uint32_t)(ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_1 | ADC_CFGR_EXTSEL_0))
+#define ADC1_EXTERNALTRIG_T6_TRGO          ((uint32_t)(ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_2 | ADC_CFGR_EXTSEL_0))
+#define ADC1_EXTERNALTRIG_T15_TRGO         ((uint32_t)(ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_2 | ADC_CFGR_EXTSEL_1))
+#define ADC_SOFTWARE_START                 (0x00000001U)
+#endif /* STM32F301x8 || STM32F302x8 || STM32F318xx */
+/**
+  * @}
+  */
+
+
+/** @defgroup ADCEx_Internal_HAL_driver_Ext_trig_src_Injected ADC Extended Internal HAL driver trigger selection for injected group
+  * @{
+  */
+#if defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F303xC) || defined(STM32F358xx)
+/* List of external triggers sorted of groups ADC1&ADC2 and/or ADC3&ADC4:     */
+/* (used internally by HAL driver. To not use into HAL structure parameters)  */
+
+/* External triggers for injected groups of ADC1 & ADC2 */
+#define ADC1_2_EXTERNALTRIGINJEC_T1_TRGO    (0x00000000U)
+#define ADC1_2_EXTERNALTRIGINJEC_T1_CC4     ((uint32_t)ADC_JSQR_JEXTSEL_0)
+#define ADC1_2_EXTERNALTRIGINJEC_T2_TRGO    ((uint32_t)ADC_JSQR_JEXTSEL_1)
+#define ADC1_2_EXTERNALTRIGINJEC_T2_CC1     ((uint32_t)(ADC_JSQR_JEXTSEL_1 | ADC_JSQR_JEXTSEL_0))
+#define ADC1_2_EXTERNALTRIGINJEC_T3_CC4     ((uint32_t)ADC_JSQR_JEXTSEL_2)
+#define ADC1_2_EXTERNALTRIGINJEC_T4_TRGO    ((uint32_t)(ADC_JSQR_JEXTSEL_2 | ADC_JSQR_JEXTSEL_0))
+#define ADC1_2_EXTERNALTRIGINJEC_EXT_IT15   ((uint32_t)(ADC_JSQR_JEXTSEL_2 | ADC_JSQR_JEXTSEL_1))
+#define ADC1_2_EXTERNALTRIGINJEC_T8_CC4     ((uint32_t)(ADC_JSQR_JEXTSEL_2 | ADC_JSQR_JEXTSEL_1 | ADC_JSQR_JEXTSEL_0))
+#define ADC1_2_EXTERNALTRIGINJEC_T1_TRGO2   ((uint32_t)ADC_JSQR_JEXTSEL_3)
+#define ADC1_2_EXTERNALTRIGINJEC_T8_TRGO    ((uint32_t)(ADC_JSQR_JEXTSEL_3 | ADC_JSQR_JEXTSEL_0))
+#define ADC1_2_EXTERNALTRIGINJEC_T8_TRGO2   ((uint32_t)(ADC_JSQR_JEXTSEL_3 | ADC_JSQR_JEXTSEL_1))
+#define ADC1_2_EXTERNALTRIGINJEC_T3_CC3     ((uint32_t)(ADC_JSQR_JEXTSEL_3 | ADC_JSQR_JEXTSEL_1 | ADC_JSQR_JEXTSEL_0))
+#define ADC1_2_EXTERNALTRIGINJEC_T3_TRGO    ((uint32_t)(ADC_JSQR_JEXTSEL_3 | ADC_JSQR_JEXTSEL_2))
+#define ADC1_2_EXTERNALTRIGINJEC_T3_CC1     ((uint32_t)(ADC_JSQR_JEXTSEL_3 | ADC_JSQR_JEXTSEL_2 | ADC_JSQR_JEXTSEL_0))
+#define ADC1_2_EXTERNALTRIGINJEC_T6_TRGO    ((uint32_t)(ADC_JSQR_JEXTSEL_3 | ADC_JSQR_JEXTSEL_2 | ADC_JSQR_JEXTSEL_1))
+#define ADC1_2_EXTERNALTRIGINJEC_T15_TRGO   ((uint32_t)ADC_JSQR_JEXTSEL)
+
+/* External triggers for injected groups of ADC3 & ADC4 */
+/* Note: External triggers JEXT2 and JEXT5 are the same (TIM4_CC3 event).     */
+/*       JEXT2 is the main trigger, JEXT5 could be redirected to another      */
+/*       in future devices.                                                   */
+/*       However, this channel is implemented with a SW offset of 0x10000 for */
+/*       differentiation between similar triggers of common groups ADC1&ADC2, */
+/*       ADC3&ADC4 (Differentiation processed into macro                      */
+/*       ADC_JSQR_JEXTSEL_SET)                                                */
+#define ADC3_4_EXTERNALTRIGINJEC_T1_TRGO    (0x00000000U)
+#define ADC3_4_EXTERNALTRIGINJEC_T1_CC4     ((uint32_t)ADC_JSQR_JEXTSEL_0)
+#define ADC3_4_EXTERNALTRIGINJEC_T4_CC3     ((uint32_t)ADC_JSQR_JEXTSEL_1 | 0x10000U)
+#define ADC3_4_EXTERNALTRIGINJEC_T8_CC2     ((uint32_t)(ADC_JSQR_JEXTSEL_1 | ADC_JSQR_JEXTSEL_0))
+#define ADC3_4_EXTERNALTRIGINJEC_T8_CC4     ((uint32_t)ADC_JSQR_JEXTSEL_2)
+
+#if defined(STM32F303xE) || defined(STM32F398xx)
+#define ADC3_4_EXTERNALTRIGINJEC_T20_TRGO   ((uint32_t)(ADC_JSQR_JEXTSEL_2 | ADC_JSQR_JEXTSEL_0))
+#endif /* STM32F303xE || STM32F398xx */
+
+#define ADC3_4_EXTERNALTRIGINJEC_T4_CC4     ((uint32_t)(ADC_JSQR_JEXTSEL_2 | ADC_JSQR_JEXTSEL_1))
+#define ADC3_4_EXTERNALTRIGINJEC_T4_TRGO    ((uint32_t)(ADC_JSQR_JEXTSEL_2 | ADC_JSQR_JEXTSEL_1 | ADC_JSQR_JEXTSEL_0))
+#define ADC3_4_EXTERNALTRIGINJEC_T1_TRGO2   ((uint32_t)ADC_JSQR_JEXTSEL_3)
+#define ADC3_4_EXTERNALTRIGINJEC_T8_TRGO    ((uint32_t)(ADC_JSQR_JEXTSEL_3 | ADC_JSQR_JEXTSEL_0))
+#define ADC3_4_EXTERNALTRIGINJEC_T8_TRGO2   ((uint32_t)(ADC_JSQR_JEXTSEL_3 | ADC_JSQR_JEXTSEL_1))
+#define ADC3_4_EXTERNALTRIGINJEC_T1_CC3     ((uint32_t)(ADC_JSQR_JEXTSEL_3 | ADC_JSQR_JEXTSEL_1 | ADC_JSQR_JEXTSEL_0))
+#define ADC3_4_EXTERNALTRIGINJEC_T3_TRGO    ((uint32_t)(ADC_JSQR_JEXTSEL_3 | ADC_JSQR_JEXTSEL_2))
+#define ADC3_4_EXTERNALTRIGINJEC_T2_TRGO    ((uint32_t)(ADC_JSQR_JEXTSEL_3 | ADC_JSQR_JEXTSEL_2 | ADC_JSQR_JEXTSEL_0))
+#define ADC3_4_EXTERNALTRIGINJEC_T7_TRGO    ((uint32_t)(ADC_JSQR_JEXTSEL_3 | ADC_JSQR_JEXTSEL_2 | ADC_JSQR_JEXTSEL_1))
+#define ADC3_4_EXTERNALTRIGINJEC_T15_TRGO   ((uint32_t)ADC_JSQR_JEXTSEL)
+#endif /* STM32F303xE || STM32F398xx || */
+       /* STM32F303xC || STM32F358xx    */
+
+#if defined(STM32F302xE) || \
+    defined(STM32F302xC)
+/* List of external triggers of group ADC1&ADC2:                              */
+/* (used internally by HAL driver. To not use into HAL structure parameters)  */
+#define ADC1_2_EXTERNALTRIGINJEC_T1_TRGO    (0x00000000U)
+#define ADC1_2_EXTERNALTRIGINJEC_T1_CC4     ((uint32_t)ADC_JSQR_JEXTSEL_0)
+#define ADC1_2_EXTERNALTRIGINJEC_T2_TRGO    ((uint32_t)ADC_JSQR_JEXTSEL_1)
+#define ADC1_2_EXTERNALTRIGINJEC_T2_CC1     ((uint32_t)(ADC_JSQR_JEXTSEL_1 | ADC_JSQR_JEXTSEL_0))
+#define ADC1_2_EXTERNALTRIGINJEC_T3_CC4     ((uint32_t)ADC_JSQR_JEXTSEL_2)
+#define ADC1_2_EXTERNALTRIGINJEC_T4_TRGO    ((uint32_t)(ADC_JSQR_JEXTSEL_2 | ADC_JSQR_JEXTSEL_0))
+#define ADC1_2_EXTERNALTRIGINJEC_EXT_IT15   ((uint32_t)(ADC_JSQR_JEXTSEL_2 | ADC_JSQR_JEXTSEL_1))
+#define ADC1_2_EXTERNALTRIGINJEC_T1_TRGO2   ((uint32_t)ADC_JSQR_JEXTSEL_3)
+#define ADC1_2_EXTERNALTRIGINJEC_T3_CC3     ((uint32_t)(ADC_JSQR_JEXTSEL_3 | ADC_JSQR_JEXTSEL_1 | ADC_JSQR_JEXTSEL_0))
+#define ADC1_2_EXTERNALTRIGINJEC_T3_TRGO    ((uint32_t)(ADC_JSQR_JEXTSEL_3 | ADC_JSQR_JEXTSEL_2))
+#define ADC1_2_EXTERNALTRIGINJEC_T3_CC1     ((uint32_t)(ADC_JSQR_JEXTSEL_3 | ADC_JSQR_JEXTSEL_2 | ADC_JSQR_JEXTSEL_0))
+#define ADC1_2_EXTERNALTRIGINJEC_T6_TRGO    ((uint32_t)(ADC_JSQR_JEXTSEL_3 | ADC_JSQR_JEXTSEL_2 | ADC_JSQR_JEXTSEL_1))
+#define ADC1_2_EXTERNALTRIGINJEC_T15_TRGO   ((uint32_t)ADC_JSQR_JEXTSEL)
+#endif /* STM32F302xE || */
+       /* STM32F302xC    */
+      
+#if defined(STM32F303x8) || defined(STM32F328xx)
+/* List of external triggers of group ADC1&ADC2:                              */
+/* (used internally by HAL driver. To not use into HAL structure parameters)  */
+#define ADC1_2_EXTERNALTRIGINJEC_T1_TRGO    (0x00000000U)
+#define ADC1_2_EXTERNALTRIGINJEC_T1_CC4     ((uint32_t)ADC_JSQR_JEXTSEL_0)
+#define ADC1_2_EXTERNALTRIGINJEC_T2_TRGO    ((uint32_t)ADC_JSQR_JEXTSEL_1)
+#define ADC1_2_EXTERNALTRIGINJEC_T2_CC1     ((uint32_t)(ADC_JSQR_JEXTSEL_1 | ADC_JSQR_JEXTSEL_0))
+#define ADC1_2_EXTERNALTRIGINJEC_T3_CC4     ((uint32_t)ADC_JSQR_JEXTSEL_2)
+#define ADC1_2_EXTERNALTRIGINJEC_T4_TRGO    ((uint32_t)(ADC_JSQR_JEXTSEL_2 | ADC_JSQR_JEXTSEL_0))
+#define ADC1_2_EXTERNALTRIGINJEC_EXT_IT15   ((uint32_t)(ADC_JSQR_JEXTSEL_2 | ADC_JSQR_JEXTSEL_1))
+#define ADC1_2_EXTERNALTRIGINJEC_T8_CC4     ((uint32_t)(ADC_JSQR_JEXTSEL_2 | ADC_JSQR_JEXTSEL_1 | ADC_JSQR_JEXTSEL_0))
+#define ADC1_2_EXTERNALTRIGINJEC_T1_TRGO2   ((uint32_t)ADC_JSQR_JEXTSEL_3)
+#define ADC1_2_EXTERNALTRIGINJEC_T8_TRGO    ((uint32_t)(ADC_JSQR_JEXTSEL_3 | ADC_JSQR_JEXTSEL_0))
+#define ADC1_2_EXTERNALTRIGINJEC_T8_TRGO2   ((uint32_t)(ADC_JSQR_JEXTSEL_3 | ADC_JSQR_JEXTSEL_1))
+#define ADC1_2_EXTERNALTRIGINJEC_T3_CC3     ((uint32_t)(ADC_JSQR_JEXTSEL_3 | ADC_JSQR_JEXTSEL_1 | ADC_JSQR_JEXTSEL_0))
+#define ADC1_2_EXTERNALTRIGINJEC_T3_TRGO    ((uint32_t)(ADC_JSQR_JEXTSEL_3 | ADC_JSQR_JEXTSEL_2))
+#define ADC1_2_EXTERNALTRIGINJEC_T3_CC1     ((uint32_t)(ADC_JSQR_JEXTSEL_3 | ADC_JSQR_JEXTSEL_2 | ADC_JSQR_JEXTSEL_0))
+#define ADC1_2_EXTERNALTRIGINJEC_T6_TRGO    ((uint32_t)(ADC_JSQR_JEXTSEL_3 | ADC_JSQR_JEXTSEL_2 | ADC_JSQR_JEXTSEL_1))
+#define ADC1_2_EXTERNALTRIGINJEC_T15_TRGO   ((uint32_t)ADC_JSQR_JEXTSEL)
+#endif /* STM32F303x8 || STM32F328xx */
+
+#if defined(STM32F334x8)
+/* List of external triggers of group ADC1&ADC2:                              */
+/* (used internally by HAL driver. To not use into HAL structure parameters)  */
+#define ADC1_2_EXTERNALTRIGINJEC_T1_TRGO     (0x00000000U)
+#define ADC1_2_EXTERNALTRIGINJEC_T1_CC4      ((uint32_t)ADC_JSQR_JEXTSEL_0)
+#define ADC1_2_EXTERNALTRIGINJEC_T2_TRGO     ((uint32_t)ADC_JSQR_JEXTSEL_1)
+#define ADC1_2_EXTERNALTRIGINJEC_T2_CC1      ((uint32_t)(ADC_JSQR_JEXTSEL_1 | ADC_JSQR_JEXTSEL_0))
+#define ADC1_2_EXTERNALTRIGINJEC_T3_CC4      ((uint32_t)ADC_JSQR_JEXTSEL_2)
+#define ADC1_2_EXTERNALTRIGINJEC_EXT_IT15    ((uint32_t)(ADC_JSQR_JEXTSEL_2 | ADC_JSQR_JEXTSEL_1))
+#define ADC1_2_EXTERNALTRIGINJEC_T1_TRGO2    ((uint32_t)ADC_JSQR_JEXTSEL_3)
+#define ADC1_2_EXTERNALTRIGINJEC_HRTIM_TRG2  ((uint32_t)(ADC_JSQR_JEXTSEL_3 | ADC_JSQR_JEXTSEL_0))
+#define ADC1_2_EXTERNALTRIGINJEC_HRTIM_TRG4  ((uint32_t)(ADC_JSQR_JEXTSEL_3 | ADC_JSQR_JEXTSEL_1))
+#define ADC1_2_EXTERNALTRIGINJEC_T3_CC3      ((uint32_t)(ADC_JSQR_JEXTSEL_3 | ADC_JSQR_JEXTSEL_1 | ADC_JSQR_JEXTSEL_0))
+#define ADC1_2_EXTERNALTRIGINJEC_T3_TRGO     ((uint32_t)(ADC_JSQR_JEXTSEL_3 | ADC_JSQR_JEXTSEL_2))
+#define ADC1_2_EXTERNALTRIGINJEC_T3_CC1      ((uint32_t)(ADC_JSQR_JEXTSEL_3 | ADC_JSQR_JEXTSEL_2 | ADC_JSQR_JEXTSEL_0))
+#define ADC1_2_EXTERNALTRIGINJEC_T6_TRGO     ((uint32_t)(ADC_JSQR_JEXTSEL_3 | ADC_JSQR_JEXTSEL_2 | ADC_JSQR_JEXTSEL_1))
+#define ADC1_2_EXTERNALTRIGINJEC_T15_TRGO    ((uint32_t)ADC_JSQR_JEXTSEL)
+#endif /* STM32F334x8 */
+
+#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+/* List of external triggers of injected group for ADC1:                      */
+/* (used internally by HAL driver. To not use into HAL structure parameters)  */
+#define ADC1_EXTERNALTRIGINJEC_T1_TRGO    (0x00000000U)
+#define ADC1_EXTERNALTRIGINJEC_T1_CC4     ((uint32_t)ADC_JSQR_JEXTSEL_0)
+#define ADC1_EXTERNALTRIGINJEC_T2_TRGO    ((uint32_t)ADC_JSQR_JEXTSEL_1)
+#define ADC1_EXTERNALTRIGINJEC_T2_CC1     ((uint32_t)(ADC_JSQR_JEXTSEL_1 | ADC_JSQR_JEXTSEL_0))
+#define ADC1_EXTERNALTRIGINJEC_EXT_IT15   ((uint32_t)(ADC_JSQR_JEXTSEL_2 | ADC_JSQR_JEXTSEL_1))
+#define ADC1_EXTERNALTRIGINJEC_T1_TRGO2   ((uint32_t)ADC_JSQR_JEXTSEL_3)
+#define ADC1_EXTERNALTRIGINJEC_T6_TRGO    ((uint32_t)(ADC_JSQR_JEXTSEL_3 | ADC_JSQR_JEXTSEL_2 | ADC_JSQR_JEXTSEL_1))
+#define ADC1_EXTERNALTRIGINJEC_T15_TRGO   ((uint32_t)ADC_JSQR_JEXTSEL)
+#endif /* STM32F301x8 || STM32F302x8 || STM32F318xx */
+/**
+  * @}
+  */
+
+#define ADC_FLAG_ALL    (ADC_FLAG_RDY | ADC_FLAG_EOSMP | ADC_FLAG_EOC | ADC_FLAG_EOS |  \
+                         ADC_FLAG_JEOC | ADC_FLAG_JEOS | ADC_FLAG_OVR | ADC_FLAG_AWD1 | \
+                         ADC_FLAG_AWD2 | ADC_FLAG_AWD3 | ADC_FLAG_JQOVF)
+
+/* Combination of all post-conversion flags bits: EOC/EOS, JEOC/JEOS, OVR, AWDx */
+#define ADC_FLAG_POSTCONV_ALL (ADC_FLAG_EOC | ADC_FLAG_EOS  | ADC_FLAG_JEOC | ADC_FLAG_JEOS | \
+                               ADC_FLAG_OVR | ADC_FLAG_AWD1 | ADC_FLAG_AWD2 | ADC_FLAG_AWD3 | \
+                               ADC_FLAG_JQOVF)
+      
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+
+      
+#if defined(STM32F373xC) || defined(STM32F378xx)
+
+/** @defgroup ADCEx_Internal_HAL_driver_Ext_trig_src_Regular ADC Extended Internal HAL driver trigger selection for regular group
+  * @{
+  */
+/* List of external triggers of regular group for ADC1:                       */
+/* (used internally by HAL driver. To not use into HAL structure parameters)  */
+
+/* External triggers of regular group for ADC1 */
+#define ADC_EXTERNALTRIG_T19_TRGO          (0x00000000U)
+#define ADC_EXTERNALTRIG_T19_CC3           ((uint32_t)ADC_CR2_EXTSEL_0)
+#define ADC_EXTERNALTRIG_T19_CC4           ((uint32_t)ADC_CR2_EXTSEL_1)
+#define ADC_EXTERNALTRIG_T2_CC2            ((uint32_t)(ADC_CR2_EXTSEL_1 | ADC_CR2_EXTSEL_0))
+#define ADC_EXTERNALTRIG_T3_TRGO           ((uint32_t)ADC_CR2_EXTSEL_2)
+#define ADC_EXTERNALTRIG_T4_CC4            ((uint32_t)(ADC_CR2_EXTSEL_2 | ADC_CR2_EXTSEL_0))
+#define ADC_EXTERNALTRIG_EXT_IT11          ((uint32_t)(ADC_CR2_EXTSEL_2 | ADC_CR2_EXTSEL_1))
+#define ADC_SWSTART                        ((uint32_t)(ADC_CR2_EXTSEL_2 | ADC_CR2_EXTSEL_1 | ADC_CR2_EXTSEL_0))
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_Internal_HAL_driver_Ext_trig_src_Injected ADC Extended Internal HAL driver trigger selection for injected group
+  * @{
+  */
+/* List of external triggers of injected group for ADC1:                      */
+/* (used internally by HAL driver. To not use into HAL structure parameters)  */
+
+/* External triggers of injected group for ADC1 */
+#define ADC_EXTERNALTRIGINJEC_T19_CC1      ( 0x00000000U)
+#define ADC_EXTERNALTRIGINJEC_T19_CC2      ((uint32_t) ADC_CR2_JEXTSEL_0)
+#define ADC_EXTERNALTRIGINJEC_T2_TRGO      ((uint32_t) ADC_CR2_JEXTSEL_1)
+#define ADC_EXTERNALTRIGINJEC_T2_CC1       ((uint32_t)(ADC_CR2_JEXTSEL_1 | ADC_CR2_JEXTSEL_0))
+#define ADC_EXTERNALTRIGINJEC_T3_CC4       ((uint32_t) ADC_CR2_JEXTSEL_2)
+#define ADC_EXTERNALTRIGINJEC_T4_TRGO      ((uint32_t)(ADC_CR2_JEXTSEL_2 | ADC_CR2_JEXTSEL_0))
+#define ADC_EXTERNALTRIGINJEC_EXT_IT15     ((uint32_t)(ADC_CR2_JEXTSEL_2 | ADC_CR2_JEXTSEL_1))
+#define ADC_JSWSTART                       ((uint32_t)(ADC_CR2_JEXTSEL_2 | ADC_CR2_JEXTSEL_1 | ADC_CR2_JEXTSEL_0))
+/**
+  * @}
+  */
+      
+/** @defgroup ADCEx_sampling_times_all_channels ADC Extended Sampling Times All Channels
+  * @{
+  */
+#define ADC_SAMPLETIME_ALLCHANNELS_SMPR2BIT2                                          \
+     (ADC_SMPR2_SMP9_2 | ADC_SMPR2_SMP8_2 | ADC_SMPR2_SMP7_2 | ADC_SMPR2_SMP6_2 |     \
+      ADC_SMPR2_SMP5_2 | ADC_SMPR2_SMP4_2 | ADC_SMPR2_SMP3_2 | ADC_SMPR2_SMP2_2 |     \
+      ADC_SMPR2_SMP1_2 | ADC_SMPR2_SMP0_2)
+#define ADC_SAMPLETIME_ALLCHANNELS_SMPR1BIT2                                          \
+     (ADC_SMPR1_SMP17_2 | ADC_SMPR1_SMP16_2 | ADC_SMPR1_SMP15_2 | ADC_SMPR1_SMP14_2 | \
+      ADC_SMPR1_SMP13_2 | ADC_SMPR1_SMP12_2 | ADC_SMPR1_SMP11_2 | ADC_SMPR1_SMP10_2 )
+
+#define ADC_SAMPLETIME_ALLCHANNELS_SMPR2BIT1                                          \
+     (ADC_SMPR2_SMP9_1 | ADC_SMPR2_SMP8_1 | ADC_SMPR2_SMP7_1 | ADC_SMPR2_SMP6_1 |     \
+      ADC_SMPR2_SMP5_1 | ADC_SMPR2_SMP4_1 | ADC_SMPR2_SMP3_1 | ADC_SMPR2_SMP2_1 |     \
+      ADC_SMPR2_SMP1_1 | ADC_SMPR2_SMP0_1)
+#define ADC_SAMPLETIME_ALLCHANNELS_SMPR1BIT1                                          \
+     (ADC_SMPR1_SMP17_1 | ADC_SMPR1_SMP16_1 | ADC_SMPR1_SMP15_1 | ADC_SMPR1_SMP14_1 | \
+      ADC_SMPR1_SMP13_1 | ADC_SMPR1_SMP12_1 | ADC_SMPR1_SMP11_1 | ADC_SMPR1_SMP10_1 )
+
+#define ADC_SAMPLETIME_ALLCHANNELS_SMPR2BIT0                                          \
+     (ADC_SMPR2_SMP9_0 | ADC_SMPR2_SMP8_0 | ADC_SMPR2_SMP7_0 | ADC_SMPR2_SMP6_0 |     \
+      ADC_SMPR2_SMP5_0 | ADC_SMPR2_SMP4_0 | ADC_SMPR2_SMP3_0 | ADC_SMPR2_SMP2_0 |     \
+      ADC_SMPR2_SMP1_0 | ADC_SMPR2_SMP0_0)
+#define ADC_SAMPLETIME_ALLCHANNELS_SMPR1BIT0                                          \
+     (ADC_SMPR1_SMP17_0 | ADC_SMPR1_SMP16_0 | ADC_SMPR1_SMP15_0 | ADC_SMPR1_SMP14_0 | \
+      ADC_SMPR1_SMP13_0 | ADC_SMPR1_SMP12_0 | ADC_SMPR1_SMP11_0 | ADC_SMPR1_SMP10_0 )
+
+#define ADC_SAMPLETIME_1CYCLE5_SMPR2ALLCHANNELS    (0x00000000U)
+#define ADC_SAMPLETIME_7CYCLES5_SMPR2ALLCHANNELS   (ADC_SAMPLETIME_ALLCHANNELS_SMPR2BIT0)
+#define ADC_SAMPLETIME_13CYCLES5_SMPR2ALLCHANNELS  (ADC_SAMPLETIME_ALLCHANNELS_SMPR2BIT1)
+#define ADC_SAMPLETIME_28CYCLES5_SMPR2ALLCHANNELS  (ADC_SAMPLETIME_ALLCHANNELS_SMPR2BIT1 | ADC_SAMPLETIME_ALLCHANNELS_SMPR2BIT0)
+#define ADC_SAMPLETIME_41CYCLES5_SMPR2ALLCHANNELS  (ADC_SAMPLETIME_ALLCHANNELS_SMPR2BIT2)
+#define ADC_SAMPLETIME_55CYCLES5_SMPR2ALLCHANNELS  (ADC_SAMPLETIME_ALLCHANNELS_SMPR2BIT2 | ADC_SAMPLETIME_ALLCHANNELS_SMPR2BIT0)
+#define ADC_SAMPLETIME_71CYCLES5_SMPR2ALLCHANNELS  (ADC_SAMPLETIME_ALLCHANNELS_SMPR2BIT2 | ADC_SAMPLETIME_ALLCHANNELS_SMPR2BIT1)
+#define ADC_SAMPLETIME_239CYCLES5_SMPR2ALLCHANNELS (ADC_SAMPLETIME_ALLCHANNELS_SMPR2BIT2 | ADC_SAMPLETIME_ALLCHANNELS_SMPR2BIT1 | ADC_SAMPLETIME_ALLCHANNELS_SMPR2BIT0)
+
+#define ADC_SAMPLETIME_1CYCLE5_SMPR1ALLCHANNELS    (0x00000000U)
+#define ADC_SAMPLETIME_7CYCLES5_SMPR1ALLCHANNELS   (ADC_SAMPLETIME_ALLCHANNELS_SMPR1BIT0)
+#define ADC_SAMPLETIME_13CYCLES5_SMPR1ALLCHANNELS  (ADC_SAMPLETIME_ALLCHANNELS_SMPR1BIT1)
+#define ADC_SAMPLETIME_28CYCLES5_SMPR1ALLCHANNELS  (ADC_SAMPLETIME_ALLCHANNELS_SMPR1BIT1 | ADC_SAMPLETIME_ALLCHANNELS_SMPR1BIT0)
+#define ADC_SAMPLETIME_41CYCLES5_SMPR1ALLCHANNELS  (ADC_SAMPLETIME_ALLCHANNELS_SMPR1BIT2)
+#define ADC_SAMPLETIME_55CYCLES5_SMPR1ALLCHANNELS  (ADC_SAMPLETIME_ALLCHANNELS_SMPR1BIT2 | ADC_SAMPLETIME_ALLCHANNELS_SMPR1BIT0)
+#define ADC_SAMPLETIME_71CYCLES5_SMPR1ALLCHANNELS  (ADC_SAMPLETIME_ALLCHANNELS_SMPR1BIT2 | ADC_SAMPLETIME_ALLCHANNELS_SMPR1BIT1)
+#define ADC_SAMPLETIME_239CYCLES5_SMPR1ALLCHANNELS (ADC_SAMPLETIME_ALLCHANNELS_SMPR1BIT2 | ADC_SAMPLETIME_ALLCHANNELS_SMPR1BIT1 | ADC_SAMPLETIME_ALLCHANNELS_SMPR1BIT0)
+
+/* Combination of all post-conversion flags bits: EOC/EOS, JEOC/JEOS, OVR, AWDx */
+#define ADC_FLAG_POSTCONV_ALL   (ADC_FLAG_EOC | ADC_FLAG_JEOC | ADC_FLAG_AWD )
+/**
+  * @}
+  */
+     
+#endif /* STM32F373xC || STM32F378xx */
+     
+/**
+  * @}
+  */
+     
+/* Exported macro ------------------------------------------------------------*/
+
+/** @defgroup ADCEx_Exported_Macros ADCEx Exported Macros
+  * @{
+  */
+/* Macro for internal HAL driver usage, and possibly can be used into code of */
+/* final user.                                                                */
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+
+/**
+  * @brief Enable the ADC peripheral
+  * @param __HANDLE__ ADC handle
+  * @note ADC enable requires a delay for ADC stabilization time
+  *       (refer to device datasheet, parameter tSTAB)
+  * @note On STM32F3 devices, some hardware constraints must be strictly
+  *       respected before using this macro:
+  *        - ADC internal voltage regulator must be preliminarily enabled.
+  *          This is performed by function HAL_ADC_Init().
+  *        - ADC state requirements: ADC must be disabled, no conversion on 
+  *          going, no calibration on going.
+  *          These checks are performed by functions HAL_ADC_start_xxx().
+  * @retval None
+  */
+#define __HAL_ADC_ENABLE(__HANDLE__)                                           \
+ (SET_BIT((__HANDLE__)->Instance->CR, ADC_CR_ADEN))
+
+/**
+  * @brief Disable the ADC peripheral
+  * @param __HANDLE__ ADC handle
+  * @note On STM32F3 devices, some hardware constraints must be strictly
+  *       respected before using this macro:
+  *        - ADC state requirements: ADC must be enabled, no conversion on 
+  *          going.
+  *          These checks are performed by functions HAL_ADC_start_xxx().
+  * @retval None
+  */
+#define __HAL_ADC_DISABLE(__HANDLE__)                                          \
+  do{                                                                          \
+      SET_BIT((__HANDLE__)->Instance->CR, ADC_CR_ADDIS);                       \
+      __HAL_ADC_CLEAR_FLAG((__HANDLE__), (ADC_FLAG_EOSMP | ADC_FLAG_RDY));     \
+  } while(0U)
+
+/**
+  * @brief Enable the ADC end of conversion interrupt.
+  * @param __HANDLE__ ADC handle
+  * @param __INTERRUPT__ ADC Interrupt
+  *          This parameter can be any combination of the following values:
+  *            @arg ADC_IT_RDY:   ADC Ready (ADRDY) interrupt source
+  *            @arg ADC_IT_EOSMP: ADC End of Sampling interrupt source
+  *            @arg ADC_IT_EOC:   ADC End of Regular Conversion interrupt source
+  *            @arg ADC_IT_EOS:   ADC End of Regular sequence of Conversions interrupt source
+  *            @arg ADC_IT_OVR:   ADC overrun interrupt source
+  *            @arg ADC_IT_JEOC:  ADC End of Injected Conversion interrupt source
+  *            @arg ADC_IT_JEOS:  ADC End of Injected sequence of Conversions interrupt source
+  *            @arg ADC_IT_AWD1:  ADC Analog watchdog 1 interrupt source (main analog watchdog, present on all STM32 devices)
+  *            @arg ADC_IT_AWD2:  ADC Analog watchdog 2 interrupt source (additional analog watchdog, present only on STM32F3 devices)
+  *            @arg ADC_IT_AWD3:  ADC Analog watchdog 3 interrupt source (additional analog watchdog, present only on STM32F3 devices)
+  *            @arg ADC_IT_JQOVF: ADC Injected Context Queue Overflow interrupt source
+  * @retval None
+  */
+#define __HAL_ADC_ENABLE_IT(__HANDLE__, __INTERRUPT__)                         \
+  (SET_BIT((__HANDLE__)->Instance->IER, (__INTERRUPT__)))
+
+/**
+  * @brief Disable the ADC end of conversion interrupt.
+  * @param __HANDLE__ ADC handle
+  * @param __INTERRUPT__ ADC Interrupt
+  *          This parameter can be any combination of the following values:
+  *            @arg ADC_IT_RDY:   ADC Ready (ADRDY) interrupt source
+  *            @arg ADC_IT_EOSMP: ADC End of Sampling interrupt source
+  *            @arg ADC_IT_EOC:   ADC End of Regular Conversion interrupt source
+  *            @arg ADC_IT_EOS:   ADC End of Regular sequence of Conversions interrupt source
+  *            @arg ADC_IT_OVR:   ADC overrun interrupt source
+  *            @arg ADC_IT_JEOC:  ADC End of Injected Conversion interrupt source
+  *            @arg ADC_IT_JEOS:  ADC End of Injected sequence of Conversions interrupt source
+  *            @arg ADC_IT_AWD1:  ADC Analog watchdog 1 interrupt source (main analog watchdog, present on all STM32 devices)
+  *            @arg ADC_IT_AWD2:  ADC Analog watchdog 2 interrupt source (additional analog watchdog, present only on STM32F3 devices)
+  *            @arg ADC_IT_AWD3:  ADC Analog watchdog 3 interrupt source (additional analog watchdog, present only on STM32F3 devices)
+  *            @arg ADC_IT_JQOVF: ADC Injected Context Queue Overflow interrupt source
+  * @retval None
+  */
+#define __HAL_ADC_DISABLE_IT(__HANDLE__, __INTERRUPT__)                        \
+  (CLEAR_BIT((__HANDLE__)->Instance->IER, (__INTERRUPT__)))
+
+/** @brief  Checks if the specified ADC interrupt source is enabled or disabled.
+  * @param __HANDLE__ ADC handle
+  * @param __INTERRUPT__ ADC interrupt source to check
+  *          This parameter can be any combination of the following values:
+  *            @arg ADC_IT_RDY:   ADC Ready (ADRDY) interrupt source
+  *            @arg ADC_IT_EOSMP: ADC End of Sampling interrupt source
+  *            @arg ADC_IT_EOC:   ADC End of Regular Conversion interrupt source
+  *            @arg ADC_IT_EOS:   ADC End of Regular sequence of Conversions interrupt source
+  *            @arg ADC_IT_OVR:   ADC overrun interrupt source
+  *            @arg ADC_IT_JEOC:  ADC End of Injected Conversion interrupt source
+  *            @arg ADC_IT_JEOS:  ADC End of Injected sequence of Conversions interrupt source
+  *            @arg ADC_IT_AWD1:  ADC Analog watchdog 1 interrupt source (main analog watchdog, present on all STM32 devices)
+  *            @arg ADC_IT_AWD2:  ADC Analog watchdog 2 interrupt source (additional analog watchdog, present only on STM32F3 devices)
+  *            @arg ADC_IT_AWD3:  ADC Analog watchdog 3 interrupt source (additional analog watchdog, present only on STM32F3 devices)
+  *            @arg ADC_IT_JQOVF: ADC Injected Context Queue Overflow interrupt source
+  * @retval State of interruption (SET or RESET)
+  */
+#define __HAL_ADC_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__)                     \
+  (((__HANDLE__)->Instance->IER & (__INTERRUPT__)) == (__INTERRUPT__))
+
+/**
+  * @brief Get the selected ADC's flag status.
+  * @param __HANDLE__ ADC handle
+  * @param __FLAG__ ADC flag
+  *          This parameter can be any combination of the following values:
+  *            @arg ADC_FLAG_RDY:   ADC Ready (ADRDY) flag
+  *            @arg ADC_FLAG_EOSMP: ADC End of Sampling flag
+  *            @arg ADC_FLAG_EOC:   ADC End of Regular Conversion flag
+  *            @arg ADC_FLAG_EOS:   ADC End of Regular sequence of Conversions flag
+  *            @arg ADC_FLAG_OVR:   ADC overrun flag
+  *            @arg ADC_FLAG_JEOC:  ADC End of Injected Conversion flag
+  *            @arg ADC_FLAG_JEOS:  ADC End of Injected sequence of Conversions flag
+  *            @arg ADC_FLAG_AWD1:  ADC Analog watchdog 1 flag (main analog watchdog, present on all STM32 devices)
+  *            @arg ADC_FLAG_AWD2:  ADC Analog watchdog 2 flag (additional analog watchdog, present only on STM32F3 devices)
+  *            @arg ADC_FLAG_AWD3:  ADC Analog watchdog 3 flag (additional analog watchdog, present only on STM32F3 devices)
+  *            @arg ADC_FLAG_JQOVF: ADC Injected Context Queue Overflow flag
+  * @retval None
+  */
+#define __HAL_ADC_GET_FLAG(__HANDLE__, __FLAG__)                               \
+  ((((__HANDLE__)->Instance->ISR) & (__FLAG__)) == (__FLAG__))
+
+/**
+  * @brief Clear the ADC's pending flags
+  * @param __HANDLE__ ADC handle
+  * @param __FLAG__ ADC flag
+  *          This parameter can be any combination of the following values:
+  *            @arg ADC_FLAG_RDY:   ADC Ready (ADRDY) flag
+  *            @arg ADC_FLAG_EOSMP: ADC End of Sampling flag
+  *            @arg ADC_FLAG_EOC:   ADC End of Regular Conversion flag
+  *            @arg ADC_FLAG_EOS:   ADC End of Regular sequence of Conversions flag
+  *            @arg ADC_FLAG_OVR:   ADC overrun flag
+  *            @arg ADC_FLAG_JEOC:  ADC End of Injected Conversion flag
+  *            @arg ADC_FLAG_JEOS:  ADC End of Injected sequence of Conversions flag
+  *            @arg ADC_FLAG_AWD1:  ADC Analog watchdog 1 flag (main analog watchdog, present on all STM32 devices)
+  *            @arg ADC_FLAG_AWD2:  ADC Analog watchdog 2 flag (additional analog watchdog, present only on STM32F3 devices)
+  *            @arg ADC_FLAG_AWD3:  ADC Analog watchdog 3 flag (additional analog watchdog, present only on STM32F3 devices)
+  *            @arg ADC_FLAG_JQOVF: ADC Injected Context Queue Overflow flag
+  * @retval None
+  */
+/* Note: bit cleared bit by writing 1 (writing 0 has no effect on any bit of  */
+/*       register ISR).                                                       */
+#define __HAL_ADC_CLEAR_FLAG(__HANDLE__, __FLAG__)                             \
+  (WRITE_REG((__HANDLE__)->Instance->ISR, (__FLAG__)))
+
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+
+
+#if defined(STM32F373xC) || defined(STM32F378xx)
+
+/**
+  * @brief Enable the ADC peripheral
+  * @note ADC enable requires a delay for ADC stabilization time
+  *       (refer to device datasheet, parameter tSTAB)
+  * @note On STM32F37x devices, if ADC is already enabled this macro trigs
+  *       a conversion SW start on regular group.
+  * @param __HANDLE__ ADC handle
+  * @retval None
+  */
+#define __HAL_ADC_ENABLE(__HANDLE__)                                           \
+  (SET_BIT((__HANDLE__)->Instance->CR2, (ADC_CR2_ADON)))
+  
+/**
+  * @brief Disable the ADC peripheral
+  * @param __HANDLE__ ADC handle
+  * @retval None
+  */
+#define __HAL_ADC_DISABLE(__HANDLE__)                                          \
+  (CLEAR_BIT((__HANDLE__)->Instance->CR2, (ADC_CR2_ADON)))
+    
+/** @brief Enable the ADC end of conversion interrupt.
+  * @param __HANDLE__ ADC handle
+  * @param __INTERRUPT__ ADC Interrupt
+  *          This parameter can be any combination of the following values:
+  *            @arg ADC_IT_EOC: ADC End of Regular Conversion interrupt source
+  *            @arg ADC_IT_JEOC: ADC End of Injected Conversion interrupt source
+  *            @arg ADC_IT_AWD: ADC Analog watchdog interrupt source
+  * @retval None
+  */
+#define __HAL_ADC_ENABLE_IT(__HANDLE__, __INTERRUPT__)                         \
+  (SET_BIT((__HANDLE__)->Instance->CR1, (__INTERRUPT__)))
+
+/** @brief Disable the ADC end of conversion interrupt.
+  * @param __HANDLE__ ADC handle
+  * @param __INTERRUPT__ ADC Interrupt
+  *          This parameter can be any combination of the following values:
+  *            @arg ADC_IT_EOC: ADC End of Regular Conversion interrupt source
+  *            @arg ADC_IT_JEOC: ADC End of Injected Conversion interrupt source
+  *            @arg ADC_IT_AWD: ADC Analog watchdog interrupt source
+  * @retval None
+  */
+#define __HAL_ADC_DISABLE_IT(__HANDLE__, __INTERRUPT__)                        \
+  (CLEAR_BIT((__HANDLE__)->Instance->CR1, (__INTERRUPT__)))
+
+/** @brief  Checks if the specified ADC interrupt source is enabled or disabled.
+  * @param __HANDLE__ ADC handle
+  * @param __INTERRUPT__ ADC interrupt source to check
+  *          This parameter can be any combination of the following values:
+  *            @arg ADC_IT_EOC: ADC End of Regular Conversion interrupt source
+  *            @arg ADC_IT_JEOC: ADC End of Injected Conversion interrupt source
+  *            @arg ADC_IT_AWD: ADC Analog watchdog interrupt source
+  * @retval State of interruption (SET or RESET)
+  */
+#define __HAL_ADC_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__)                     \
+  (((__HANDLE__)->Instance->CR1 & (__INTERRUPT__)) == (__INTERRUPT__))
+
+/** @brief Get the selected ADC's flag status.
+  * @param __HANDLE__ ADC handle
+  * @param __FLAG__ ADC flag
+  *          This parameter can be any combination of the following values:
+  *            @arg ADC_FLAG_STRT: ADC Regular group start flag
+  *            @arg ADC_FLAG_JSTRT: ADC Injected group start flag
+  *            @arg ADC_FLAG_EOC: ADC End of Regular conversion flag
+  *            @arg ADC_FLAG_JEOC: ADC End of Injected conversion flag
+  *            @arg ADC_FLAG_AWD: ADC Analog watchdog flag
+  * @retval None
+  */
+#define __HAL_ADC_GET_FLAG(__HANDLE__, __FLAG__)                               \
+  ((((__HANDLE__)->Instance->SR) & (__FLAG__)) == (__FLAG__))
+    
+/** @brief Clear the ADC's pending flags
+  * @param __HANDLE__ ADC handle
+  * @param __FLAG__ ADC flag
+  *          This parameter can be any combination of the following values:
+  *            @arg ADC_FLAG_STRT: ADC Regular group start flag
+  *            @arg ADC_FLAG_JSTRT: ADC Injected group start flag
+  *            @arg ADC_FLAG_EOC: ADC End of Regular conversion flag
+  *            @arg ADC_FLAG_JEOC: ADC End of Injected conversion flag
+  *            @arg ADC_FLAG_AWD: ADC Analog watchdog flag
+  * @retval None
+  */
+#define __HAL_ADC_CLEAR_FLAG(__HANDLE__, __FLAG__)                             \
+  (WRITE_REG((__HANDLE__)->Instance->SR, ~(__FLAG__)))
+
+#endif /* STM32F373xC || STM32F378xx */
+
+/**
+  * @}
+  */
+
+/* Private macro ------------------------------------------------------------*/
+
+/** @addtogroup ADCEx_Private_Macro ADCEx Private Macros
+  * @{
+  */
+/* Macro reserved for internal HAL driver usage, not intended to be used in   */
+/* code of final user.                                                        */
+      
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+
+/**
+  * @brief Verification of hardware constraints before ADC can be enabled
+  * @param __HANDLE__ ADC handle
+  * @retval SET (ADC can be enabled) or RESET (ADC cannot be enabled)
+  */
+#define ADC_ENABLING_CONDITIONS(__HANDLE__)                                    \
+  (( HAL_IS_BIT_CLR((__HANDLE__)->Instance->CR                        ,        \
+                    (ADC_CR_ADCAL    | ADC_CR_JADSTP | ADC_CR_ADSTP |          \
+                     ADC_CR_JADSTART |ADC_CR_ADSTART | ADC_CR_ADDIS |          \
+                     ADC_CR_ADEN                                     ) )       \
+   ) ? SET : RESET)
+
+/**
+  * @brief Verification of ADC state: enabled or disabled
+  * @param __HANDLE__ ADC handle
+  * @retval SET (ADC enabled) or RESET (ADC disabled)
+  */
+#define ADC_IS_ENABLE(__HANDLE__)                                                      \
+  (( ((((__HANDLE__)->Instance->CR) & (ADC_CR_ADEN | ADC_CR_ADDIS)) == ADC_CR_ADEN) && \
+     ((((__HANDLE__)->Instance->ISR) & ADC_FLAG_RDY) == ADC_FLAG_RDY)                  \
+   ) ? SET : RESET)
+
+/**
+  * @brief Test if conversion trigger of regular group is software start
+  *        or external trigger.
+  * @param __HANDLE__ ADC handle
+  * @retval SET (software start) or RESET (external trigger)
+  */
+#define ADC_IS_SOFTWARE_START_REGULAR(__HANDLE__)                              \
+  (((__HANDLE__)->Instance->CFGR & ADC_CFGR_EXTEN) == RESET)
+
+/**
+  * @brief Test if conversion trigger of injected group is software start
+  *        or external trigger.
+  * @param __HANDLE__ ADC handle
+  * @retval SET (software start) or RESET (external trigger)
+  */
+#define ADC_IS_SOFTWARE_START_INJECTED(__HANDLE__)                             \
+  (((__HANDLE__)->Instance->JSQR & ADC_JSQR_JEXTEN) == RESET)
+
+/**
+  * @brief Check if no conversion on going on regular and/or injected groups
+  * @param __HANDLE__ ADC handle
+  * @retval SET (conversion is on going) or RESET (no conversion is on going)
+  */
+#define ADC_IS_CONVERSION_ONGOING_REGULAR_INJECTED(__HANDLE__)                     \
+  (( (((__HANDLE__)->Instance->CR) & (ADC_CR_ADSTART | ADC_CR_JADSTART)) == RESET  \
+   ) ? RESET : SET)
+
+/**
+  * @brief Check if no conversion on going on regular group
+  * @param __HANDLE__ ADC handle
+  * @retval SET (conversion is on going) or RESET (no conversion is on going)
+  */
+#define ADC_IS_CONVERSION_ONGOING_REGULAR(__HANDLE__)                          \
+  (( (((__HANDLE__)->Instance->CR) & ADC_CR_ADSTART) == RESET                  \
+   ) ? RESET : SET)
+
+/**
+  * @brief Check if no conversion on going on injected group
+  * @param __HANDLE__ ADC handle
+  * @retval SET (conversion is on going) or RESET (no conversion is on going)
+  */
+#define ADC_IS_CONVERSION_ONGOING_INJECTED(__HANDLE__)                         \
+  (( (((__HANDLE__)->Instance->CR) & ADC_CR_JADSTART) == RESET                 \
+   ) ? RESET : SET)
+
+/**
+  * @brief Returns resolution bits in CFGR1 register: RES[1:0].
+  *        Returned value is among parameters to @ref ADCEx_Resolution.
+  * @param __HANDLE__ ADC handle
+  * @retval None
+  */
+#define ADC_GET_RESOLUTION(__HANDLE__) (((__HANDLE__)->Instance->CFGR) & ADC_CFGR_RES)
+
+/**
+  * @brief Simultaneously clears and sets specific bits of the handle State
+  * @note: ADC_STATE_CLR_SET() macro is merely aliased to generic macro MODIFY_REG(),
+  *        the first parameter is the ADC handle State, the second parameter is the
+  *        bit field to clear, the third and last parameter is the bit field to set.
+  * @retval None
+  */
+#define ADC_STATE_CLR_SET MODIFY_REG
+
+/**
+  * @brief Clear ADC error code (set it to error code: "no error")
+  * @param __HANDLE__ ADC handle
+  * @retval None
+  */
+#define ADC_CLEAR_ERRORCODE(__HANDLE__) ((__HANDLE__)->ErrorCode = HAL_ADC_ERROR_NONE)
+         
+/**
+  * @brief Set the ADC's sample time for Channels numbers between 0 and 9.
+  * @param _SAMPLETIME_ Sample time parameter.
+  * @param _CHANNELNB_ Channel number.  
+  * @retval None
+  */
+#define ADC_SMPR1(_SAMPLETIME_, _CHANNELNB_) ((_SAMPLETIME_) << (3U * (_CHANNELNB_)))
+    
+/**
+  * @brief Set the ADC's sample time for Channels numbers between 10 and 18.
+  * @param _SAMPLETIME_ Sample time parameter.
+  * @param _CHANNELNB_ Channel number.  
+  * @retval None
+  */
+#define ADC_SMPR2(_SAMPLETIME_, _CHANNELNB_) ((_SAMPLETIME_) << (3U * ((_CHANNELNB_) - 10U)))
+
+/**
+  * @brief Set the selected regular Channel rank for rank between 1 and 4.
+  * @param _CHANNELNB_ Channel number.
+  * @param _RANKNB_ Rank number.    
+  * @retval None
+  */
+#define ADC_SQR1_RK(_CHANNELNB_, _RANKNB_) ((_CHANNELNB_) << (6U * (_RANKNB_)))
+
+/**
+  * @brief Set the selected regular Channel rank for rank between 5 and 9.
+  * @param _CHANNELNB_ Channel number.
+  * @param _RANKNB_ Rank number.    
+  * @retval None
+  */
+#define ADC_SQR2_RK(_CHANNELNB_, _RANKNB_) ((_CHANNELNB_) << (6U * ((_RANKNB_) - 5U)))
+
+/**
+  * @brief Set the selected regular Channel rank for rank between 10 and 14.
+  * @param _CHANNELNB_ Channel number.
+  * @param _RANKNB_ Rank number.    
+  * @retval None
+  */
+#define ADC_SQR3_RK(_CHANNELNB_, _RANKNB_) ((_CHANNELNB_) << (6U * ((_RANKNB_) - 10U)))
+
+/**
+  * @brief Set the selected regular Channel rank for rank between 15 and 16.
+  * @param _CHANNELNB_ Channel number.
+  * @param _RANKNB_ Rank number.    
+  * @retval None
+  */
+#define ADC_SQR4_RK(_CHANNELNB_, _RANKNB_) ((_CHANNELNB_) << (6U * ((_RANKNB_) - 15U)))
+
+/**
+  * @brief Set the selected injected Channel rank.
+  * @param _CHANNELNB_ Channel number.
+  * @param _RANKNB_ Rank number.   
+  * @retval None
+  */
+#define ADC_JSQR_RK(_CHANNELNB_, _RANKNB_) ((_CHANNELNB_) << (6U * (_RANKNB_) +2U))
+
+
+/**
+  * @brief Set the Analog Watchdog 1 channel.
+  * @param _CHANNEL_ channel to be monitored by Analog Watchdog 1.
+  * @retval None
+  */
+#define ADC_CFGR_AWD1CH_SHIFT(_CHANNEL_) ((_CHANNEL_) << 26U)
+
+/**
+  * @brief Configure the channel number into Analog Watchdog 2 or 3.
+  * @param _CHANNEL_ ADC Channel
+  * @retval None
+  */
+#define ADC_CFGR_AWD23CR(_CHANNEL_) (1U << (_CHANNEL_)) 
+
+/**
+  * @brief Enable automatic conversion of injected group
+  * @param _INJECT_AUTO_CONVERSION_ Injected automatic conversion.
+  * @retval None
+  */
+#define ADC_CFGR_INJECT_AUTO_CONVERSION(_INJECT_AUTO_CONVERSION_) ((_INJECT_AUTO_CONVERSION_) << 25U)
+
+/**
+  * @brief Enable ADC injected context queue
+  * @param _INJECT_CONTEXT_QUEUE_MODE_ Injected context queue mode.
+  * @retval None
+  */
+#define ADC_CFGR_INJECT_CONTEXT_QUEUE(_INJECT_CONTEXT_QUEUE_MODE_) ((_INJECT_CONTEXT_QUEUE_MODE_) << 21U)
+
+/**
+  * @brief Enable ADC discontinuous conversion mode for injected group
+  * @param _INJECT_DISCONTINUOUS_MODE_ Injected discontinuous mode.
+  * @retval None
+  */
+#define ADC_CFGR_INJECT_DISCCONTINUOUS(_INJECT_DISCONTINUOUS_MODE_) ((_INJECT_DISCONTINUOUS_MODE_) << 20U)
+
+/**
+  * @brief Enable ADC discontinuous conversion mode for regular group
+  * @param _REG_DISCONTINUOUS_MODE_ Regular discontinuous mode.
+  * @retval None
+  */
+#define ADC_CFGR_REG_DISCCONTINUOUS(_REG_DISCONTINUOUS_MODE_) ((_REG_DISCONTINUOUS_MODE_) << 16U)
+
+/**
+  * @brief Configures the number of discontinuous conversions for regular group.
+  * @param _NBR_DISCONTINUOUS_CONV_ Number of discontinuous conversions.
+  * @retval None
+  */
+#define ADC_CFGR_DISCONTINUOUS_NUM(_NBR_DISCONTINUOUS_CONV_) (((_NBR_DISCONTINUOUS_CONV_) - 1U) << 17U)
+
+/**
+  * @brief Enable the ADC auto delay mode.
+  * @param _AUTOWAIT_ Auto delay bit enable or disable.
+  * @retval None
+  */
+#define ADC_CFGR_AUTOWAIT(_AUTOWAIT_) ((_AUTOWAIT_) << 14U)
+
+/**
+  * @brief Enable ADC continuous conversion mode.
+  * @param _CONTINUOUS_MODE_ Continuous mode.
+  * @retval None
+  */
+#define ADC_CFGR_CONTINUOUS(_CONTINUOUS_MODE_) ((_CONTINUOUS_MODE_) << 13U)
+    
+/**
+  * @brief Enable ADC overrun mode.
+  * @param _OVERRUN_MODE_ Overrun mode.
+  * @retval Overrun bit setting to be programmed into CFGR register
+  */
+/* Note: Bit ADC_CFGR_OVRMOD not used directly in constant                    */
+/* "ADC_OVR_DATA_OVERWRITTEN" to have this case defined to 0x00U, to set it    */
+/* as the default case to be compliant with other STM32 devices.              */
+#define ADC_CFGR_OVERRUN(_OVERRUN_MODE_)                                       \
+  ( ( (_OVERRUN_MODE_) != (ADC_OVR_DATA_PRESERVED)                             \
+    )? (ADC_CFGR_OVRMOD) : (0x00000000U)                                        \
+  )
+
+/**
+  * @brief Enable the ADC DMA continuous request.
+  * @param _DMACONTREQ_MODE_ DMA continuous request mode.
+  * @retval None
+  */
+#define ADC_CFGR_DMACONTREQ(_DMACONTREQ_MODE_) ((_DMACONTREQ_MODE_) << 1U)
+
+/**
+  * @brief For devices with 3 ADCs or more: Defines the external trigger source 
+  *        for regular group according to ADC into common group ADC1&ADC2 or 
+  *        ADC3&ADC4 (some triggers with same source have different value to
+  *        be programmed into ADC EXTSEL bits of CFGR register).
+  *        Note: No risk of trigger bits value of common group ADC1&ADC2 
+  *        misleading to another trigger at same bits value, because the 3
+  *        exceptions below are circular and do not point to any other trigger
+  *        with direct treatment.
+  *        For devices with 2 ADCs or less: this macro makes no change.
+  * @param __HANDLE__ ADC handle
+  * @param __EXT_TRIG_CONV__ External trigger selected for regular group.
+  * @retval External trigger to be programmed into EXTSEL bits of CFGR register
+  */
+#if defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F303xC) || defined(STM32F358xx)
+
+#if defined(STM32F303xC) || defined(STM32F358xx)
+#define ADC_CFGR_EXTSEL_SET(__HANDLE__, __EXT_TRIG_CONV__)                     \
+ (( ((((__HANDLE__)->Instance) == ADC3) || (((__HANDLE__)->Instance) == ADC4)) \
+  )?                                                                           \
+   ( ( (__EXT_TRIG_CONV__) == ADC_EXTERNALTRIGCONV_T2_TRGO                     \
+     )?                                                                        \
+      (ADC3_4_EXTERNALTRIG_T2_TRGO)                                            \
+      :                                                                        \
+      ( ( (__EXT_TRIG_CONV__) == ADC_EXTERNALTRIGCONV_T3_TRGO                  \
+        )?                                                                     \
+         (ADC3_4_EXTERNALTRIG_T3_TRGO)                                         \
+         :                                                                     \
+         ( ( (__EXT_TRIG_CONV__) == ADC_EXTERNALTRIGCONV_T8_TRGO               \
+           )?                                                                  \
+            (ADC3_4_EXTERNALTRIG_T8_TRGO)                                      \
+            :                                                                  \
+            (__EXT_TRIG_CONV__)                                                \
+         )                                                                     \
+      )                                                                        \
+   )                                                                           \
+   :                                                                           \
+   (__EXT_TRIG_CONV__)                                                         \
+ )
+#endif /* STM32F303xC || STM32F358xx */
+   
+#if defined(STM32F303xE) || defined(STM32F398xx)
+/* Note: Macro including external triggers specific to device STM303xE: using */
+/*       Timer20 with ADC trigger input remap.                                */
+#define ADC_CFGR_EXTSEL_SET(__HANDLE__, __EXT_TRIG_CONV__)                     \
+ (( ((((__HANDLE__)->Instance) == ADC3) || (((__HANDLE__)->Instance) == ADC4)) \
+  )?                                                                           \
+   ( ( (__EXT_TRIG_CONV__) == ADC_EXTERNALTRIGCONV_T2_TRGO                     \
+     )?                                                                        \
+      (ADC3_4_EXTERNALTRIG_T2_TRGO)                                            \
+      :                                                                        \
+      ( ( (__EXT_TRIG_CONV__) == ADC_EXTERNALTRIGCONV_T3_TRGO                  \
+        )?                                                                     \
+         (ADC3_4_EXTERNALTRIG_T3_TRGO)                                         \
+         :                                                                     \
+         ( ( (__EXT_TRIG_CONV__) == ADC_EXTERNALTRIGCONV_T8_TRGO               \
+           )?                                                                  \
+            (ADC3_4_EXTERNALTRIG_T8_TRGO)                                      \
+            :                                                                  \
+            ( ( (__EXT_TRIG_CONV__) == ADC_EXTERNALTRIGCONV_T20_CC1            \
+              )?                                                               \
+               (ADC3_4_EXTERNALTRIG_T2_CC1)                                    \
+               :                                                               \
+                ( ( (__EXT_TRIG_CONV__) == ADC_EXTERNALTRIGCONV_T20_TRGO       \
+                  )?                                                           \
+                   (ADC3_4_EXTERNALTRIG_EXT_IT2)                               \
+                   :                                                           \
+                    ( ( (__EXT_TRIG_CONV__) == ADC_EXTERNALTRIGCONV_T20_TRGO2  \
+                      )?                                                       \
+                       (ADC3_4_EXTERNALTRIG_T4_CC1)                            \
+                       :                                                       \
+                       (__EXT_TRIG_CONV__)                                     \
+                  )                                                            \
+               )                                                               \
+            )                                                                  \
+         )                                                                     \
+      )                                                                        \
+   )                                                                           \
+   :                                                                           \
+   (__EXT_TRIG_CONV__ & (~ADC_EXTERNALTRIGCONV_T20_MASK))                      \
+ )
+#endif /* STM32F303xE || STM32F398xx */
+#else
+#define ADC_CFGR_EXTSEL_SET(__HANDLE__, __EXT_TRIG_CONV__)                     \
+   (__EXT_TRIG_CONV__)
+#endif /* STM32F303xE || STM32F398xx || */
+       /* STM32F303xC || STM32F358xx    */
+
+/**
+  * @brief For devices with 3 ADCs or more: Defines the external trigger source 
+  *        for injected group according to ADC into common group ADC1&ADC2 or 
+  *        ADC3&ADC4 (some triggers with same source have different value to
+  *        be programmed into ADC JEXTSEL bits of JSQR register).
+  *        Note: No risk of trigger bits value of common group ADC1&ADC2 
+  *        misleading to another trigger at same bits value, because the 3
+  *        exceptions below are circular and do not point to any other trigger
+  *        with direct treatment, except trigger
+  *        ADC_EXTERNALTRIGINJECCONV_T4_CC3 differentiated with SW offset.
+  *        For devices with 2 ADCs or less: this macro makes no change.
+  * @param __HANDLE__ ADC handle
+  * @param __EXT_TRIG_INJECTCONV__ External trigger selected for injected group
+  * @retval External trigger to be programmed into JEXTSEL bits of JSQR register
+  */
+#if defined(STM32F303xC) || defined(STM32F303xE) || defined(STM32F398xx) || defined(STM32F358xx)
+#if defined(STM32F303xC) || defined(STM32F358xx)
+#define ADC_JSQR_JEXTSEL_SET(__HANDLE__, __EXT_TRIG_INJECTCONV__)              \
+ (( ((((__HANDLE__)->Instance) == ADC3) || (((__HANDLE__)->Instance) == ADC4)) \
+  )?                                                                           \
+   ( ( (__EXT_TRIG_INJECTCONV__) == ADC_EXTERNALTRIGINJECCONV_T2_TRGO          \
+     )?                                                                        \
+      (ADC3_4_EXTERNALTRIGINJEC_T2_TRGO)                                       \
+      :                                                                        \
+      ( ( (__EXT_TRIG_INJECTCONV__) == ADC_EXTERNALTRIGINJECCONV_T4_TRGO       \
+        )?                                                                     \
+         (ADC3_4_EXTERNALTRIGINJEC_T4_TRGO)                                    \
+         :                                                                     \
+         ( ( (__EXT_TRIG_INJECTCONV__) == ADC_EXTERNALTRIGINJECCONV_T8_CC4     \
+           )?                                                                  \
+            (ADC3_4_EXTERNALTRIGINJEC_T8_CC4)                                  \
+            :                                                                  \
+            ( ( (__EXT_TRIG_INJECTCONV__) == ADC_EXTERNALTRIGINJECCONV_T4_CC3  \
+              )?                                                               \
+               (ADC3_4_EXTERNALTRIGINJEC_T4_CC3)                               \
+               :                                                               \
+               (__EXT_TRIG_INJECTCONV__)                                       \
+            )                                                                  \
+         )                                                                     \
+      )                                                                        \
+   )                                                                           \
+   :                                                                           \
+   (__EXT_TRIG_INJECTCONV__)                                                   \
+ )
+#endif /* STM32F303xC || STM32F358xx */
+   
+#if defined(STM32F303xE) || defined(STM32F398xx)
+/* Note: Macro including external triggers specific to device STM303xE: using */
+/*       Timer20 with ADC trigger input remap.                                */
+#define ADC_JSQR_JEXTSEL_SET(__HANDLE__, __EXT_TRIG_INJECTCONV__)              \
+ (( ((((__HANDLE__)->Instance) == ADC3) || (((__HANDLE__)->Instance) == ADC4)) \
+  )?                                                                           \
+   ( ( (__EXT_TRIG_INJECTCONV__) == ADC_EXTERNALTRIGINJECCONV_T2_TRGO          \
+     )?                                                                        \
+      (ADC3_4_EXTERNALTRIGINJEC_T2_TRGO)                                       \
+      :                                                                        \
+      ( ( (__EXT_TRIG_INJECTCONV__) == ADC_EXTERNALTRIGINJECCONV_T4_TRGO       \
+        )?                                                                     \
+         (ADC3_4_EXTERNALTRIGINJEC_T4_TRGO)                                    \
+         :                                                                     \
+         ( ( (__EXT_TRIG_INJECTCONV__) == ADC_EXTERNALTRIGINJECCONV_T8_CC4     \
+           )?                                                                  \
+            (ADC3_4_EXTERNALTRIGINJEC_T8_CC4)                                  \
+            :                                                                  \
+            ( ( (__EXT_TRIG_INJECTCONV__) == ADC_EXTERNALTRIGINJECCONV_T4_CC3  \
+              )?                                                               \
+               (ADC3_4_EXTERNALTRIGINJEC_T4_CC3)                               \
+               :                                                               \
+                ( ( (__EXT_TRIG_INJECTCONV__)                                  \
+                                         == ADC_EXTERNALTRIGINJECCONV_T20_TRGO \
+                  )?                                                           \
+                   (ADC3_4_EXTERNALTRIGINJEC_T20_TRGO)                         \
+                   :                                                           \
+                    ( ( (__EXT_TRIG_INJECTCONV__)                              \
+                                       == ADC_EXTERNALTRIGINJECCONV_T20_TRGO2  \
+                      )?                                                       \
+                       (ADC3_4_EXTERNALTRIGINJEC_T1_CC3)                       \
+                       :                                                       \
+                       (__EXT_TRIG_INJECTCONV__)                               \
+                  )                                                            \
+               )                                                               \
+            )                                                                  \
+         )                                                                     \
+      )                                                                        \
+   )                                                                           \
+   :                                                                           \
+   (__EXT_TRIG_INJECTCONV__ & (~ADC_EXTERNALTRIGCONV_T20_MASK))                \
+ )
+#endif /* STM32F303xE || STM32F398xx */
+#else
+#define ADC_JSQR_JEXTSEL_SET(__HANDLE__, __EXT_TRIG_INJECTCONV__)              \
+   (__EXT_TRIG_INJECTCONV__)
+#endif /* STM32F303xE || STM32F398xx || */
+       /* STM32F303xC || STM32F358xx    */
+
+/**
+  * @brief Configure the channel number into offset OFRx register
+  * @param _CHANNEL_ ADC Channel
+  * @retval None
+  */
+#define ADC_OFR_CHANNEL(_CHANNEL_) ((_CHANNEL_) << 26U)
+
+/**
+  * @brief Configure the channel number into differential mode selection register
+  * @param _CHANNEL_ ADC Channel
+  * @retval None
+  */
+#define ADC_DIFSEL_CHANNEL(_CHANNEL_) (1U << (_CHANNEL_)) 
+
+/**
+  * @brief Calibration factor in differential mode to be set into calibration register
+  * @param _Calibration_Factor_ Calibration factor value
+  * @retval None
+  */
+#define ADC_CALFACT_DIFF_SET(_Calibration_Factor_) ((_Calibration_Factor_) << 16U)
+
+/**
+  * @brief Calibration factor in differential mode to be retrieved from calibration register
+  * @param _Calibration_Factor_ Calibration factor value
+  * @retval None
+  */
+#define ADC_CALFACT_DIFF_GET(_Calibration_Factor_) ((_Calibration_Factor_) >> 16U)
+     
+/**
+  * @brief Configure the analog watchdog high threshold into registers TR1, TR2 or TR3.
+  * @param _Threshold_ Threshold value
+  * @retval None
+  */
+#define ADC_TRX_HIGHTHRESHOLD(_Threshold_) ((_Threshold_) << 16U)
+
+/**
+  * @brief Enable the ADC DMA continuous request for ADC multimode.
+  * @param _DMAContReq_MODE_ DMA continuous request mode.
+  * @retval None
+  */
+#define ADC_CCR_MULTI_DMACONTREQ(_DMAContReq_MODE_) ((_DMAContReq_MODE_) << 13U)
+    
+/**
+  * @brief Verification of hardware constraints before ADC can be disabled
+  * @param __HANDLE__ ADC handle
+  * @retval SET (ADC can be disabled) or RESET (ADC cannot be disabled)
+  */
+#define ADC_DISABLING_CONDITIONS(__HANDLE__)                                   \
+       (( ( ((__HANDLE__)->Instance->CR) &                                     \
+            (ADC_CR_JADSTART | ADC_CR_ADSTART | ADC_CR_ADEN)) == ADC_CR_ADEN   \
+        ) ? SET : RESET)
+         
+
+/**
+  * @brief Shift the offset in function of the selected ADC resolution. 
+  *        Offset has to be left-aligned on bit 11, the LSB (right bits) are set to 0
+  *        If resolution 12 bits, no shift.
+  *        If resolution 10 bits, shift of 2 ranks on the left.
+  *        If resolution 8 bits, shift of 4 ranks on the left.
+  *        If resolution 6 bits, shift of 6 ranks on the left.
+  *        therefore, shift = (12 - resolution) = 12 - (12- (((RES[1:0]) >> 3)*2))
+  * @param __HANDLE__ ADC handle
+  * @param _Offset_ Value to be shifted
+  * @retval None
+  */
+#define ADC_OFFSET_SHIFT_RESOLUTION(__HANDLE__, _Offset_)                      \
+        ((_Offset_) << ((((__HANDLE__)->Instance->CFGR & ADC_CFGR_RES) >> 3U)*2U))
+
+/**
+  * @brief Shift the AWD1 threshold in function of the selected ADC resolution.
+  *        Thresholds have to be left-aligned on bit 11, the LSB (right bits) are set to 0.
+  *        If resolution 12 bits, no shift.
+  *        If resolution 10 bits, shift of 2 ranks on the left.
+  *        If resolution 8 bits, shift of 4 ranks on the left.
+  *        If resolution 6 bits, shift of 6 ranks on the left.
+  *        therefore, shift = (12 - resolution) = 12 - (12- (((RES[1:0]) >> 3)*2))
+  * @param __HANDLE__ ADC handle
+  * @param _Threshold_ Value to be shifted
+  * @retval None
+  */
+#define ADC_AWD1THRESHOLD_SHIFT_RESOLUTION(__HANDLE__, _Threshold_)            \
+        ((_Threshold_) << ((((__HANDLE__)->Instance->CFGR & ADC_CFGR_RES) >> 3U)*2U))
+
+/**
+  * @brief Shift the AWD2 and AWD3 threshold in function of the selected ADC resolution.
+  *        Thresholds have to be left-aligned on bit 7.
+  *        If resolution 12 bits, shift of 4 ranks on the right (the 4 LSB are discarded)
+  *        If resolution 10 bits, shift of 2 ranks on the right (the 2 LSB are discarded)
+  *        If resolution 8 bits, no shift.
+  *        If resolution 6 bits, shift of 2 ranks on the left (the 2 LSB are set to 0)
+  * @param __HANDLE__ ADC handle
+  * @param _Threshold_ Value to be shifted
+  * @retval None
+  */
+#define ADC_AWD23THRESHOLD_SHIFT_RESOLUTION(__HANDLE__, _Threshold_)           \
+         ( ((__HANDLE__)->Instance->CFGR & ADC_CFGR_RES) != (ADC_CFGR_RES_1 | ADC_CFGR_RES_0) ? \
+            ((_Threshold_) >> (4U- ((((__HANDLE__)->Instance->CFGR & ADC_CFGR_RES) >> 3U)*2U))) : \
+            (_Threshold_) << 2U )
+
+/**
+  * @brief Defines if the selected ADC is within ADC common register ADC1_2 or ADC3_4
+  * if available (ADC2, ADC3, ADC4 availability depends on STM32 product)
+  * @param __HANDLE__ ADC handle
+  * @retval Common control register ADC1_2 or ADC3_4
+  */
+#if defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F303xC) || defined(STM32F358xx)
+#define ADC_MASTER_INSTANCE(__HANDLE__)                                          \
+  ( ( ((((__HANDLE__)->Instance) == ADC1) || (((__HANDLE__)->Instance) == ADC2)) \
+    )? (ADC1) : (ADC3)                                                           \
+  )
+#endif /* STM32F303xE || STM32F398xx || */
+       /* STM32F303xC || STM32F358xx    */
+
+#if defined(STM32F302xE)                                                ||     \
+    defined(STM32F302xC)                                                ||     \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
+#define ADC_MASTER_INSTANCE(__HANDLE__)                                        \
+  (ADC1)
+#endif /* STM32F302xE                               || */
+       /* STM32F302xC                               || */
+       /* STM32F303x8 || STM32F328xx || STM32F334x8    */
+       
+#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+#define ADC_MASTER_INSTANCE(__HANDLE__)                                        \
+  (ADC1)
+#endif /* STM32F301x8 || STM32F302x8 || STM32F318xx */
+
+/**
+  * @brief Defines if the selected ADC is within ADC common register ADC1_2 or ADC3_4
+  * if available (ADC2, ADC3, ADC4 availability depends on STM32 product)
+  * @param __HANDLE__ ADC handle
+  * @retval Common control register ADC1_2 or ADC3_4
+  */
+#if defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F303xC) || defined(STM32F358xx)
+#define ADC_COMMON_REGISTER(__HANDLE__)                                          \
+  ( ( ((((__HANDLE__)->Instance) == ADC1) || (((__HANDLE__)->Instance) == ADC2)) \
+    )? (ADC1_2_COMMON) : (ADC3_4_COMMON)                                         \
+  )
+#endif /* STM32F303xE || STM32F398xx || */
+       /* STM32F303xC || STM32F358xx    */
+
+#if defined(STM32F302xE)                                                ||     \
+    defined(STM32F302xC)                                                ||     \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
+#define ADC_COMMON_REGISTER(__HANDLE__)                                        \
+  (ADC1_2_COMMON)
+#endif /* STM32F302xE                               || */
+       /* STM32F302xC                               || */
+       /* STM32F303x8 || STM32F328xx || STM32F334x8    */
+       
+#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+#define ADC_COMMON_REGISTER(__HANDLE__)                                        \
+  (ADC1_COMMON)
+#endif /* STM32F301x8 || STM32F302x8 || STM32F318xx */
+       
+/**
+  * @brief Selection of ADC common register CCR bits MULTI[4:0]corresponding to the selected ADC (applicable for devices with several ADCs)
+  * @param __HANDLE__ ADC handle
+  * @retval None
+  */
+#if defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F303xC) || defined(STM32F358xx)
+#define ADC_COMMON_CCR_MULTI(__HANDLE__)                                         \
+  ( ( ((((__HANDLE__)->Instance) == ADC1) || (((__HANDLE__)->Instance) == ADC2)) \
+    )?                                                                           \
+     (ADC1_2_COMMON->CCR & ADC12_CCR_MULTI)                                      \
+     :                                                                           \
+     (ADC3_4_COMMON->CCR & ADC34_CCR_MULTI)                                      \
+  )
+#endif /* STM32F303xE || STM32F398xx || */
+       /* STM32F303xC || STM32F358xx    */
+    
+#if defined(STM32F302xE)                                                ||    \
+    defined(STM32F302xC)                                                ||    \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
+#define ADC_COMMON_CCR_MULTI(__HANDLE__)                                      \
+  (ADC1_2_COMMON->CCR & ADC12_CCR_MULTI)
+#endif /* STM32F302xE                               || */
+       /* STM32F302xC                               || */
+       /* STM32F303x8 || STM32F328xx || STM32F334x8    */
+
+#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+#define ADC_COMMON_CCR_MULTI(__HANDLE__)                                      \
+  (RESET)
+#endif /* STM32F301x8 || STM32F302x8 || STM32F318xx */
+
+/**
+  * @brief Verification of condition for ADC start conversion: ADC must be in non-multimode, or multimode with handle of ADC master (applicable for devices with several ADCs)
+  * @param __HANDLE__ ADC handle
+  * @retval None
+  */
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
+#define ADC_NONMULTIMODE_OR_MULTIMODEMASTER(__HANDLE__)                        \
+  ((ADC_COMMON_CCR_MULTI(__HANDLE__) == ADC_MODE_INDEPENDENT) ||               \
+   (IS_ADC_MULTIMODE_MASTER_INSTANCE((__HANDLE__)->Instance))   )
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx    */
+
+#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+#define ADC_NONMULTIMODE_OR_MULTIMODEMASTER(__HANDLE__)                        \
+  (!RESET)
+#endif /* STM32F301x8 || STM32F302x8 || STM32F318xx */
+
+/**
+  * @brief Verification of condition for ADC group regular start conversion: ADC must be in non-multimode or multimode on group injected only, or multimode with handle of ADC master (applicable for devices with several ADCs)
+  * @param __HANDLE__ ADC handle.
+  * @retval None
+  */
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
+#define ADC_NONMULTIMODE_REG_OR_MULTIMODEMASTER(__HANDLE__)                    \
+  ((ADC_COMMON_CCR_MULTI(__HANDLE__) == ADC_MODE_INDEPENDENT)     ||           \
+   (ADC_COMMON_CCR_MULTI(__HANDLE__) == ADC_DUALMODE_INJECSIMULT) ||           \
+   (ADC_COMMON_CCR_MULTI(__HANDLE__) == ADC_DUALMODE_ALTERTRIG)   ||           \
+   (IS_ADC_MULTIMODE_MASTER_INSTANCE((__HANDLE__)->Instance))       )
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx    */
+
+#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+#define ADC_NONMULTIMODE_REG_OR_MULTIMODEMASTER(__HANDLE__)                    \
+  (!RESET)
+#endif /* STM32F301x8 || STM32F302x8 || STM32F318xx */
+
+/**
+  * @brief Verification of condition for ADC group injected start conversion: ADC must be in non-multimode or multimode on group regular only, or multimode with handle of ADC master (applicable for devices with several ADCs)
+  * @param __HANDLE__ ADC handle.
+  * @retval None
+  */
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
+#define ADC_NONMULTIMODE_INJ_OR_MULTIMODEMASTER(__HANDLE__)                    \
+  ((ADC_COMMON_CCR_MULTI(__HANDLE__) == ADC_MODE_INDEPENDENT)   ||             \
+   (ADC_COMMON_CCR_MULTI(__HANDLE__) == ADC_DUALMODE_REGSIMULT) ||             \
+   (ADC_COMMON_CCR_MULTI(__HANDLE__) == ADC_DUALMODE_INTERL)    ||             \
+   (IS_ADC_MULTIMODE_MASTER_INSTANCE((__HANDLE__)->Instance))     )
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx    */
+
+#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+#define ADC_NONMULTIMODE_INJ_OR_MULTIMODEMASTER(__HANDLE__)                    \
+  (!RESET)
+#endif /* STM32F301x8 || STM32F302x8 || STM32F318xx */
+
+/**
+  * @brief Check ADC multimode setting: In case of multimode, check whether ADC master of the selected ADC has feature auto-injection enabled (applicable for devices with several ADCs)
+  * @param __HANDLE__ ADC handle
+  * @retval None
+  */
+#if defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F303xC) || defined(STM32F358xx)
+#define ADC_MULTIMODE_AUTO_INJECTED(__HANDLE__)                                \
+  (( (((__HANDLE__)->Instance) == ADC1) || (((__HANDLE__)->Instance) == ADC2)  \
+   )?                                                                          \
+    (ADC1->CFGR & ADC_CFGR_JAUTO)                                              \
+    :                                                                          \
+    (ADC3->CFGR & ADC_CFGR_JAUTO)                                              \
+  )
+#elif defined(STM32F302xE)                                                || \
+      defined(STM32F302xC)                                                || \
+      defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
+#define ADC_MULTIMODE_AUTO_INJECTED(__HANDLE__)                                \
+  (( (((__HANDLE__)->Instance) == ADC1) || (((__HANDLE__)->Instance) == ADC2)  \
+   )?                                                                          \
+    (ADC1->CFGR & ADC_CFGR_JAUTO)                                              \
+    :                                                                          \
+    (RESET)                                                                    \
+  )
+#else
+#define ADC_MULTIMODE_AUTO_INJECTED(__HANDLE__)                                \
+  (RESET)
+#endif 
+
+/**
+  * @brief Set handle of the other ADC sharing the same common register ADC1_2 or ADC3_4
+  * if available (ADC2, ADC3, ADC4 availability depends on STM32 product)
+  * @param __HANDLE__ ADC handle
+  * @param __HANDLE_OTHER_ADC__ other ADC handle
+  * @retval None
+  */
+#if defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F303xC) || defined(STM32F358xx)
+#define ADC_COMMON_ADC_OTHER(__HANDLE__, __HANDLE_OTHER_ADC__)                 \
+  ( ( ((__HANDLE__)->Instance == ADC1)                                         \
+    )?                                                                         \
+     ((__HANDLE_OTHER_ADC__)->Instance = ADC2)                                 \
+     :                                                                         \
+     ( ( ((__HANDLE__)->Instance == ADC2)                                      \
+       )?                                                                      \
+        ((__HANDLE_OTHER_ADC__)->Instance = ADC1)                              \
+        :                                                                      \
+        ( ( ((__HANDLE__)->Instance == ADC3)                                   \
+          )?                                                                   \
+           ((__HANDLE_OTHER_ADC__)->Instance = ADC4)                           \
+           :                                                                   \
+           ( ( ((__HANDLE__)->Instance == ADC4)                                \
+             )?                                                                \
+              ((__HANDLE_OTHER_ADC__)->Instance = ADC3)                        \
+              :                                                                \
+              ((__HANDLE_OTHER_ADC__)->Instance = NULL)                        \
+           )                                                                   \
+         )                                                                     \
+     )                                                                         \
+  )
+#endif /* STM32F303xE || STM32F398xx || */
+       /* STM32F303xC || STM32F358xx    */
+    
+#if defined(STM32F302xE)                                                || \
+    defined(STM32F302xC)                                                || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
+#define ADC_COMMON_ADC_OTHER(__HANDLE__, __HANDLE_OTHER_ADC__)                 \
+  ( ( ((__HANDLE__)->Instance == ADC1)                                         \
+    )?                                                                         \
+     ((__HANDLE_OTHER_ADC__)->Instance = ADC2)                                 \
+     :                                                                         \
+     ((__HANDLE_OTHER_ADC__)->Instance = ADC1)                                 \
+  )
+#endif /* STM32F302xE                               || */
+       /* STM32F302xC                               || */
+       /* STM32F303x8 || STM32F328xx || STM32F334x8    */
+
+#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+#define ADC_COMMON_ADC_OTHER(__HANDLE__, __HANDLE_OTHER_ADC__)                 \
+  ((__HANDLE_OTHER_ADC__)->Instance = NULL)
+#endif /* STM32F301x8 || STM32F302x8 || STM32F318xx */
+
+/**
+  * @brief Set handle of the ADC slave associated to the ADC master
+  * if available (ADC2, ADC3, ADC4 availability depends on STM32 product)
+  * @param __HANDLE_MASTER__ ADC master handle
+  * @param __HANDLE_SLAVE__ ADC slave handle
+  * @retval None
+  */
+#if defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F303xC) || defined(STM32F358xx)
+#define ADC_MULTI_SLAVE(__HANDLE_MASTER__, __HANDLE_SLAVE__)                   \
+  ( ( ((__HANDLE_MASTER__)->Instance == ADC1)                                  \
+    )?                                                                         \
+     ((__HANDLE_SLAVE__)->Instance = ADC2)                                     \
+     :                                                                         \
+     ( ( ((__HANDLE_MASTER__)->Instance == ADC3)                               \
+       )?                                                                      \
+        ((__HANDLE_SLAVE__)->Instance = ADC4)                                  \
+        :                                                                      \
+        ((__HANDLE_SLAVE__)->Instance = NULL)                                  \
+     )                                                                         \
+  )
+#endif /* STM32F303xE || STM32F398xx || */
+       /* STM32F303xC || STM32F358xx    */
+    
+#if defined(STM32F302xE)                                                || \
+    defined(STM32F302xC)                                                || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
+#define ADC_MULTI_SLAVE(__HANDLE_MASTER__, __HANDLE_SLAVE__)             \
+  ( ( ((__HANDLE_MASTER__)->Instance == ADC1)                                  \
+    )?                                                                         \
+     ((__HANDLE_SLAVE__)->Instance = ADC2)                                     \
+     :                                                                         \
+     ( NULL )                                                                  \
+  )
+#endif /* STM32F302xE                               || */
+       /* STM32F302xC                               || */
+       /* STM32F303x8 || STM32F328xx || STM32F334x8    */
+
+
+#define IS_ADC_RESOLUTION(RESOLUTION) (((RESOLUTION) == ADC_RESOLUTION_12B) || \
+                                       ((RESOLUTION) == ADC_RESOLUTION_10B) || \
+                                       ((RESOLUTION) == ADC_RESOLUTION_8B)  || \
+                                       ((RESOLUTION) == ADC_RESOLUTION_6B)    )
+
+#define IS_ADC_RESOLUTION_8_6_BITS(RESOLUTION) (((RESOLUTION) == ADC_RESOLUTION_8B) || \
+                                                ((RESOLUTION) == ADC_RESOLUTION_6B)   )
+
+
+#define IS_ADC_DATA_ALIGN(ALIGN) (((ALIGN) == ADC_DATAALIGN_RIGHT) || \
+                                  ((ALIGN) == ADC_DATAALIGN_LEFT)    )
+
+#define IS_ADC_SCAN_MODE(SCAN_MODE) (((SCAN_MODE) == ADC_SCAN_DISABLE) || \
+                                     ((SCAN_MODE) == ADC_SCAN_ENABLE)    )
+
+#define IS_ADC_EOC_SELECTION(EOC_SELECTION) (((EOC_SELECTION) == ADC_EOC_SINGLE_CONV)    || \
+                                             ((EOC_SELECTION) == ADC_EOC_SEQ_CONV)   )
+
+#define IS_ADC_OVERRUN(OVR) (((OVR) == ADC_OVR_DATA_PRESERVED)  || \
+                             ((OVR) == ADC_OVR_DATA_OVERWRITTEN)  )
+
+#define IS_ADC_CHANNEL(CHANNEL) (((CHANNEL) == ADC_CHANNEL_1)           || \
+                                 ((CHANNEL) == ADC_CHANNEL_2)           || \
+                                 ((CHANNEL) == ADC_CHANNEL_3)           || \
+                                 ((CHANNEL) == ADC_CHANNEL_4)           || \
+                                 ((CHANNEL) == ADC_CHANNEL_5)           || \
+                                 ((CHANNEL) == ADC_CHANNEL_6)           || \
+                                 ((CHANNEL) == ADC_CHANNEL_7)           || \
+                                 ((CHANNEL) == ADC_CHANNEL_8)           || \
+                                 ((CHANNEL) == ADC_CHANNEL_9)           || \
+                                 ((CHANNEL) == ADC_CHANNEL_10)          || \
+                                 ((CHANNEL) == ADC_CHANNEL_11)          || \
+                                 ((CHANNEL) == ADC_CHANNEL_12)          || \
+                                 ((CHANNEL) == ADC_CHANNEL_13)          || \
+                                 ((CHANNEL) == ADC_CHANNEL_14)          || \
+                                 ((CHANNEL) == ADC_CHANNEL_15)          || \
+                                 ((CHANNEL) == ADC_CHANNEL_TEMPSENSOR)  || \
+                                 ((CHANNEL) == ADC_CHANNEL_VBAT)        || \
+                                 ((CHANNEL) == ADC_CHANNEL_VREFINT)     || \
+                                 ((CHANNEL) == ADC_CHANNEL_VOPAMP1)     || \
+                                 ((CHANNEL) == ADC_CHANNEL_VOPAMP2)     || \
+                                 ((CHANNEL) == ADC_CHANNEL_VOPAMP3)     || \
+                                 ((CHANNEL) == ADC_CHANNEL_VOPAMP4)       )
+
+#define IS_ADC_DIFF_CHANNEL(CHANNEL) (((CHANNEL) == ADC_CHANNEL_1)      || \
+                                      ((CHANNEL) == ADC_CHANNEL_2)      || \
+                                      ((CHANNEL) == ADC_CHANNEL_3)      || \
+                                      ((CHANNEL) == ADC_CHANNEL_4)      || \
+                                      ((CHANNEL) == ADC_CHANNEL_5)      || \
+                                      ((CHANNEL) == ADC_CHANNEL_6)      || \
+                                      ((CHANNEL) == ADC_CHANNEL_7)      || \
+                                      ((CHANNEL) == ADC_CHANNEL_8)      || \
+                                      ((CHANNEL) == ADC_CHANNEL_9)      || \
+                                      ((CHANNEL) == ADC_CHANNEL_10)     || \
+                                      ((CHANNEL) == ADC_CHANNEL_11)     || \
+                                      ((CHANNEL) == ADC_CHANNEL_12)     || \
+                                      ((CHANNEL) == ADC_CHANNEL_13)     || \
+                                      ((CHANNEL) == ADC_CHANNEL_14)       )
+
+#define IS_ADC_SAMPLE_TIME(TIME) (((TIME) == ADC_SAMPLETIME_1CYCLE_5)    || \
+                                  ((TIME) == ADC_SAMPLETIME_2CYCLES_5)   || \
+                                  ((TIME) == ADC_SAMPLETIME_4CYCLES_5)   || \
+                                  ((TIME) == ADC_SAMPLETIME_7CYCLES_5)   || \
+                                  ((TIME) == ADC_SAMPLETIME_19CYCLES_5)  || \
+                                  ((TIME) == ADC_SAMPLETIME_61CYCLES_5)  || \
+                                  ((TIME) == ADC_SAMPLETIME_181CYCLES_5) || \
+                                  ((TIME) == ADC_SAMPLETIME_601CYCLES_5)   )
+
+#define IS_ADC_SINGLE_DIFFERENTIAL(SING_DIFF) (((SING_DIFF) == ADC_SINGLE_ENDED)      || \
+                                               ((SING_DIFF) == ADC_DIFFERENTIAL_ENDED)  )
+
+#define IS_ADC_OFFSET_NUMBER(OFFSET_NUMBER) (((OFFSET_NUMBER) == ADC_OFFSET_NONE) || \
+                                             ((OFFSET_NUMBER) == ADC_OFFSET_1)    || \
+                                             ((OFFSET_NUMBER) == ADC_OFFSET_2)    || \
+                                             ((OFFSET_NUMBER) == ADC_OFFSET_3)    || \
+                                             ((OFFSET_NUMBER) == ADC_OFFSET_4)      )
+
+#define IS_ADC_REGULAR_RANK(CHANNEL) (((CHANNEL) == ADC_REGULAR_RANK_1 ) || \
+                                      ((CHANNEL) == ADC_REGULAR_RANK_2 ) || \
+                                      ((CHANNEL) == ADC_REGULAR_RANK_3 ) || \
+                                      ((CHANNEL) == ADC_REGULAR_RANK_4 ) || \
+                                      ((CHANNEL) == ADC_REGULAR_RANK_5 ) || \
+                                      ((CHANNEL) == ADC_REGULAR_RANK_6 ) || \
+                                      ((CHANNEL) == ADC_REGULAR_RANK_7 ) || \
+                                      ((CHANNEL) == ADC_REGULAR_RANK_8 ) || \
+                                      ((CHANNEL) == ADC_REGULAR_RANK_9 ) || \
+                                      ((CHANNEL) == ADC_REGULAR_RANK_10) || \
+                                      ((CHANNEL) == ADC_REGULAR_RANK_11) || \
+                                      ((CHANNEL) == ADC_REGULAR_RANK_12) || \
+                                      ((CHANNEL) == ADC_REGULAR_RANK_13) || \
+                                      ((CHANNEL) == ADC_REGULAR_RANK_14) || \
+                                      ((CHANNEL) == ADC_REGULAR_RANK_15) || \
+                                      ((CHANNEL) == ADC_REGULAR_RANK_16)   )
+
+#define IS_ADC_EXTTRIG_EDGE(EDGE) (((EDGE) == ADC_EXTERNALTRIGCONVEDGE_NONE)         || \
+                                   ((EDGE) == ADC_EXTERNALTRIGCONVEDGE_RISING)       || \
+                                   ((EDGE) == ADC_EXTERNALTRIGCONVEDGE_FALLING)      || \
+                                   ((EDGE) == ADC_EXTERNALTRIGCONVEDGE_RISINGFALLING)  )
+
+#if defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F303xC) || defined(STM32F358xx)
+
+#if defined(STM32F303xC) || defined(STM32F358xx)
+#define IS_ADC_EXTTRIG(REGTRIG) (((REGTRIG) == ADC_EXTERNALTRIGCONV_T1_CC1)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T1_CC2)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T2_CC2)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T3_CC4)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T4_CC4)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T6_TRGO)  || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_EXT_IT11) || \
+                                                                                 \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T2_CC1)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T2_CC3)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T3_CC1)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T4_CC1)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T7_TRGO)  || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T8_CC1)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_EXT_IT2)  || \
+                                                                                 \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T1_CC3)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T1_TRGO)  || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T1_TRGO2) || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T2_TRGO)  || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T3_TRGO)  || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T4_TRGO)  || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T8_TRGO)  || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T8_TRGO2) || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T15_TRGO) || \
+                                                                                 \
+                                 ((REGTRIG) == ADC_SOFTWARE_START)              )
+#endif /* STM32F303xC || STM32F358xx */
+
+#if defined(STM32F303xE) || defined(STM32F398xx)
+#define IS_ADC_EXTTRIG(REGTRIG) (((REGTRIG) == ADC_EXTERNALTRIGCONV_T1_CC1)    || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T1_CC2)    || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T2_CC2)    || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T3_CC4)    || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T4_CC4)    || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T6_TRGO)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_EXT_IT11)  || \
+                                                                                  \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T2_CC1)    || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T2_CC3)    || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T3_CC1)    || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T4_CC1)    || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T7_TRGO)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T8_CC1)    || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_EXT_IT2)   || \
+                                                                                  \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T1_CC3)    || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T1_TRGO)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T1_TRGO2)  || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T2_TRGO)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T3_TRGO)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T4_TRGO)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T8_TRGO)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T8_TRGO2)  || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T15_TRGO)  || \
+                                                                                  \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T20_CC2)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T20_CC3)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T20_CC1)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T20_TRGO)  || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T20_TRGO2) || \
+                                                                                  \
+                                 ((REGTRIG) == ADC_SOFTWARE_START)               )
+#endif /* STM32F303xE || STM32F398xx */
+
+#endif /* STM32F303xC || STM32F303xE || STM32F398xx || STM32F358xx */
+
+#if defined(STM32F302xE) || \
+    defined(STM32F302xC)
+
+#if defined(STM32F302xE)
+#define IS_ADC_EXTTRIG(REGTRIG) (((REGTRIG) == ADC_EXTERNALTRIGCONV_T1_CC1)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T1_CC2)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T1_CC3)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T2_CC2)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T3_TRGO)  || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T4_CC4)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_EXT_IT11) || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T1_TRGO)  || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T1_TRGO2) || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T2_TRGO)  || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T4_TRGO)  || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T6_TRGO)  || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T15_TRGO) || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T3_CC4)   || \
+                                                                                 \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T20_CC2)  || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T20_CC3)  || \
+                                                                                 \
+                                 ((REGTRIG) == ADC_SOFTWARE_START)              )
+#endif /* STM32F302xE */
+
+#if defined(STM32F302xC)
+#define IS_ADC_EXTTRIG(REGTRIG) (((REGTRIG) == ADC_EXTERNALTRIGCONV_T1_CC1)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T1_CC2)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T1_CC3)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T2_CC2)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T3_TRGO)  || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T4_CC4)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_EXT_IT11) || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T1_TRGO)  || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T1_TRGO2) || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T2_TRGO)  || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T4_TRGO)  || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T6_TRGO)  || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T15_TRGO) || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T3_CC4)   || \
+                                                                                 \
+                                 ((REGTRIG) == ADC_SOFTWARE_START)              )
+#endif /* STM32F302xC */
+
+#endif /* STM32F302xE || */
+       /* STM32F302xC    */
+
+#if defined(STM32F303x8) || defined(STM32F328xx)
+#define IS_ADC_EXTTRIG(REGTRIG) (((REGTRIG) == ADC_EXTERNALTRIGCONV_T1_CC1)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T1_CC2)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T1_CC3)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T2_CC2)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T3_TRGO)  || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T4_CC4)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_EXT_IT11) || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T8_TRGO)  || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T8_TRGO2) || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T1_TRGO)  || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T1_TRGO2) || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T2_TRGO)  || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T4_TRGO)  || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T6_TRGO)  || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T15_TRGO) || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T3_CC4)   || \
+                                                                                 \
+                                 ((REGTRIG) == ADC_SOFTWARE_START)              )
+#endif /* STM32F303x8 || STM32F328xx */
+
+#if defined(STM32F334x8)
+#define IS_ADC_EXTTRIG(REGTRIG) (((REGTRIG) == ADC_EXTERNALTRIGCONV_T1_CC1)    || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T1_CC2)    || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T1_CC3)    || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T2_CC2)    || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T3_TRGO)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_EXT_IT11)  || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONVHRTIM_TRG1) || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONVHRTIM_TRG3) || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T1_TRGO)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T1_TRGO2)  || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T2_TRGO)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T6_TRGO)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T15_TRGO)  || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T3_CC4)    || \
+                                                                                  \
+                                 ((REGTRIG) == ADC_SOFTWARE_START)               )
+#endif /* STM32F334x8 */
+
+#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+#define IS_ADC_EXTTRIG(REGTRIG) (((REGTRIG) == ADC_EXTERNALTRIGCONV_T1_CC1)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T1_CC2)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T1_CC3)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T2_CC2)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_EXT_IT11) || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T1_TRGO)  || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T1_TRGO2) || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T2_TRGO)  || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T6_TRGO)  || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T15_TRGO) || \
+                                 ((REGTRIG) == ADC_SOFTWARE_START)              )
+#endif /* STM32F301x8 || STM32F302x8 || STM32F318xx */
+
+#define IS_ADC_EXTTRIGINJEC_EDGE(EDGE) (((EDGE) == ADC_EXTERNALTRIGINJECCONV_EDGE_NONE)         || \
+                                        ((EDGE) == ADC_EXTERNALTRIGINJECCONV_EDGE_RISING)       || \
+                                        ((EDGE) == ADC_EXTERNALTRIGINJECCONV_EDGE_FALLING)      || \
+                                        ((EDGE) == ADC_EXTERNALTRIGINJECCONV_EDGE_RISINGFALLING)  )
+
+
+#if defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F303xC) || defined(STM32F358xx)
+
+#if defined(STM32F303xC) || defined(STM32F358xx)
+#define IS_ADC_EXTTRIGINJEC(INJTRIG) (((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T2_CC1)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T3_CC1)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T3_CC4)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T6_TRGO)  || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_EXT_IT15) || \
+                                                                                           \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T4_CC3)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T4_CC4)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T7_TRGO)  || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T8_CC2)   || \
+                                                                                           \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T1_CC4)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T1_TRGO)  || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T1_TRGO2) || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T2_TRGO)  || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T3_CC3)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T3_TRGO)  || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T4_TRGO)  || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T8_CC4)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T8_TRGO)  || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T8_TRGO2) || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T15_TRGO) || \
+                                                                                           \
+                                      ((INJTRIG) == ADC_INJECTED_SOFTWARE_START)          )
+#endif /* STM32F303xC || STM32F358xx */
+
+#if defined(STM32F303xE) || defined(STM32F398xx)
+#define IS_ADC_EXTTRIGINJEC(INJTRIG) (((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T2_CC1)    || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T3_CC1)    || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T3_CC4)    || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T6_TRGO)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_EXT_IT15)  || \
+                                                                                            \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T4_CC3)    || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T4_CC4)    || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T7_TRGO)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T8_CC2)    || \
+                                                                                            \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T1_CC4)    || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T1_TRGO)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T1_TRGO2)  || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T2_TRGO)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T3_CC3)    || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T3_TRGO)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T4_TRGO)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T8_CC4)    || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T8_TRGO)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T8_TRGO2)  || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T15_TRGO)  || \
+                                                                                            \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T20_CC4)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T20_CC2)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T20_TRGO)  || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T20_TRGO2) || \
+                                                                                            \
+                                      ((INJTRIG) == ADC_INJECTED_SOFTWARE_START)           )
+#endif /* STM32F303xE || STM32F398xx */
+
+#endif /* STM32F303xC || STM32F303xE || STM32F398xx || STM32F358xx */
+
+#if defined(STM32F302xE) || \
+    defined(STM32F302xC)
+
+#if defined(STM32F302xE)
+#define IS_ADC_EXTTRIGINJEC(INJTRIG) (((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T1_CC4)    || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T1_TRGO)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T1_TRGO2)  || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T2_CC1)    || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T2_TRGO)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T3_CC1)    || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T3_CC3)    || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T3_CC4)    || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T3_TRGO)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T4_TRGO)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T6_TRGO)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T15_TRGO)  || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_EXT_IT15)  || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T20_CC4)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T20_TRGO)  || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T20_TRGO2) || \
+                                      ((INJTRIG) == ADC_INJECTED_SOFTWARE_START)             )
+#endif /* STM32F302xE */
+
+#if defined(STM32F302xC)
+#define IS_ADC_EXTTRIGINJEC(INJTRIG) (((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T1_CC4)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T1_TRGO)  || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T1_TRGO2) || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T2_CC1)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T2_TRGO)  || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T3_CC1)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T3_CC3)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T3_CC4)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T3_TRGO)  || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T4_TRGO)  || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T6_TRGO)  || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T15_TRGO) || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_EXT_IT15) || \
+                                      ((INJTRIG) == ADC_INJECTED_SOFTWARE_START)          )
+#endif /* STM32F302xC */
+
+#endif /* STM32F302xE || */
+       /* STM32F302xC    */
+
+#if defined(STM32F303x8) || defined(STM32F328xx)
+#define IS_ADC_EXTTRIGINJEC(INJTRIG) (((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T1_TRGO)  || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T1_CC4)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T2_TRGO)  || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T2_CC1)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T3_CC4)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T4_TRGO)  || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_EXT_IT15) || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T8_CC4)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T1_TRGO2) || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T8_TRGO)  || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T8_TRGO2) || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T3_CC3)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T3_TRGO)  || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T3_CC1)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T6_TRGO)  || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T15_TRGO) || \
+                                      ((INJTRIG) == ADC_INJECTED_SOFTWARE_START)          )
+#endif /* STM32F303x8 || STM32F328xx */
+
+#if defined(STM32F334x8)
+#define IS_ADC_EXTTRIGINJEC(INJTRIG) (((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T1_TRGO)    || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T1_CC4)     || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T2_TRGO)    || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T2_CC1)     || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T3_CC4)     || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_EXT_IT15)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T1_TRGO2)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_HRTIM_TRG2) || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_HRTIM_TRG4) || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T3_CC3)     || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T3_TRGO)    || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T3_CC1)     || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T6_TRGO)    || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T15_TRGO)   || \
+                                      ((INJTRIG) == ADC_INJECTED_SOFTWARE_START)            )
+#endif /* STM32F334x8 */
+
+#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+#define IS_ADC_EXTTRIGINJEC(INJTRIG) (((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T1_TRGO)  || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T1_CC4)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_EXT_IT15) || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T1_TRGO2) || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T6_TRGO)  || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T15_TRGO) || \
+                                      ((INJTRIG) == ADC_INJECTED_SOFTWARE_START)          )
+#endif /* STM32F301x8 || STM32F302x8 || STM32F318xx */
+
+#define IS_ADC_INJECTED_RANK(CHANNEL) (((CHANNEL) == ADC_INJECTED_RANK_1) || \
+                                       ((CHANNEL) == ADC_INJECTED_RANK_2) || \
+                                       ((CHANNEL) == ADC_INJECTED_RANK_3) || \
+                                       ((CHANNEL) == ADC_INJECTED_RANK_4)   )
+
+#define IS_ADC_MODE(MODE) (((MODE) == ADC_MODE_INDEPENDENT)               || \
+                           ((MODE) == ADC_DUALMODE_REGSIMULT_INJECSIMULT) || \
+                           ((MODE) == ADC_DUALMODE_REGSIMULT_ALTERTRIG)   || \
+                           ((MODE) == ADC_DUALMODE_REGINTERL_INJECSIMULT) || \
+                           ((MODE) == ADC_DUALMODE_INJECSIMULT)           || \
+                           ((MODE) == ADC_DUALMODE_REGSIMULT)             || \
+                           ((MODE) == ADC_DUALMODE_INTERL)                || \
+                           ((MODE) == ADC_DUALMODE_ALTERTRIG)               )
+
+#define IS_ADC_DMA_ACCESS_MODE(MODE) (((MODE) == ADC_DMAACCESSMODE_DISABLED)   || \
+                                      ((MODE) == ADC_DMAACCESSMODE_12_10_BITS) || \
+                                      ((MODE) == ADC_DMAACCESSMODE_8_6_BITS)     )
+
+#define IS_ADC_SAMPLING_DELAY(DELAY) (((DELAY) == ADC_TWOSAMPLINGDELAY_1CYCLE)   || \
+                                      ((DELAY) == ADC_TWOSAMPLINGDELAY_2CYCLES)  || \
+                                      ((DELAY) == ADC_TWOSAMPLINGDELAY_3CYCLES)  || \
+                                      ((DELAY) == ADC_TWOSAMPLINGDELAY_4CYCLES)  || \
+                                      ((DELAY) == ADC_TWOSAMPLINGDELAY_5CYCLES)  || \
+                                      ((DELAY) == ADC_TWOSAMPLINGDELAY_6CYCLES)  || \
+                                      ((DELAY) == ADC_TWOSAMPLINGDELAY_7CYCLES)  || \
+                                      ((DELAY) == ADC_TWOSAMPLINGDELAY_8CYCLES)  || \
+                                      ((DELAY) == ADC_TWOSAMPLINGDELAY_9CYCLES)  || \
+                                      ((DELAY) == ADC_TWOSAMPLINGDELAY_10CYCLES) || \
+                                      ((DELAY) == ADC_TWOSAMPLINGDELAY_11CYCLES) || \
+                                      ((DELAY) == ADC_TWOSAMPLINGDELAY_12CYCLES)   )
+
+#define IS_ADC_ANALOG_WATCHDOG_NUMBER(WATCHDOG) (((WATCHDOG) == ADC_ANALOGWATCHDOG_1) || \
+                                                 ((WATCHDOG) == ADC_ANALOGWATCHDOG_2) || \
+                                                 ((WATCHDOG) == ADC_ANALOGWATCHDOG_3)   )
+
+#define IS_ADC_ANALOG_WATCHDOG_MODE(WATCHDOG) (((WATCHDOG) == ADC_ANALOGWATCHDOG_NONE)             || \
+                                               ((WATCHDOG) == ADC_ANALOGWATCHDOG_SINGLE_REG)       || \
+                                               ((WATCHDOG) == ADC_ANALOGWATCHDOG_SINGLE_INJEC)     || \
+                                               ((WATCHDOG) == ADC_ANALOGWATCHDOG_SINGLE_REGINJEC)  || \
+                                               ((WATCHDOG) == ADC_ANALOGWATCHDOG_ALL_REG)          || \
+                                               ((WATCHDOG) == ADC_ANALOGWATCHDOG_ALL_INJEC)        || \
+                                               ((WATCHDOG) == ADC_ANALOGWATCHDOG_ALL_REGINJEC)       )
+
+#define IS_ADC_CONVERSION_GROUP(CONVERSION) (((CONVERSION) == ADC_REGULAR_GROUP)         || \
+                                             ((CONVERSION) == ADC_INJECTED_GROUP)        || \
+                                             ((CONVERSION) == ADC_REGULAR_INJECTED_GROUP)  )
+
+#define IS_ADC_EVENT_TYPE(EVENT) (((EVENT) == ADC_AWD_EVENT)  || \
+                                  ((EVENT) == ADC_AWD2_EVENT) || \
+                                  ((EVENT) == ADC_AWD3_EVENT) || \
+                                  ((EVENT) == ADC_OVR_EVENT)  || \
+                                  ((EVENT) == ADC_JQOVF_EVENT)  )
+
+/** @defgroup ADCEx_range_verification ADC Extended Range Verification
+  * in function of ADC resolution selected (12, 10, 8 or 6 bits)
+  * @{
+  */
+#define IS_ADC_RANGE(RESOLUTION, ADC_VALUE)                                         \
+   ((((RESOLUTION) == ADC_RESOLUTION_12B) && ((ADC_VALUE) <= (0x0FFFU))) || \
+    (((RESOLUTION) == ADC_RESOLUTION_10B) && ((ADC_VALUE) <= (0x03FFU))) || \
+    (((RESOLUTION) == ADC_RESOLUTION_8B)  && ((ADC_VALUE) <= (0x00FFU))) || \
+    (((RESOLUTION) == ADC_RESOLUTION_6B)  && ((ADC_VALUE) <= (0x003FU)))   )
+/**
+  * @}
+  */
+
+/** @defgroup ADC_injected_nb_conv_verification ADC Injected Conversion Number Verification
+  * @{
+  */
+#define IS_ADC_INJECTED_NB_CONV(LENGTH) (((LENGTH) >= (1U)) && ((LENGTH) <= (4U)))
+/**
+  * @}
+  */
+
+/** @defgroup ADC_regular_nb_conv_verification ADC Regular Conversion Number Verification
+  * @{
+  */
+#define IS_ADC_REGULAR_NB_CONV(LENGTH) (((LENGTH) >= (1U)) && ((LENGTH) <= (16U)))
+/**
+  * @}
+  */
+
+/** @defgroup ADC_regular_discontinuous_mode_number_verification ADC Regular Discontinuous Mode NumberVerification
+  * @{
+  */
+#define IS_ADC_REGULAR_DISCONT_NUMBER(NUMBER) (((NUMBER) >= (1U)) && ((NUMBER) <= (8U)))
+/**
+  * @}
+  */
+
+/** @defgroup ADC_calibration_factor_length_verification ADC Calibration Factor Length Verification
+  * @{
+  */
+/**
+  * @brief Calibration factor length verification (7 bits maximum)
+  * @param _Calibration_Factor_ Calibration factor value
+  * @retval None
+  */
+#define IS_ADC_CALFACT(_Calibration_Factor_) ((_Calibration_Factor_) <= (0x7FU))
+/**
+  * @}
+  */
+    
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx */
+
+
+#if defined(STM32F373xC) || defined(STM32F378xx)
+
+/**
+  * @brief Verification of ADC state: enabled or disabled
+  * @param __HANDLE__ ADC handle
+  * @retval SET (ADC enabled) or RESET (ADC disabled)
+  */
+#define ADC_IS_ENABLE(__HANDLE__)                                              \
+  ((( ((__HANDLE__)->Instance->CR2 & ADC_CR2_ADON) == ADC_CR2_ADON )           \
+   ) ? SET : RESET)
+
+/**
+  * @brief Test if conversion trigger of regular group is software start
+  *        or external trigger.
+  * @param __HANDLE__ ADC handle
+  * @retval SET (software start) or RESET (external trigger)
+  */
+#define ADC_IS_SOFTWARE_START_REGULAR(__HANDLE__)                              \
+  (((__HANDLE__)->Instance->CR2 & ADC_CR2_EXTSEL) == ADC_SOFTWARE_START)
+
+/**
+  * @brief Test if conversion trigger of injected group is software start
+  *        or external trigger.
+  * @param __HANDLE__ ADC handle
+  * @retval SET (software start) or RESET (external trigger)
+  */
+#define ADC_IS_SOFTWARE_START_INJECTED(__HANDLE__)                             \
+  (((__HANDLE__)->Instance->CR2 & ADC_CR2_JEXTSEL) == ADC_INJECTED_SOFTWARE_START)
+
+/**
+  * @brief Simultaneously clears and sets specific bits of the handle State
+  * @note: ADC_STATE_CLR_SET() macro is merely aliased to generic macro MODIFY_REG(),
+  *        the first parameter is the ADC handle State, the second parameter is the
+  *        bit field to clear, the third and last parameter is the bit field to set.
+  * @retval None
+  */
+#define ADC_STATE_CLR_SET MODIFY_REG
+
+/**
+  * @brief Clear ADC error code (set it to error code: "no error")
+  * @param __HANDLE__ ADC handle
+  * @retval None
+  */
+#define ADC_CLEAR_ERRORCODE(__HANDLE__)                                        \
+  ((__HANDLE__)->ErrorCode = HAL_ADC_ERROR_NONE)
+
+/**
+  * @brief Set ADC number of conversions into regular channel sequence length.
+  * @param _NbrOfConversion_ Regular channel sequence length 
+  * @retval None
+  */
+#define ADC_SQR1_L_SHIFT(_NbrOfConversion_)                                    \
+  (((_NbrOfConversion_) - (uint8_t)1U) << 20U)
+
+/**
+  * @brief Set the ADC's sample time for channel numbers between 10 and 18.
+  * @param _SAMPLETIME_ Sample time parameter.
+  * @param _CHANNELNB_ Channel number.  
+  * @retval None
+  */
+#define ADC_SMPR1(_SAMPLETIME_, _CHANNELNB_)                                   \
+  ((_SAMPLETIME_) << (3U * ((_CHANNELNB_) - 10U)))
+
+/**
+  * @brief Set the ADC's sample time for channel numbers between 0 and 9.
+  * @param _SAMPLETIME_ Sample time parameter.
+  * @param _CHANNELNB_ Channel number.  
+  * @retval None
+  */
+#define ADC_SMPR2(_SAMPLETIME_, _CHANNELNB_)                                   \
+  ((_SAMPLETIME_) << (3U * (_CHANNELNB_)))
+
+/**
+  * @brief Set the selected regular channel rank for rank between 1 and 6.
+  * @param _CHANNELNB_ Channel number.
+  * @param _RANKNB_ Rank number.    
+  * @retval None
+  */
+#define ADC_SQR3_RK(_CHANNELNB_, _RANKNB_)                                     \
+  ((_CHANNELNB_) << (5U * ((_RANKNB_) - 1U)))
+
+/**
+  * @brief Set the selected regular channel rank for rank between 7 and 12.
+  * @param _CHANNELNB_ Channel number.
+  * @param _RANKNB_ Rank number.    
+  * @retval None
+  */
+#define ADC_SQR2_RK(_CHANNELNB_, _RANKNB_)                                     \
+  ((_CHANNELNB_) << (5U * ((_RANKNB_) - 7U)))
+
+/**
+  * @brief Set the selected regular channel rank for rank between 13 and 16.
+  * @param _CHANNELNB_ Channel number.
+  * @param _RANKNB_ Rank number.    
+  * @retval None
+  */
+#define ADC_SQR1_RK(_CHANNELNB_, _RANKNB_)                                     \
+  ((_CHANNELNB_) << (5U * ((_RANKNB_) - 13U)))
+
+/**
+  * @brief Set the injected sequence length.
+  * @param _JSQR_JL_ Sequence length.
+  * @retval None
+  */
+#define ADC_JSQR_JL_SHIFT(_JSQR_JL_)                                           \
+  (((_JSQR_JL_) -1U) << 20U)
+
+/**
+  * @brief Set the selected injected channel rank
+  *        Note: on STM32F37x devices, channel rank position in JSQR register
+  *              is depending on total number of ranks selected into
+  *              injected sequencer (ranks sequence starting from 4-JL)
+  * @param _CHANNELNB_ Channel number.
+  * @param _RANKNB_ Rank number.
+  * @param _JSQR_JL_ Sequence length.
+  * @retval None
+  */
+#define ADC_JSQR_RK_JL(_CHANNELNB_, _RANKNB_, _JSQR_JL_)                       \
+  ((_CHANNELNB_) << (5U * ((4U - ((_JSQR_JL_) - (_RANKNB_))) - 1U)))
+
+/**
+  * @brief Enable ADC continuous conversion mode.
+  * @param _CONTINUOUS_MODE_ Continuous mode.
+  * @retval None
+  */
+#define ADC_CR2_CONTINUOUS(_CONTINUOUS_MODE_)                                  \
+  ((_CONTINUOUS_MODE_) << 1U)
+
+/**
+  * @brief Configures the number of discontinuous conversions for the regular group channels.
+  * @param _NBR_DISCONTINUOUS_CONV_ Number of discontinuous conversions.
+  * @retval None
+  */
+#define ADC_CR1_DISCONTINUOUS_NUM(_NBR_DISCONTINUOUS_CONV_)                    \
+  (((_NBR_DISCONTINUOUS_CONV_) - 1U) << 13U)
+   
+/**
+  * @brief Enable ADC scan mode to convert multiple ranks with sequencer.
+  * @param _SCAN_MODE_ Scan conversion mode.
+  * @retval None
+  */
+/* Note: Scan mode is compared to ENABLE for legacy purpose, this parameter   */
+/*       is equivalent to ADC_SCAN_ENABLE.                                    */
+#define ADC_CR1_SCAN_SET(_SCAN_MODE_)                                          \
+  (( ((_SCAN_MODE_) == ADC_SCAN_ENABLE) || ((_SCAN_MODE_) == ENABLE)           \
+   )? (ADC_SCAN_ENABLE) : (ADC_SCAN_DISABLE)                                   \
+  )
+    
+/**
+  * @brief Calibration factor in differential mode to be set into calibration register
+  * @param _Calibration_Factor_ Calibration factor value
+  * @retval None
+  */
+#define ADC_CALFACT_DIFF_SET(_Calibration_Factor_)                             \
+  ((_Calibration_Factor_) << 16U)
+
+/**
+  * @brief Calibration factor in differential mode to be retrieved from calibration register
+  * @param _Calibration_Factor_ Calibration factor value
+  * @retval None
+  */
+#define ADC_CALFACT_DIFF_GET(_Calibration_Factor_)                             \
+  ((_Calibration_Factor_) >> 16U)
+      
+      
+/**
+  * @brief Get the maximum ADC conversion cycles on all channels.
+  * Returns the selected sampling time + conversion time (12.5 ADC clock cycles)
+  * Approximation of sampling time within 4 ranges, returns the highest value:
+  *   below 7.5 cycles {1.5 cycle; 7.5 cycles},
+  *   between 13.5 cycles and 28.5 cycles {13.5 cycles; 28.5 cycles}
+  *   between 41.5 cycles and 71.5 cycles {41.5 cycles; 55.5 cycles; 71.5cycles}
+  *   equal to 239.5 cycles
+  * Unit: ADC clock cycles
+  * @param __HANDLE__ ADC handle
+  * @retval ADC conversion cycles on all channels
+  */   
+#define ADC_CONVCYCLES_MAX_RANGE(__HANDLE__)                                                                     \
+    (( (((__HANDLE__)->Instance->SMPR2 & ADC_SAMPLETIME_ALLCHANNELS_SMPR2BIT2) == RESET)  &&                     \
+       (((__HANDLE__)->Instance->SMPR1 & ADC_SAMPLETIME_ALLCHANNELS_SMPR1BIT2) == RESET) ) ?                     \
+                                                                                                                 \
+          (( (((__HANDLE__)->Instance->SMPR2 & ADC_SAMPLETIME_ALLCHANNELS_SMPR2BIT1) == RESET)  &&               \
+             (((__HANDLE__)->Instance->SMPR1 & ADC_SAMPLETIME_ALLCHANNELS_SMPR1BIT1) == RESET) ) ?               \
+               ADC_CONVERSIONCLOCKCYCLES_SAMPLETIME_7CYCLES5 : ADC_CONVERSIONCLOCKCYCLES_SAMPLETIME_28CYCLES5)   \
+          :                                                                                                      \
+          ((((((__HANDLE__)->Instance->SMPR2 & ADC_SAMPLETIME_ALLCHANNELS_SMPR2BIT1) == RESET)  &&               \
+             (((__HANDLE__)->Instance->SMPR1 & ADC_SAMPLETIME_ALLCHANNELS_SMPR1BIT1) == RESET)) ||               \
+            ((((__HANDLE__)->Instance->SMPR2 & ADC_SAMPLETIME_ALLCHANNELS_SMPR1BIT0) == RESET)  &&               \
+             (((__HANDLE__)->Instance->SMPR1 & ADC_SAMPLETIME_ALLCHANNELS_SMPR1BIT0) == RESET))) ?               \
+               ADC_CONVERSIONCLOCKCYCLES_SAMPLETIME_71CYCLES5 : ADC_CONVERSIONCLOCKCYCLES_SAMPLETIME_239CYCLES5) \
+     )
+
+/**
+  * @brief Get the total ADC clock prescaler (APB2 prescaler x ADC prescaler)
+  * from system clock configuration register.
+  * Approximation within 3 ranges, returns the higher value:
+  *   total prescaler minimum: 2 (ADC presc 2, APB2 presc 0)
+  *   total prescaler 32 (ADC presc 0 and APB2 presc all, or
+  *                       ADC presc {4, 6, 8} and APB2 presc {0, 2, 4})
+  *   total prescaler maximum: 128 (ADC presc {4, 6, 8} and APB2 presc {8, 16})
+  * Unit: none (prescaler factor)
+  * @retval ADC and APB2 prescaler factor
+  */
+#define ADC_CLOCK_PRESCALER_RANGE()                                            \
+  (( (RCC->CFGR & (RCC_CFGR_ADCPRE_1 | RCC_CFGR_ADCPRE_0)) == RESET) ?         \
+      (( (RCC->CFGR & RCC_CFGR_PPRE2_2) == RESET) ? 2 : 32U )                   \
+      :                                                                        \
+      (( (RCC->CFGR & RCC_CFGR_PPRE2_1) == RESET) ? 32 : 128U )                 \
+  )
+
+/**
+  * @brief Get the ADC clock prescaler from system clock configuration register. 
+  * @retval None
+  */
+#define ADC_GET_CLOCK_PRESCALER() (((RCC->CFGR & RCC_CFGR_ADCPRE) >> 14U) +1U)
+
+#define IS_ADC_DATA_ALIGN(ALIGN) (((ALIGN) == ADC_DATAALIGN_RIGHT) || \
+                                  ((ALIGN) == ADC_DATAALIGN_LEFT)    )
+
+#define IS_ADC_SCAN_MODE(SCAN_MODE) (((SCAN_MODE) == ADC_SCAN_DISABLE) || \
+                                     ((SCAN_MODE) == ADC_SCAN_ENABLE)    )
+
+#define IS_ADC_CHANNEL(CHANNEL) (((CHANNEL) == ADC_CHANNEL_0)           || \
+                                 ((CHANNEL) == ADC_CHANNEL_1)           || \
+                                 ((CHANNEL) == ADC_CHANNEL_2)           || \
+                                 ((CHANNEL) == ADC_CHANNEL_3)           || \
+                                 ((CHANNEL) == ADC_CHANNEL_4)           || \
+                                 ((CHANNEL) == ADC_CHANNEL_5)           || \
+                                 ((CHANNEL) == ADC_CHANNEL_6)           || \
+                                 ((CHANNEL) == ADC_CHANNEL_7)           || \
+                                 ((CHANNEL) == ADC_CHANNEL_8)           || \
+                                 ((CHANNEL) == ADC_CHANNEL_9)           || \
+                                 ((CHANNEL) == ADC_CHANNEL_10)          || \
+                                 ((CHANNEL) == ADC_CHANNEL_11)          || \
+                                 ((CHANNEL) == ADC_CHANNEL_12)          || \
+                                 ((CHANNEL) == ADC_CHANNEL_13)          || \
+                                 ((CHANNEL) == ADC_CHANNEL_14)          || \
+                                 ((CHANNEL) == ADC_CHANNEL_15)          || \
+                                 ((CHANNEL) == ADC_CHANNEL_TEMPSENSOR)  || \
+                                 ((CHANNEL) == ADC_CHANNEL_VREFINT)     || \
+                                 ((CHANNEL) == ADC_CHANNEL_VBAT)          )
+
+#define IS_ADC_SAMPLE_TIME(TIME) (((TIME) == ADC_SAMPLETIME_1CYCLE_5)    || \
+                                  ((TIME) == ADC_SAMPLETIME_7CYCLES_5)   || \
+                                  ((TIME) == ADC_SAMPLETIME_13CYCLES_5)  || \
+                                  ((TIME) == ADC_SAMPLETIME_28CYCLES_5)  || \
+                                  ((TIME) == ADC_SAMPLETIME_41CYCLES_5)  || \
+                                  ((TIME) == ADC_SAMPLETIME_55CYCLES_5)  || \
+                                  ((TIME) == ADC_SAMPLETIME_71CYCLES_5)  || \
+                                  ((TIME) == ADC_SAMPLETIME_239CYCLES_5)   )
+
+#define IS_ADC_REGULAR_RANK(CHANNEL) (((CHANNEL) == ADC_REGULAR_RANK_1 ) || \
+                                      ((CHANNEL) == ADC_REGULAR_RANK_2 ) || \
+                                      ((CHANNEL) == ADC_REGULAR_RANK_3 ) || \
+                                      ((CHANNEL) == ADC_REGULAR_RANK_4 ) || \
+                                      ((CHANNEL) == ADC_REGULAR_RANK_5 ) || \
+                                      ((CHANNEL) == ADC_REGULAR_RANK_6 ) || \
+                                      ((CHANNEL) == ADC_REGULAR_RANK_7 ) || \
+                                      ((CHANNEL) == ADC_REGULAR_RANK_8 ) || \
+                                      ((CHANNEL) == ADC_REGULAR_RANK_9 ) || \
+                                      ((CHANNEL) == ADC_REGULAR_RANK_10) || \
+                                      ((CHANNEL) == ADC_REGULAR_RANK_11) || \
+                                      ((CHANNEL) == ADC_REGULAR_RANK_12) || \
+                                      ((CHANNEL) == ADC_REGULAR_RANK_13) || \
+                                      ((CHANNEL) == ADC_REGULAR_RANK_14) || \
+                                      ((CHANNEL) == ADC_REGULAR_RANK_15) || \
+                                      ((CHANNEL) == ADC_REGULAR_RANK_16)   )
+
+#define IS_ADC_EXTTRIG_EDGE(EDGE) (((EDGE) == ADC_EXTERNALTRIGCONVEDGE_NONE)  || \
+                                   ((EDGE) == ADC_EXTERNALTRIGCONVEDGE_RISING)  )
+
+#define IS_ADC_EXTTRIG(REGTRIG) (((REGTRIG) == ADC_EXTERNALTRIGCONV_T2_CC2)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T3_TRGO)  || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T4_CC4)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T19_TRGO) || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T19_CC3)  || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T19_CC4)  || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_EXT_IT11) || \
+                                 ((REGTRIG) == ADC_SOFTWARE_START)              )
+
+#define IS_ADC_EXTTRIGINJEC_EDGE(EDGE) (((EDGE) == ADC_EXTERNALTRIGINJECCONV_EDGE_NONE)  || \
+                                        ((EDGE) == ADC_EXTERNALTRIGINJECCONV_EDGE_RISING)  )
+
+#define IS_ADC_EXTTRIGINJEC(INJTRIG) (((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T2_CC1)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T2_TRGO)  || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T3_CC4)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T4_TRGO)  || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T19_CC1)  || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T19_CC2)  || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_EXT_IT15) || \
+                                      ((INJTRIG) == ADC_INJECTED_SOFTWARE_START)          )
+
+#define IS_ADC_INJECTED_RANK(CHANNEL) (((CHANNEL) == ADC_INJECTED_RANK_1) || \
+                                       ((CHANNEL) == ADC_INJECTED_RANK_2) || \
+                                       ((CHANNEL) == ADC_INJECTED_RANK_3) || \
+                                       ((CHANNEL) == ADC_INJECTED_RANK_4)   )
+
+#define IS_ADC_ANALOG_WATCHDOG_MODE(WATCHDOG) (((WATCHDOG) == ADC_ANALOGWATCHDOG_NONE)             || \
+                                               ((WATCHDOG) == ADC_ANALOGWATCHDOG_SINGLE_REG)       || \
+                                               ((WATCHDOG) == ADC_ANALOGWATCHDOG_SINGLE_INJEC)     || \
+                                               ((WATCHDOG) == ADC_ANALOGWATCHDOG_SINGLE_REGINJEC)  || \
+                                               ((WATCHDOG) == ADC_ANALOGWATCHDOG_ALL_REG)          || \
+                                               ((WATCHDOG) == ADC_ANALOGWATCHDOG_ALL_INJEC)        || \
+                                               ((WATCHDOG) == ADC_ANALOGWATCHDOG_ALL_REGINJEC)       )
+
+#define IS_ADC_CONVERSION_GROUP(CONVERSION) (((CONVERSION) == ADC_REGULAR_GROUP)          || \
+                                             ((CONVERSION) == ADC_INJECTED_GROUP)         || \
+                                             ((CONVERSION) == ADC_REGULAR_INJECTED_GROUP)   )
+
+#define IS_ADC_EVENT_TYPE(EVENT) ((EVENT) == ADC_AWD_EVENT)
+
+/** @defgroup ADCEx_range_verification ADC Extended Range Verification
+  * For a unique ADC resolution: 12 bits
+  * @{
+  */
+#define IS_ADC_RANGE(ADC_VALUE) ((ADC_VALUE) <= (0x0FFFU))
+/**
+  * @}
+  */
+
+/** @defgroup ADC_injected_nb_conv_verification ADC Injected Conversion Number Verification
+  * @{
+  */
+#define IS_ADC_INJECTED_NB_CONV(LENGTH) (((LENGTH) >= (1U)) && ((LENGTH) <= (4U)))
+/**
+  * @}
+  */
+
+/** @defgroup ADC_regular_nb_conv_verification ADC Regular Conversion Number Verification
+  * @{
+  */
+#define IS_ADC_REGULAR_NB_CONV(LENGTH) (((LENGTH) >= (1U)) && ((LENGTH) <= (16U)))
+/**
+  * @}
+  */
+
+/** @defgroup ADC_regular_discontinuous_mode_number_verification ADC Regular Discontinuous Mode NumberVerification
+  * @{
+  */
+#define IS_ADC_REGULAR_DISCONT_NUMBER(NUMBER) (((NUMBER) >= (1U)) && ((NUMBER) <= (8U)))
+/**
+  * @}
+  */
+              
+#endif /* STM32F373xC || STM32F378xx */
+/**
+  * @}
+  */
+
+
+/* Exported functions --------------------------------------------------------*/  
+/** @addtogroup ADCEx_Exported_Functions ADCEx Exported Functions
+  * @{
+  */ 
+          
+/* Initialization/de-initialization functions *********************************/
+
+/** @addtogroup ADCEx_Exported_Functions_Group2 ADCEx Input and Output operation functions
+  * @{
+  */ 
+/* I/O operation functions ****************************************************/
+
+/* ADC calibration */
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+HAL_StatusTypeDef       HAL_ADCEx_Calibration_Start(struct __ADC_HandleTypeDef* hadc, uint32_t SingleDiff);
+uint32_t                HAL_ADCEx_Calibration_GetValue(struct __ADC_HandleTypeDef *hadc, uint32_t SingleDiff);
+HAL_StatusTypeDef       HAL_ADCEx_Calibration_SetValue(struct __ADC_HandleTypeDef *hadc, uint32_t SingleDiff, uint32_t CalibrationFactor);
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+
+#if defined(STM32F373xC) || defined(STM32F378xx)
+HAL_StatusTypeDef       HAL_ADCEx_Calibration_Start(struct __ADC_HandleTypeDef* hadc);
+#endif /* STM32F373xC || STM32F378xx */
+
+/* Blocking mode: Polling */
+HAL_StatusTypeDef       HAL_ADCEx_InjectedStart(struct __ADC_HandleTypeDef* hadc);
+HAL_StatusTypeDef       HAL_ADCEx_InjectedStop(struct __ADC_HandleTypeDef* hadc);
+HAL_StatusTypeDef       HAL_ADCEx_InjectedPollForConversion(struct __ADC_HandleTypeDef* hadc, uint32_t Timeout);
+
+/* Non-blocking mode: Interruption */
+HAL_StatusTypeDef       HAL_ADCEx_InjectedStart_IT(struct __ADC_HandleTypeDef* hadc);
+HAL_StatusTypeDef       HAL_ADCEx_InjectedStop_IT(struct __ADC_HandleTypeDef* hadc);
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+/* ADC multimode */
+HAL_StatusTypeDef       HAL_ADCEx_MultiModeStart_DMA(struct __ADC_HandleTypeDef *hadc, uint32_t *pData, uint32_t Length);
+HAL_StatusTypeDef       HAL_ADCEx_MultiModeStop_DMA(struct __ADC_HandleTypeDef *hadc); 
+uint32_t                HAL_ADCEx_MultiModeGetValue(struct __ADC_HandleTypeDef *hadc);
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+
+/* ADC group regular stop conversion without impacting group injected */
+/* Blocking mode: Polling */
+HAL_StatusTypeDef       HAL_ADCEx_RegularStop(struct __ADC_HandleTypeDef* hadc);
+/* Non-blocking mode: Interruption */
+HAL_StatusTypeDef       HAL_ADCEx_RegularStop_IT(struct __ADC_HandleTypeDef* hadc);
+/* Non-blocking mode: DMA */
+HAL_StatusTypeDef       HAL_ADCEx_RegularStop_DMA(struct __ADC_HandleTypeDef* hadc);
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+/* ADC multimode */
+HAL_StatusTypeDef       HAL_ADCEx_RegularMultiModeStop_DMA(struct __ADC_HandleTypeDef *hadc);
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+
+/* ADC retrieve conversion value intended to be used with polling or interruption */
+uint32_t                HAL_ADCEx_InjectedGetValue(struct __ADC_HandleTypeDef* hadc, uint32_t InjectedRank);
+
+/* ADC IRQHandler and Callbacks used in non-blocking modes (Interruption) */
+void                    HAL_ADCEx_InjectedConvCpltCallback(struct __ADC_HandleTypeDef* hadc);
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+void                    HAL_ADCEx_InjectedQueueOverflowCallback(struct __ADC_HandleTypeDef* hadc);
+void                    HAL_ADCEx_LevelOutOfWindow2Callback(struct __ADC_HandleTypeDef* hadc);
+void                    HAL_ADCEx_LevelOutOfWindow3Callback(struct __ADC_HandleTypeDef* hadc);
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+/**
+  * @}
+  */
+     
+/** @addtogroup ADCEx_Exported_Functions_Group3 ADCEx Peripheral Control functions
+  * @{
+  */ 
+/* Peripheral Control functions ***********************************************/
+HAL_StatusTypeDef       HAL_ADCEx_InjectedConfigChannel(struct __ADC_HandleTypeDef* hadc,ADC_InjectionConfTypeDef* sConfigInjected);
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+HAL_StatusTypeDef       HAL_ADCEx_MultiModeConfigChannel(struct __ADC_HandleTypeDef *hadc, ADC_MultiModeTypeDef *multimode);
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+  
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*__STM32F3xx_ADC_H */
+
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libs/HALf3/include/HALf3/stm32f3xx_hal_conf.h
+++ b/libs/HALf3/include/HALf3/stm32f3xx_hal_conf.h
@@ -33,7 +33,7 @@
   */
 
 #define HAL_MODULE_ENABLED
-  /*#define HAL_ADC_MODULE_ENABLED   */
+#define HAL_ADC_MODULE_ENABLED
 /*#define HAL_CRYP_MODULE_ENABLED   */
 #define HAL_CAN_MODULE_ENABLED
 /*#define HAL_CEC_MODULE_ENABLED   */

--- a/libs/HALf3/src/stm32f3xx_hal_adc.c
+++ b/libs/HALf3/src/stm32f3xx_hal_adc.c
@@ -1,0 +1,1214 @@
+/**
+  ******************************************************************************
+  * @file    stm32f3xx_hal_adc.c
+  * @author  MCD Application Team
+  * @brief   This file provides firmware functions to manage the following 
+  *          functionalities of the Analog to Digital Convertor (ADC)
+  *          peripheral:
+  *           + Initialization and de-initialization functions
+  *             ++ Initialization and Configuration of ADC
+  *           + Operation functions
+  *             ++ Start, stop, get result of conversions of regular
+  *                group, using 3 possible modes: polling, interruption or DMA.
+  *           + Control functions
+  *             ++ Channels configuration on regular group
+  *             ++ Channels configuration on injected group
+  *             ++ Analog Watchdog configuration
+  *           + State functions
+  *             ++ ADC state machine management
+  *             ++ Interrupts and flags management
+  *          Other functions (extended functions) are available in file 
+  *          "stm32f3xx_hal_adc_ex.c".
+  *
+  @verbatim
+  ==============================================================================
+                     ##### ADC peripheral features #####
+  ==============================================================================
+  [..] 
+  (+) 12-bit, 10-bit, 8-bit or 6-bit configurable resolution (available only on 
+      STM32F30xxC devices).
+
+  (+) Interrupt generation at the end of regular conversion, end of injected
+      conversion, and in case of analog watchdog or overrun events.
+  
+  (+) Single and continuous conversion modes.
+  
+  (+) Scan mode for conversion of several channels sequentially.
+  
+  (+) Data alignment with in-built data coherency.
+  
+  (+) Programmable sampling time (channel wise)
+  
+  (+) ADC conversion of regular group and injected group.
+
+  (+) External trigger (timer or EXTI) with configurable polarity
+      for both regular and injected groups.
+
+  (+) DMA request generation for transfer of conversions data of regular group.
+
+  (+) Multimode dual mode (available on devices with 2 ADCs or more).
+  
+  (+) Configurable DMA data storage in Multimode Dual mode (available on devices
+      with 2 DCs or more).
+  
+  (+) Configurable delay between conversions in Dual interleaved mode (available 
+      on devices with 2 DCs or more).
+  
+  (+) ADC calibration
+
+  (+) ADC channels selectable single/differential input (available only on
+      STM32F30xxC devices)
+
+  (+) ADC Injected sequencer&channels configuration context queue (available 
+      only on STM32F30xxC devices)
+
+  (+) ADC offset on injected and regular groups (offset on regular group 
+      available only on STM32F30xxC devices)
+
+  (+) ADC supply requirements: 2.4 V to 3.6 V at full speed and down to 1.8 V at 
+      slower speed.
+  
+  (+) ADC input range: from Vref- (connected to Vssa) to Vref+ (connected to 
+      Vdda or to an external voltage reference).
+
+
+                     ##### How to use this driver #####
+  ==============================================================================
+    [..]
+
+     *** Configuration of top level parameters related to ADC ***
+     ============================================================
+     [..]
+
+    (#) Enable the ADC interface
+      (++) As prerequisite, ADC clock must be configured at RCC top level.
+      
+        (++) For STM32F30x/STM32F33x devices:
+             Two possible clock sources: synchronous clock derived from AHB clock 
+             or asynchronous clock derived from ADC dedicated PLL 72MHz.
+              - Synchronous clock is mandatory since used as ADC core clock.
+                Synchronous clock can be used optionally as ADC conversion clock, depending on ADC init structure clock setting.
+                Synchronous clock is configured using macro __ADCx_CLK_ENABLE().
+              - Asynchronous can be used optionally as ADC conversion clock, depending on ADC init structure clock setting.
+                Asynchronous clock is configured using function HAL_RCCEx_PeriphCLKConfig().
+             (+++) For example, in case of device with a single ADC:
+                   Into HAL_ADC_MspInit() (recommended code location) or with
+                   other device clock parameters configuration:
+               (+++) __HAL_RCC_ADC1_CLK_ENABLE()                            (mandatory)
+               (+++) PeriphClkInit.PeriphClockSelection = RCC_PERIPHCLK_ADC (optional, if ADC conversion from asynchronous clock)
+               (+++) PeriphClkInit.Adc1ClockSelection = RCC_ADC1PLLCLK_DIV1 (optional, if ADC conversion from asynchronous clock)
+               (+++) HAL_RCCEx_PeriphCLKConfig(&RCC_PeriphClkInitStructure) (optional, if ADC conversion from asynchronous clock)
+
+             (+++) For example, in case of device with 4 ADCs:
+
+               (+++) if((hadc->Instance == ADC1) || (hadc->Instance == ADC2))   
+               (+++) {                                                          
+               (+++)   __HAL_RCC_ADC12_CLK_ENABLE()                             (mandatory)
+               (+++)   PeriphClkInit.PeriphClockSelection = RCC_PERIPHCLK_ADC   (optional, if ADC conversion from asynchronous clock)
+               (+++)   PeriphClkInit.Adc12ClockSelection = RCC_ADC12PLLCLK_DIV1 (optional, if ADC conversion from asynchronous clock)
+               (+++)   HAL_RCCEx_PeriphCLKConfig(&RCC_PeriphClkInitStructure)   (optional, if ADC conversion from asynchronous clock)
+               (+++) }                                                          
+               (+++) else                                                       
+               (+++) {                                                          
+               (+++)   __HAL_RCC_ADC34_CLK_ENABLE()                              (mandatory)
+               (+++)   PeriphClkInit.Adc34ClockSelection = RCC_ADC34PLLCLK_DIV1; (optional, if ADC conversion from asynchronous clock)
+               (+++)   HAL_RCCEx_PeriphCLKConfig(&RCC_PeriphClkInitStructure);   (optional, if ADC conversion from asynchronous clock)
+               (+++) }                                                          
+      
+        (++) For STM32F37x devices:
+             One clock setting is mandatory: 
+             ADC clock (core and conversion clock) from APB2 clock.
+             (+++) Example:
+                   Into HAL_ADC_MspInit() (recommended code location) or with
+                   other device clock parameters configuration:
+               (+++) PeriphClkInit.PeriphClockSelection = RCC_PERIPHCLK_ADC
+               (+++) PeriphClkInit.AdcClockSelection = RCC_ADCPLLCLK_DIV2
+               (+++) HAL_RCCEx_PeriphCLKConfig(&PeriphClkInit)
+
+    (#) ADC pins configuration
+         (++) Enable the clock for the ADC GPIOs
+              using macro __HAL_RCC_GPIOx_CLK_ENABLE()
+         (++) Configure these ADC pins in analog mode
+              using function HAL_GPIO_Init()
+
+    (#) Optionally, in case of usage of ADC with interruptions:
+         (++) Configure the NVIC for ADC
+              using function HAL_NVIC_EnableIRQ(ADCx_IRQn)
+         (++) Insert the ADC interruption handler function HAL_ADC_IRQHandler() 
+              into the function of corresponding ADC interruption vector 
+              ADCx_IRQHandler().
+
+    (#) Optionally, in case of usage of DMA:
+         (++) Configure the DMA (DMA channel, mode normal or circular, ...)
+              using function HAL_DMA_Init().
+         (++) Configure the NVIC for DMA
+              using function HAL_NVIC_EnableIRQ(DMAx_Channelx_IRQn)
+         (++) Insert the ADC interruption handler function HAL_ADC_IRQHandler() 
+              into the function of corresponding DMA interruption vector 
+              DMAx_Channelx_IRQHandler().
+
+     *** Configuration of ADC, groups regular/injected, channels parameters ***
+     ==========================================================================
+     [..]
+
+    (#) Configure the ADC parameters (resolution, data alignment, ...)
+        and regular group parameters (conversion trigger, sequencer, ...)
+        using function HAL_ADC_Init().
+
+    (#) Configure the channels for regular group parameters (channel number, 
+        channel rank into sequencer, ..., into regular group)
+        using function HAL_ADC_ConfigChannel().
+
+    (#) Optionally, configure the injected group parameters (conversion trigger, 
+        sequencer, ..., of injected group)
+        and the channels for injected group parameters (channel number, 
+        channel rank into sequencer, ..., into injected group)
+        using function HAL_ADCEx_InjectedConfigChannel().
+
+    (#) Optionally, configure the analog watchdog parameters (channels
+        monitored, thresholds, ...)
+        using function HAL_ADC_AnalogWDGConfig().
+
+    (#) Optionally, for devices with several ADC instances: configure the 
+        multimode parameters
+        using function HAL_ADCEx_MultiModeConfigChannel().
+
+     *** Execution of ADC conversions ***
+     ====================================
+     [..]
+
+    (#) Optionally, perform an automatic ADC calibration to improve the
+        conversion accuracy
+        using function HAL_ADCEx_Calibration_Start().
+
+    (#) ADC driver can be used among three modes: polling, interruption,
+        transfer by DMA.
+
+        (++) ADC conversion by polling:
+          (+++) Activate the ADC peripheral and start conversions
+                using function HAL_ADC_Start()
+          (+++) Wait for ADC conversion completion 
+                using function HAL_ADC_PollForConversion()
+                (or for injected group: HAL_ADCEx_InjectedPollForConversion() )
+          (+++) Retrieve conversion results 
+                using function HAL_ADC_GetValue()
+                (or for injected group: HAL_ADCEx_InjectedGetValue() )
+          (+++) Stop conversion and disable the ADC peripheral 
+                using function HAL_ADC_Stop()
+
+        (++) ADC conversion by interruption: 
+          (+++) Activate the ADC peripheral and start conversions
+                using function HAL_ADC_Start_IT()
+          (+++) Wait for ADC conversion completion by call of function
+                HAL_ADC_ConvCpltCallback()
+                (this function must be implemented in user program)
+                (or for injected group: HAL_ADCEx_InjectedConvCpltCallback() )
+          (+++) Retrieve conversion results 
+                using function HAL_ADC_GetValue()
+                (or for injected group: HAL_ADCEx_InjectedGetValue() )
+          (+++) Stop conversion and disable the ADC peripheral 
+                using function HAL_ADC_Stop_IT()
+
+        (++) ADC conversion with transfer by DMA:
+          (+++) Activate the ADC peripheral and start conversions
+                using function HAL_ADC_Start_DMA()
+          (+++) Wait for ADC conversion completion by call of function
+                HAL_ADC_ConvCpltCallback() or HAL_ADC_ConvHalfCpltCallback()
+                (these functions must be implemented in user program)
+          (+++) Conversion results are automatically transferred by DMA into
+                destination variable address.
+          (+++) Stop conversion and disable the ADC peripheral 
+                using function HAL_ADC_Stop_DMA()
+
+        (++) For devices with several ADCs: ADC multimode conversion 
+             with transfer by DMA:
+          (+++) Activate the ADC peripheral (slave)
+                using function HAL_ADC_Start()
+                (conversion start pending ADC master)
+          (+++) Activate the ADC peripheral (master) and start conversions
+                using function HAL_ADCEx_MultiModeStart_DMA()
+          (+++) Wait for ADC conversion completion by call of function
+                HAL_ADC_ConvCpltCallback() or HAL_ADC_ConvHalfCpltCallback()
+                (these functions must be implemented in user program)
+          (+++) Conversion results are automatically transferred by DMA into
+                destination variable address.
+          (+++) Stop conversion and disable the ADC peripheral (master)
+                using function HAL_ADCEx_MultiModeStop_DMA()
+          (+++) Stop conversion and disable the ADC peripheral (slave)
+                using function HAL_ADC_Stop_IT()
+
+     [..]
+
+    (@) Callback functions must be implemented in user program:
+      (+@) HAL_ADC_ErrorCallback()
+      (+@) HAL_ADC_LevelOutOfWindowCallback() (callback of analog watchdog)
+      (+@) HAL_ADC_ConvCpltCallback()
+      (+@) HAL_ADC_ConvHalfCpltCallback
+      (+@) HAL_ADCEx_InjectedConvCpltCallback()
+      (+@) HAL_ADCEx_InjectedQueueOverflowCallback() (for STM32F30x/STM32F33x devices)
+
+     *** Deinitialization of ADC ***
+     ============================================================
+     [..]
+
+    (#) Disable the ADC interface
+      (++) ADC clock can be hard reset and disabled at RCC top level.
+        (++) Hard reset of ADC peripherals
+             using macro __ADCx_FORCE_RESET(), __ADCx_RELEASE_RESET().
+        (++) ADC clock disable
+             using the equivalent macro/functions as configuration step.
+
+        (++) For STM32F30x/STM32F33x devices:
+           Caution: For devices with several ADCs:
+           These settings impact both ADC of common group: ADC1&ADC2, ADC3&ADC4
+           if available (ADC2, ADC3, ADC4 availability depends on STM32 product)
+
+             (+++) For example, in case of device with a single ADC:
+                   Into HAL_ADC_MspDeInit() (recommended code location) or with
+                   other device clock parameters configuration:
+               (+++) __HAL_RCC_ADC1_FORCE_RESET()                           (optional)
+               (+++) __HAL_RCC_ADC1_RELEASE_RESET()                         (optional)
+               (+++) __HAL_RCC_ADC1_CLK_DISABLE()                           (mandatory)
+               (+++) PeriphClkInit.PeriphClockSelection = RCC_PERIPHCLK_ADC (optional, if configured before)
+               (+++) PeriphClkInit.Adc1ClockSelection = RCC_ADC1PLLCLK_OFF  (optional, if configured before)
+               (+++) HAL_RCCEx_PeriphCLKConfig(&RCC_PeriphClkInitStructure) (optional, if configured before)
+
+             (+++) For example, in case of device with 4 ADCs:
+               (+++) if((hadc->Instance == ADC1) || (hadc->Instance == ADC2))   
+               (+++) {                                                          
+               (+++)   __HAL_RCC_ADC12_FORCE_RESET()                            (optional)
+               (+++)   __HAL_RCC_ADC12_RELEASE_RESET()                          (optional)
+               (+++)   __HAL_RCC_ADC12_CLK_DISABLE()                            (mandatory)
+               (+++)   PeriphClkInit.PeriphClockSelection = RCC_PERIPHCLK_ADC   (optional, if configured before)
+               (+++)   PeriphClkInit.Adc12ClockSelection = RCC_ADC12PLLCLK_OFF  (optional, if configured before)
+               (+++)   HAL_RCCEx_PeriphCLKConfig(&RCC_PeriphClkInitStructure)   (optional, if configured before)
+               (+++) }                                                          
+               (+++) else                                                       
+               (+++) {                                                          
+               (+++)   __HAL_RCC_ADC32_FORCE_RESET()                            (optional)
+               (+++)   __HAL_RCC_ADC32_RELEASE_RESET()                          (optional)
+               (+++)   __HAL_RCC_ADC34_CLK_DISABLE()                            (mandatory)
+               (+++)   PeriphClkInit.Adc34ClockSelection = RCC_ADC34PLLCLK_OFF  (optional, if configured before)
+               (+++)   HAL_RCCEx_PeriphCLKConfig(&RCC_PeriphClkInitStructure)   (optional, if configured before)
+               (+++) }                                                          
+      
+        (++) For STM32F37x devices:
+             (+++) Example:
+                   Into HAL_ADC_MspDeInit() (recommended code location) or with
+                   other device clock parameters configuration:
+               (+++) PeriphClkInit.PeriphClockSelection = RCC_PERIPHCLK_ADC
+               (+++) PeriphClkInit.AdcClockSelection = RCC_ADCPLLCLK_OFF
+               (+++) HAL_RCCEx_PeriphCLKConfig(&PeriphClkInit)
+
+    (#) ADC pins configuration
+         (++) Disable the clock for the ADC GPIOs
+              using macro __HAL_RCC_GPIOx_CLK_DISABLE()
+
+    (#) Optionally, in case of usage of ADC with interruptions:
+         (++) Disable the NVIC for ADC
+              using function HAL_NVIC_DisableIRQ(ADCx_IRQn)
+
+    (#) Optionally, in case of usage of DMA:
+         (++) Deinitialize the DMA
+              using function HAL_DMA_DeInit().
+         (++) Disable the NVIC for DMA
+              using function HAL_NVIC_DisableIRQ(DMAx_Channelx_IRQn)
+
+    [..]
+    
+    *** Callback registration ***
+    =============================================
+    [..]
+
+     The compilation flag USE_HAL_ADC_REGISTER_CALLBACKS, when set to 1,
+     allows the user to configure dynamically the driver callbacks.
+     Use Functions @ref HAL_ADC_RegisterCallback()
+     to register an interrupt callback.
+    [..]
+
+     Function @ref HAL_ADC_RegisterCallback() allows to register following callbacks:
+       (+) ConvCpltCallback               : ADC conversion complete callback
+       (+) ConvHalfCpltCallback           : ADC conversion DMA half-transfer callback
+       (+) LevelOutOfWindowCallback       : ADC analog watchdog 1 callback
+       (+) ErrorCallback                  : ADC error callback
+       (+) InjectedConvCpltCallback       : ADC group injected conversion complete callback
+       (+) MspInitCallback                : ADC Msp Init callback
+       (+) MspDeInitCallback              : ADC Msp DeInit callback
+     This function takes as parameters the HAL peripheral handle, the Callback ID
+     and a pointer to the user callback function.
+    [..]
+
+     Use function @ref HAL_ADC_UnRegisterCallback to reset a callback to the default
+     weak function.
+    [..]
+
+     @ref HAL_ADC_UnRegisterCallback takes as parameters the HAL peripheral handle,
+     and the Callback ID.
+     This function allows to reset following callbacks:
+       (+) ConvCpltCallback               : ADC conversion complete callback
+       (+) ConvHalfCpltCallback           : ADC conversion DMA half-transfer callback
+       (+) LevelOutOfWindowCallback       : ADC analog watchdog 1 callback
+       (+) ErrorCallback                  : ADC error callback
+       (+) InjectedConvCpltCallback       : ADC group injected conversion complete callback
+       (+) MspInitCallback                : ADC Msp Init callback
+       (+) MspDeInitCallback              : ADC Msp DeInit callback
+     [..]
+
+     By default, after the @ref HAL_ADC_Init() and when the state is @ref HAL_ADC_STATE_RESET
+     all callbacks are set to the corresponding weak functions:
+     examples @ref HAL_ADC_ConvCpltCallback(), @ref HAL_ADC_ErrorCallback().
+     Exception done for MspInit and MspDeInit functions that are
+     reset to the legacy weak functions in the @ref HAL_ADC_Init()/ @ref HAL_ADC_DeInit() only when
+     these callbacks are null (not registered beforehand).
+    [..]
+
+     If MspInit or MspDeInit are not null, the @ref HAL_ADC_Init()/ @ref HAL_ADC_DeInit()
+     keep and use the user MspInit/MspDeInit callbacks (registered beforehand) whatever the state.
+     [..]
+
+     Callbacks can be registered/unregistered in @ref HAL_ADC_STATE_READY state only.
+     Exception done MspInit/MspDeInit functions that can be registered/unregistered
+     in @ref HAL_ADC_STATE_READY or @ref HAL_ADC_STATE_RESET state,
+     thus registered (user) MspInit/DeInit callbacks can be used during the Init/DeInit.
+    [..]
+
+     Then, the user first registers the MspInit/MspDeInit user callbacks
+     using @ref HAL_ADC_RegisterCallback() before calling @ref HAL_ADC_DeInit()
+     or @ref HAL_ADC_Init() function.
+     [..]
+
+     When the compilation flag USE_HAL_ADC_REGISTER_CALLBACKS is set to 0 or
+     not defined, the callback registration feature is not available and all callbacks
+     are set to the corresponding weak functions.
+  
+    @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) 2016 STMicroelectronics.
+  * All rights reserved.</center></h2>
+  *
+  * This software component is licensed by ST under BSD 3-Clause license,
+  * the "License"; You may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at:
+  *                        opensource.org/licenses/BSD-3-Clause
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f3xx_hal.h"
+
+/** @addtogroup STM32F3xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup ADC ADC
+  * @brief ADC HAL module driver
+  * @{
+  */
+
+#ifdef HAL_ADC_MODULE_ENABLED
+    
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/
+
+/** @defgroup ADC_Exported_Functions ADC Exported Functions
+  * @{
+  */ 
+
+/** @defgroup ADC_Exported_Functions_Group1 Initialization and de-initialization functions
+ *  @brief    Initialization and Configuration functions 
+ *
+@verbatim    
+ ===============================================================================
+              ##### Initialization and de-initialization functions #####
+ ===============================================================================
+    [..]  This section provides functions allowing to:
+      (+) Initialize and configure the ADC. 
+      (+) De-initialize the ADC. 
+         
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initializes the ADC peripheral and regular group according to  
+  *         parameters specified in structure "ADC_InitTypeDef".
+  * @note   As prerequisite, ADC clock must be configured at RCC top level
+  *         depending on both possible clock sources: PLL clock or AHB clock.
+  *         See commented example code below that can be copied and uncommented 
+  *         into HAL_ADC_MspInit().
+  * @note   Possibility to update parameters on the fly:
+  *         This function initializes the ADC MSP (HAL_ADC_MspInit()) only when
+  *         coming from ADC state reset. Following calls to this function can
+  *         be used to reconfigure some parameters of ADC_InitTypeDef  
+  *         structure on the fly, without modifying MSP configuration. If ADC  
+  *         MSP has to be modified again, HAL_ADC_DeInit() must be called
+  *         before HAL_ADC_Init().
+  *         The setting of these parameters is conditioned to ADC state.
+  *         For parameters constraints, see comments of structure 
+  *         "ADC_InitTypeDef".
+  * @note   This function configures the ADC within 2 scopes: scope of entire 
+  *         ADC and scope of regular group. For parameters details, see comments 
+  *         of structure "ADC_InitTypeDef".
+  * @note   For devices with several ADCs: parameters related to common ADC 
+  *         registers (ADC clock mode) are set only if all ADCs sharing the
+  *         same common group are disabled.
+  *         If this is not the case, these common parameters setting are  
+  *         bypassed without error reporting: it can be the intended behaviour in
+  *         case of update of a parameter of ADC_InitTypeDef on the fly,
+  *         without  disabling the other ADCs sharing the same common group.
+  * @param  hadc ADC handle
+  * @retval HAL status
+  */
+__weak HAL_StatusTypeDef HAL_ADC_Init(ADC_HandleTypeDef* hadc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hadc);
+
+  /* Note : This function is defined into this file for library reference. */
+  /*        Function content is located into file stm32f3xx_hal_adc_ex.c   */
+  
+  /* Return function status */
+  return HAL_ERROR;
+}
+
+/**
+  * @brief  Deinitialize the ADC peripheral registers to their default reset
+  *         values, with deinitialization of the ADC MSP.
+  * @note   For devices with several ADCs: reset of ADC common registers is done 
+  *         only if all ADCs sharing the same common group are disabled.
+  *         If this is not the case, reset of these common parameters reset is  
+  *         bypassed without error reporting: it can be the intended behaviour in
+  *         case of reset of a single ADC while the other ADCs sharing the same 
+  *         common group is still running.
+  * @note   For devices with several ADCs: Global reset of all ADCs sharing a
+  *         common group is possible.
+  *         As this function is intended to reset a single ADC, to not impact 
+  *         other ADCs, instructions for global reset of multiple ADCs have been
+  *         let commented below.
+  *         If needed, the example code can be copied and uncommented into
+  *         function HAL_ADC_MspDeInit().
+  * @param  hadc ADC handle
+  * @retval HAL status
+  */
+__weak HAL_StatusTypeDef HAL_ADC_DeInit(ADC_HandleTypeDef* hadc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hadc);
+
+  /* Note : This function is defined into this file for library reference. */
+  /*        Function content is located into file stm32f3xx_hal_adc_ex.c   */
+  
+  /* Return function status */
+  return HAL_ERROR;
+}
+    
+/**
+  * @brief  Initializes the ADC MSP.
+  * @param  hadc ADC handle
+  * @retval None
+  */
+__weak void HAL_ADC_MspInit(ADC_HandleTypeDef* hadc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hadc);
+
+  /* NOTE : This function should not be modified. When the callback is needed,
+            function HAL_ADC_MspInit must be implemented in the user file.
+   */ 
+}
+
+/**
+  * @brief  DeInitializes the ADC MSP.
+  * @param  hadc ADC handle
+  * @retval None
+  */
+__weak void HAL_ADC_MspDeInit(ADC_HandleTypeDef* hadc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hadc);
+
+  /* NOTE : This function should not be modified. When the callback is needed,
+            function HAL_ADC_MspDeInit must be implemented in the user file.
+   */ 
+}
+
+#if (USE_HAL_ADC_REGISTER_CALLBACKS == 1)
+/**
+  * @brief  Register a User ADC Callback
+  *         To be used instead of the weak predefined callback
+  * @param  hadc Pointer to a ADC_HandleTypeDef structure that contains
+  *                the configuration information for the specified ADC.
+  * @param  CallbackID ID of the callback to be registered
+  *         This parameter can be one of the following values:
+  *          @arg @ref HAL_ADC_CONVERSION_COMPLETE_CB_ID      ADC conversion complete callback ID
+  *          @arg @ref HAL_ADC_CONVERSION_HALF_CB_ID          ADC conversion complete callback ID
+  *          @arg @ref HAL_ADC_LEVEL_OUT_OF_WINDOW_1_CB_ID    ADC analog watchdog 1 callback ID
+  *          @arg @ref HAL_ADC_ERROR_CB_ID                    ADC error callback ID
+  *          @arg @ref HAL_ADC_INJ_CONVERSION_COMPLETE_CB_ID  ADC group injected conversion complete callback ID
+  *          @arg @ref HAL_ADC_MSPINIT_CB_ID                  ADC Msp Init callback ID
+  *          @arg @ref HAL_ADC_MSPDEINIT_CB_ID                ADC Msp DeInit callback ID
+  *          @arg @ref HAL_ADC_MSPINIT_CB_ID MspInit callback ID
+  *          @arg @ref HAL_ADC_MSPDEINIT_CB_ID MspDeInit callback ID
+  * @param  pCallback pointer to the Callback function
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADC_RegisterCallback(ADC_HandleTypeDef *hadc, HAL_ADC_CallbackIDTypeDef CallbackID, pADC_CallbackTypeDef pCallback)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+  
+  if (pCallback == NULL)
+  {
+    /* Update the error code */
+    hadc->ErrorCode |= HAL_ADC_ERROR_INVALID_CALLBACK;
+
+    return HAL_ERROR;
+  }
+  
+  if ((hadc->State & HAL_ADC_STATE_READY) != 0)
+  {
+    switch (CallbackID)
+    {
+      case HAL_ADC_CONVERSION_COMPLETE_CB_ID :
+        hadc->ConvCpltCallback = pCallback;
+        break;
+      
+      case HAL_ADC_CONVERSION_HALF_CB_ID :
+        hadc->ConvHalfCpltCallback = pCallback;
+        break;
+      
+      case HAL_ADC_LEVEL_OUT_OF_WINDOW_1_CB_ID :
+        hadc->LevelOutOfWindowCallback = pCallback;
+        break;
+      
+      case HAL_ADC_ERROR_CB_ID :
+        hadc->ErrorCallback = pCallback;
+        break;
+      
+      case HAL_ADC_INJ_CONVERSION_COMPLETE_CB_ID :
+        hadc->InjectedConvCpltCallback = pCallback;
+        break;
+      
+      case HAL_ADC_MSPINIT_CB_ID :
+        hadc->MspInitCallback = pCallback;
+        break;
+      
+      case HAL_ADC_MSPDEINIT_CB_ID :
+        hadc->MspDeInitCallback = pCallback;
+        break;
+      
+      default :
+        /* Update the error code */
+        hadc->ErrorCode |= HAL_ADC_ERROR_INVALID_CALLBACK;
+
+        /* Return error status */
+        status = HAL_ERROR;
+        break;
+    }
+  }
+  else if (HAL_ADC_STATE_RESET == hadc->State)
+  {
+    switch (CallbackID)
+    {
+      case HAL_ADC_MSPINIT_CB_ID :
+        hadc->MspInitCallback = pCallback;
+        break;
+      
+      case HAL_ADC_MSPDEINIT_CB_ID :
+        hadc->MspDeInitCallback = pCallback;
+        break;
+      
+      default :
+        /* Update the error code */
+        hadc->ErrorCode |= HAL_ADC_ERROR_INVALID_CALLBACK;
+      
+        /* Return error status */
+        status = HAL_ERROR;
+        break;
+    }
+  }
+  else
+  {
+    /* Update the error code */
+    hadc->ErrorCode |= HAL_ADC_ERROR_INVALID_CALLBACK;
+    
+    /* Return error status */
+    status =  HAL_ERROR;
+  }
+  
+  return status;
+}
+
+/**
+  * @brief  Unregister a ADC Callback
+  *         ADC callback is redirected to the weak predefined callback
+  * @param  hadc Pointer to a ADC_HandleTypeDef structure that contains
+  *                the configuration information for the specified ADC.
+  * @param  CallbackID ID of the callback to be unregistered
+  *         This parameter can be one of the following values:
+  *          @arg @ref HAL_ADC_CONVERSION_COMPLETE_CB_ID      ADC conversion complete callback ID
+  *          @arg @ref HAL_ADC_CONVERSION_HALF_CB_ID          ADC conversion complete callback ID
+  *          @arg @ref HAL_ADC_LEVEL_OUT_OF_WINDOW_1_CB_ID    ADC analog watchdog 1 callback ID
+  *          @arg @ref HAL_ADC_ERROR_CB_ID                    ADC error callback ID
+  *          @arg @ref HAL_ADC_INJ_CONVERSION_COMPLETE_CB_ID  ADC group injected conversion complete callback ID
+  *          @arg @ref HAL_ADC_MSPINIT_CB_ID                  ADC Msp Init callback ID
+  *          @arg @ref HAL_ADC_MSPDEINIT_CB_ID                ADC Msp DeInit callback ID
+  *          @arg @ref HAL_ADC_MSPINIT_CB_ID MspInit callback ID
+  *          @arg @ref HAL_ADC_MSPDEINIT_CB_ID MspDeInit callback ID
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADC_UnRegisterCallback(ADC_HandleTypeDef *hadc, HAL_ADC_CallbackIDTypeDef CallbackID)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+  
+  if ((hadc->State & HAL_ADC_STATE_READY) != 0)
+  {
+    switch (CallbackID)
+    {
+      case HAL_ADC_CONVERSION_COMPLETE_CB_ID :
+        hadc->ConvCpltCallback = HAL_ADC_ConvCpltCallback;
+        break;
+      
+      case HAL_ADC_CONVERSION_HALF_CB_ID :
+        hadc->ConvHalfCpltCallback = HAL_ADC_ConvHalfCpltCallback;
+        break;
+      
+      case HAL_ADC_LEVEL_OUT_OF_WINDOW_1_CB_ID :
+        hadc->LevelOutOfWindowCallback = HAL_ADC_LevelOutOfWindowCallback;
+        break;
+      
+      case HAL_ADC_ERROR_CB_ID :
+        hadc->ErrorCallback = HAL_ADC_ErrorCallback;
+        break;
+      
+      case HAL_ADC_INJ_CONVERSION_COMPLETE_CB_ID :
+        hadc->InjectedConvCpltCallback = HAL_ADCEx_InjectedConvCpltCallback;
+        break;
+      
+      case HAL_ADC_MSPINIT_CB_ID :
+        hadc->MspInitCallback = HAL_ADC_MspInit; /* Legacy weak MspInit              */
+        break;
+      
+      case HAL_ADC_MSPDEINIT_CB_ID :
+        hadc->MspDeInitCallback = HAL_ADC_MspDeInit; /* Legacy weak MspDeInit            */
+        break;
+      
+      default :
+        /* Update the error code */
+        hadc->ErrorCode |= HAL_ADC_ERROR_INVALID_CALLBACK;
+        
+        /* Return error status */
+        status =  HAL_ERROR;
+        break;
+    }
+  }
+  else if (HAL_ADC_STATE_RESET == hadc->State)
+  {
+    switch (CallbackID)
+    {
+      case HAL_ADC_MSPINIT_CB_ID :
+        hadc->MspInitCallback = HAL_ADC_MspInit;                   /* Legacy weak MspInit              */
+        break;
+        
+      case HAL_ADC_MSPDEINIT_CB_ID :
+        hadc->MspDeInitCallback = HAL_ADC_MspDeInit;               /* Legacy weak MspDeInit            */
+        break;
+        
+      default :
+        /* Update the error code */
+        hadc->ErrorCode |= HAL_ADC_ERROR_INVALID_CALLBACK;
+        
+        /* Return error status */
+        status =  HAL_ERROR;
+        break;
+    }
+  }
+  else
+  {
+    /* Update the error code */
+    hadc->ErrorCode |= HAL_ADC_ERROR_INVALID_CALLBACK;
+    
+    /* Return error status */
+    status =  HAL_ERROR;
+  }
+  
+  return status;
+}
+
+#endif /* USE_HAL_ADC_REGISTER_CALLBACKS */
+
+/**
+  * @}
+  */
+
+/** @defgroup ADC_Exported_Functions_Group2 Input and Output operation functions
+ *  @brief    IO operation functions 
+ *
+@verbatim   
+ ===============================================================================
+             ##### IO operation functions #####
+ ===============================================================================  
+    [..]  This section provides functions allowing to:
+      (+) Start conversion of regular group.
+      (+) Stop conversion of regular group.
+      (+) Poll for conversion complete on regular group.
+      (+) Poll for conversion event.
+      (+) Get result of regular channel conversion.
+      (+) Start conversion of regular group and enable interruptions.
+      (+) Stop conversion of regular group and disable interruptions.
+      (+) Handle ADC interrupt request
+      (+) Start conversion of regular group and enable DMA transfer.
+      (+) Stop conversion of regular group and disable ADC DMA transfer.
+               
+@endverbatim
+  * @{
+  */
+/**
+  * @brief  Enables ADC, starts conversion of regular group.
+  *         Interruptions enabled in this function: None.
+  * @note:  Case of multimode enabled (for devices with several ADCs): This 
+  *         function must be called for ADC slave first, then ADC master. 
+  *         For ADC slave, ADC is enabled only (conversion is not started).  
+  *         For ADC master, ADC is enabled and multimode conversion is started.
+  * @param  hadc ADC handle
+  * @retval HAL status
+  */
+__weak HAL_StatusTypeDef HAL_ADC_Start(ADC_HandleTypeDef* hadc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hadc);
+
+  /* Return function status */
+  return HAL_ERROR;
+}
+
+/**
+  * @brief  Stop ADC conversion of regular group (and injected group in 
+  *         case of auto_injection mode), disable ADC peripheral.
+  * @note:  ADC peripheral disable is forcing stop of potential 
+  *         conversion on injected group. If injected group is under use, it
+  *         should be preliminarily stopped using HAL_ADCEx_InjectedStop function.
+  * @note:  Case of multimode enabled (for devices with several ADCs): This 
+  *         function must be called for ADC master first, then ADC slave.
+  *         For ADC master, converson is stopped and ADC is disabled. 
+  *         For ADC slave, ADC is disabled only (conversion stop of ADC master
+  *         has already stopped conversion of ADC slave).
+  * @param  hadc ADC handle
+  * @retval HAL status.
+  */
+__weak HAL_StatusTypeDef HAL_ADC_Stop(ADC_HandleTypeDef* hadc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hadc);
+
+  /* Note : This function is defined into this file for library reference. */
+  /*        Function content is located into file stm32f3xx_hal_adc_ex.c   */
+  
+  /* Return function status */
+  return HAL_ERROR;
+}
+
+/**
+  * @brief  Wait for regular group conversion to be completed.
+  * @param  hadc ADC handle
+  * @param  Timeout Timeout value in millisecond.
+  * @retval HAL status
+  */
+__weak HAL_StatusTypeDef HAL_ADC_PollForConversion(ADC_HandleTypeDef* hadc, uint32_t Timeout)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hadc);
+  UNUSED(Timeout);
+
+  /* Note : This function is defined into this file for library reference. */
+  /*        Function content is located into file stm32f3xx_hal_adc_ex.c   */
+  
+  /* Return function status */
+  return HAL_ERROR;
+}
+
+/**
+  * @brief  Poll for conversion event.
+  * @param  hadc ADC handle
+  * @param  EventType the ADC event type.
+  *          This parameter can be one of the following values:
+  *            @arg ADC_AWD_EVENT: ADC Analog watchdog 1 event (main analog watchdog, present on all STM32 devices)
+  *            @arg ADC_AWD2_EVENT: ADC Analog watchdog 2 event (additional analog watchdog, present only on STM32F3 devices)
+  *            @arg ADC_AWD3_EVENT: ADC Analog watchdog 3 event (additional analog watchdog, present only on STM32F3 devices)
+  *            @arg ADC_OVR_EVENT: ADC Overrun event
+  *            @arg ADC_JQOVF_EVENT: ADC Injected context queue overflow event
+  * @param  Timeout Timeout value in millisecond.
+  * @retval HAL status
+  */
+__weak HAL_StatusTypeDef HAL_ADC_PollForEvent(ADC_HandleTypeDef* hadc, uint32_t EventType, uint32_t Timeout)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hadc);
+  UNUSED(EventType);
+  UNUSED(Timeout);
+
+  /* Note : This function is defined into this file for library reference. */
+  /*        Function content is located into file stm32f3xx_hal_adc_ex.c   */
+  
+  /* Return function status */
+  return HAL_ERROR;
+}
+
+/**
+  * @brief  Enables ADC, starts conversion of regular group with interruption.
+  *         Interruptions enabled in this function:
+  *          - EOC (end of conversion of regular group) or EOS (end of 
+  *            sequence of regular group) depending on ADC initialization 
+  *            parameter "EOCSelection" (if available)
+  *          - overrun (if available)
+  *         Each of these interruptions has its dedicated callback function.
+  * @note:  Case of multimode enabled (for devices with several ADCs): This 
+  *         function must be called for ADC slave first, then ADC master. 
+  *         For ADC slave, ADC is enabled only (conversion is not started).  
+  *         For ADC master, ADC is enabled and multimode conversion is started.
+  * @param  hadc ADC handle
+  * @retval HAL status
+  */
+__weak HAL_StatusTypeDef HAL_ADC_Start_IT(ADC_HandleTypeDef* hadc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hadc);
+
+  /* Note : This function is defined into this file for library reference. */
+  /*        Function content is located into file stm32f3xx_hal_adc_ex.c   */
+  
+  /* Return function status */
+  return HAL_ERROR;
+}
+
+/**
+  * @brief  Stop ADC conversion of regular group (and injected group in 
+  *         case of auto_injection mode), disable interruption of 
+  *         end-of-conversion, disable ADC peripheral.
+  * @note:  ADC peripheral disable is forcing stop of potential 
+  *         conversion on injected group. If injected group is under use, it
+  *         should be preliminarily stopped using HAL_ADCEx_InjectedStop function.
+  * @note:  Case of multimode enabled (for devices with several ADCs): This 
+  *         function must be called for ADC master first, then ADC slave.
+  *         For ADC master, conversion is stopped and ADC is disabled. 
+  *         For ADC slave, ADC is disabled only (conversion stop of ADC master
+  *         has already stopped conversion of ADC slave).
+  * @param  hadc ADC handle
+  * @retval HAL status.
+  */
+__weak HAL_StatusTypeDef HAL_ADC_Stop_IT(ADC_HandleTypeDef* hadc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hadc);
+
+  /* Note : This function is defined into this file for library reference. */
+  /*        Function content is located into file stm32f3xx_hal_adc_ex.c   */
+  
+  /* Return function status */
+  return HAL_ERROR;
+}
+
+/**
+  * @brief  Enables ADC, starts conversion of regular group and transfers result
+  *         through DMA.
+  *         Interruptions enabled in this function:
+  *          - DMA transfer complete
+  *          - DMA half transfer
+  *          - overrun (if available)
+  *         Each of these interruptions has its dedicated callback function.
+  * @note:  Case of multimode enabled (for devices with several ADCs): This 
+  *         function is for single-ADC mode only. For multimode, use the 
+  *         dedicated MultimodeStart function.
+  * @param  hadc ADC handle
+  * @param  pData The destination Buffer address.
+  * @param  Length The length of data to be transferred from ADC peripheral to memory.
+  * @retval None
+  */
+__weak HAL_StatusTypeDef HAL_ADC_Start_DMA(ADC_HandleTypeDef* hadc, uint32_t* pData, uint32_t Length)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hadc);
+  UNUSED(pData);
+  UNUSED(Length);
+
+  /* Note : This function is defined into this file for library reference. */
+  /*        Function content is located into file stm32f3xx_hal_adc_ex.c   */
+  
+  /* Return function status */
+  return HAL_ERROR;
+}
+
+/**
+  * @brief  Stop ADC conversion of regular group (and injected group in 
+  *         case of auto_injection mode), disable ADC DMA transfer, disable 
+  *         ADC peripheral.
+  * @note:  ADC peripheral disable is forcing stop of potential 
+  *         conversion on injected group. If injected group is under use, it
+  *         should be preliminarily stopped using HAL_ADCEx_InjectedStop function.
+  * @note:  Case of multimode enabled (for devices with several ADCs): This 
+  *         function is for single-ADC mode only. For multimode, use the 
+  *         dedicated MultimodeStop function.
+  * @param  hadc ADC handle
+  * @retval HAL status.
+  */
+__weak HAL_StatusTypeDef HAL_ADC_Stop_DMA(ADC_HandleTypeDef* hadc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hadc);
+
+  /* Note : This function is defined into this file for library reference. */
+  /*        Function content is located into file stm32f3xx_hal_adc_ex.c   */
+  
+  /* Return function status */
+  return HAL_ERROR;
+}
+
+/**
+  * @brief  Get ADC regular group conversion result.
+  * @note   Reading DR register automatically clears EOC (end of conversion of
+  *         regular group) flag.
+  *         Additionally, this functions clears EOS (end of sequence of
+  *         regular group) flag, in case of the end of the sequence is reached.
+  * @param  hadc ADC handle
+  * @retval Converted value
+  */
+__weak uint32_t HAL_ADC_GetValue(ADC_HandleTypeDef* hadc)
+{
+  /* Note : This function is defined into this file for library reference. */
+  /*        Function content is located into file stm32f3xx_hal_adc_ex.c   */
+  
+  /* Return ADC converted value */ 
+  return hadc->Instance->DR;
+}
+
+/**
+  * @brief  Handles ADC interrupt request.  
+  * @param  hadc ADC handle
+  * @retval None
+  */
+__weak void HAL_ADC_IRQHandler(ADC_HandleTypeDef* hadc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hadc);
+
+  /* Note : This function is defined into this file for library reference. */
+  /*        Function content is located into file stm32f3xx_hal_adc_ex.c   */
+}
+
+/**
+  * @brief  Conversion complete callback in non blocking mode 
+  * @param  hadc ADC handle
+  * @retval None
+  */
+__weak void HAL_ADC_ConvCpltCallback(ADC_HandleTypeDef* hadc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hadc);
+
+  /* NOTE : This function should not be modified. When the callback is needed,
+            function HAL_ADC_ConvCpltCallback must be implemented in the user file.
+   */
+}
+
+/**
+  * @brief  Conversion DMA half-transfer callback in non blocking mode 
+  * @param  hadc ADC handle
+  * @retval None
+  */
+__weak void HAL_ADC_ConvHalfCpltCallback(ADC_HandleTypeDef* hadc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hadc);
+
+  /* NOTE : This function should not be modified. When the callback is needed,
+            function HAL_ADC_ConvHalfCpltCallback must be implemented in the user file.
+  */
+}
+
+/**
+  * @brief  Analog watchdog callback in non blocking mode. 
+  * @param  hadc ADC handle
+  * @retval None
+  */
+__weak void HAL_ADC_LevelOutOfWindowCallback(ADC_HandleTypeDef* hadc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hadc);
+
+  /* NOTE : This function should not be modified. When the callback is needed,
+            function HAL_ADC_LevelOoutOfWindowCallback must be implemented in the user file.
+  */
+}
+
+/**
+  * @brief  ADC error callback in non blocking mode
+  *        (ADC conversion with interruption or transfer by DMA)
+  * @param  hadc ADC handle
+  * @retval None
+  */
+__weak void HAL_ADC_ErrorCallback(ADC_HandleTypeDef *hadc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hadc);
+
+  /* NOTE : This function should not be modified. When the callback is needed,
+            function HAL_ADC_ErrorCallback must be implemented in the user file.
+  */
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup ADC_Exported_Functions_Group3 Peripheral Control functions
+ *  @brief    Peripheral Control functions 
+ *
+@verbatim   
+ ===============================================================================
+             ##### Peripheral Control functions #####
+ ===============================================================================  
+    [..]  This section provides functions allowing to:
+      (+) Configure channels on regular group
+      (+) Configure the analog watchdog
+      
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Configures the the selected channel to be linked to the regular
+  *         group.
+  * @note   In case of usage of internal measurement channels:
+  *         Vbat/VrefInt/TempSensor.
+  *         The recommended sampling time is at least:
+  *          - For devices STM32F37x: 17.1us for temperature sensor
+  *          - For the other STM32F3 devices: 2.2us for each of channels 
+  *            Vbat/VrefInt/TempSensor.
+  *         These internal paths can be be disabled using function 
+  *         HAL_ADC_DeInit().
+  * @note   Possibility to update parameters on the fly:
+  *         This function initializes channel into regular group, following  
+  *         calls to this function can be used to reconfigure some parameters 
+  *         of structure "ADC_ChannelConfTypeDef" on the fly, without reseting 
+  *         the ADC.
+  *         The setting of these parameters is conditioned to ADC state.
+  *         For parameters constraints, see comments of structure 
+  *         "ADC_ChannelConfTypeDef".
+  * @param  hadc ADC handle
+  * @param  sConfig Structure of ADC channel for regular group.
+  * @retval HAL status
+  */
+__weak HAL_StatusTypeDef HAL_ADC_ConfigChannel(ADC_HandleTypeDef* hadc, ADC_ChannelConfTypeDef* sConfig)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hadc);
+  UNUSED(sConfig);
+
+  /* Note : This function is defined into this file for library reference. */
+  /*        Function content is located into file stm32f3xx_hal_adc_ex.c   */
+  
+  /* Return function status */
+  return HAL_ERROR;
+}
+
+/**
+  * @brief  Configures the analog watchdog.
+  * @note   Possibility to update parameters on the fly:
+  *         This function initializes the selected analog watchdog, following  
+  *         calls to this function can be used to reconfigure some parameters 
+  *         of structure "ADC_AnalogWDGConfTypeDef" on the fly, without reseting 
+  *         the ADC.
+  *         The setting of these parameters is conditioned to ADC state.
+  *         For parameters constraints, see comments of structure 
+  *         "ADC_AnalogWDGConfTypeDef".
+  * @param  hadc ADC handle
+  * @param  AnalogWDGConfig Structure of ADC analog watchdog configuration
+  * @retval HAL status
+  */
+__weak HAL_StatusTypeDef HAL_ADC_AnalogWDGConfig(ADC_HandleTypeDef* hadc, ADC_AnalogWDGConfTypeDef* AnalogWDGConfig)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hadc);
+  UNUSED(AnalogWDGConfig);
+
+  /* Note : This function is defined into this file for library reference. */
+  /*        Function content is located into file stm32f3xx_hal_adc_ex.c   */
+  
+  /* Return function status */
+  return HAL_ERROR;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup ADC_Exported_Functions_Group4 Peripheral State functions
+ *  @brief   ADC Peripheral State functions 
+ *
+@verbatim   
+ ===============================================================================
+            ##### Peripheral state and errors functions #####
+ ===============================================================================
+    [..]
+    This subsection provides functions to get in run-time the status of the  
+    peripheral.
+      (+) Check the ADC state
+      (+) Check the ADC error code
+         
+@endverbatim
+  * @{
+  */
+  
+/**
+  * @brief  return the ADC state
+  * @note   ADC state machine is managed by bitfield, state must be compared
+  *         with bit by bit.
+  *         For example:                                                         
+  *           " if (HAL_IS_BIT_SET(HAL_ADC_GetState(hadc1), HAL_ADC_STATE_REG_BUSY)) "
+  *           " if (HAL_IS_BIT_SET(HAL_ADC_GetState(hadc1), HAL_ADC_STATE_AWD1)    ) "
+  * @param  hadc ADC handle
+  * @retval HAL state
+  */
+uint32_t HAL_ADC_GetState(ADC_HandleTypeDef* hadc)
+{
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  
+  /* Return ADC state */
+  return hadc->State;
+}
+
+/**
+  * @brief  Return the ADC error code
+  * @param  hadc ADC handle
+  * @retval ADC Error Code
+  */
+uint32_t HAL_ADC_GetError(ADC_HandleTypeDef *hadc)
+{
+  return hadc->ErrorCode;
+}
+
+/**
+  * @}
+  */
+       
+/**
+  * @}
+  */
+
+#endif /* HAL_ADC_MODULE_ENABLED */
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libs/HALf3/src/stm32f3xx_hal_adc.c
+++ b/libs/HALf3/src/stm32f3xx_hal_adc.c
@@ -2,7 +2,7 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_adc.c
   * @author  MCD Application Team
-  * @brief   This file provides firmware functions to manage the following 
+  * @brief   This file provides firmware functions to manage the following
   *          functionalities of the Analog to Digital Convertor (ADC)
   *          peripheral:
   *           + Initialization and de-initialization functions
@@ -17,28 +17,28 @@
   *           + State functions
   *             ++ ADC state machine management
   *             ++ Interrupts and flags management
-  *          Other functions (extended functions) are available in file 
+  *          Other functions (extended functions) are available in file
   *          "stm32f3xx_hal_adc_ex.c".
   *
   @verbatim
   ==============================================================================
                      ##### ADC peripheral features #####
   ==============================================================================
-  [..] 
-  (+) 12-bit, 10-bit, 8-bit or 6-bit configurable resolution (available only on 
+  [..]
+  (+) 12-bit, 10-bit, 8-bit or 6-bit configurable resolution (available only on
       STM32F30xxC devices).
 
   (+) Interrupt generation at the end of regular conversion, end of injected
       conversion, and in case of analog watchdog or overrun events.
-  
+
   (+) Single and continuous conversion modes.
-  
+
   (+) Scan mode for conversion of several channels sequentially.
-  
+
   (+) Data alignment with in-built data coherency.
-  
+
   (+) Programmable sampling time (channel wise)
-  
+
   (+) ADC conversion of regular group and injected group.
 
   (+) External trigger (timer or EXTI) with configurable polarity
@@ -47,28 +47,28 @@
   (+) DMA request generation for transfer of conversions data of regular group.
 
   (+) Multimode dual mode (available on devices with 2 ADCs or more).
-  
+
   (+) Configurable DMA data storage in Multimode Dual mode (available on devices
       with 2 DCs or more).
-  
-  (+) Configurable delay between conversions in Dual interleaved mode (available 
+
+  (+) Configurable delay between conversions in Dual interleaved mode (available
       on devices with 2 DCs or more).
-  
+
   (+) ADC calibration
 
   (+) ADC channels selectable single/differential input (available only on
       STM32F30xxC devices)
 
-  (+) ADC Injected sequencer&channels configuration context queue (available 
+  (+) ADC Injected sequencer&channels configuration context queue (available
       only on STM32F30xxC devices)
 
-  (+) ADC offset on injected and regular groups (offset on regular group 
+  (+) ADC offset on injected and regular groups (offset on regular group
       available only on STM32F30xxC devices)
 
-  (+) ADC supply requirements: 2.4 V to 3.6 V at full speed and down to 1.8 V at 
+  (+) ADC supply requirements: 2.4 V to 3.6 V at full speed and down to 1.8 V at
       slower speed.
-  
-  (+) ADC input range: from Vref- (connected to Vssa) to Vref+ (connected to 
+
+  (+) ADC input range: from Vref- (connected to Vssa) to Vref+ (connected to
       Vdda or to an external voltage reference).
 
 
@@ -82,9 +82,9 @@
 
     (#) Enable the ADC interface
       (++) As prerequisite, ADC clock must be configured at RCC top level.
-      
+
         (++) For STM32F30x/STM32F33x devices:
-             Two possible clock sources: synchronous clock derived from AHB clock 
+             Two possible clock sources: synchronous clock derived from AHB clock
              or asynchronous clock derived from ADC dedicated PLL 72MHz.
               - Synchronous clock is mandatory since used as ADC core clock.
                 Synchronous clock can be used optionally as ADC conversion clock, depending on ADC init structure clock setting.
@@ -101,22 +101,22 @@
 
              (+++) For example, in case of device with 4 ADCs:
 
-               (+++) if((hadc->Instance == ADC1) || (hadc->Instance == ADC2))   
-               (+++) {                                                          
+               (+++) if((hadc->Instance == ADC1) || (hadc->Instance == ADC2))
+               (+++) {
                (+++)   __HAL_RCC_ADC12_CLK_ENABLE()                             (mandatory)
                (+++)   PeriphClkInit.PeriphClockSelection = RCC_PERIPHCLK_ADC   (optional, if ADC conversion from asynchronous clock)
                (+++)   PeriphClkInit.Adc12ClockSelection = RCC_ADC12PLLCLK_DIV1 (optional, if ADC conversion from asynchronous clock)
                (+++)   HAL_RCCEx_PeriphCLKConfig(&RCC_PeriphClkInitStructure)   (optional, if ADC conversion from asynchronous clock)
-               (+++) }                                                          
-               (+++) else                                                       
-               (+++) {                                                          
+               (+++) }
+               (+++) else
+               (+++) {
                (+++)   __HAL_RCC_ADC34_CLK_ENABLE()                              (mandatory)
                (+++)   PeriphClkInit.Adc34ClockSelection = RCC_ADC34PLLCLK_DIV1; (optional, if ADC conversion from asynchronous clock)
                (+++)   HAL_RCCEx_PeriphCLKConfig(&RCC_PeriphClkInitStructure);   (optional, if ADC conversion from asynchronous clock)
-               (+++) }                                                          
-      
+               (+++) }
+
         (++) For STM32F37x devices:
-             One clock setting is mandatory: 
+             One clock setting is mandatory:
              ADC clock (core and conversion clock) from APB2 clock.
              (+++) Example:
                    Into HAL_ADC_MspInit() (recommended code location) or with
@@ -134,8 +134,8 @@
     (#) Optionally, in case of usage of ADC with interruptions:
          (++) Configure the NVIC for ADC
               using function HAL_NVIC_EnableIRQ(ADCx_IRQn)
-         (++) Insert the ADC interruption handler function HAL_ADC_IRQHandler() 
-              into the function of corresponding ADC interruption vector 
+         (++) Insert the ADC interruption handler function HAL_ADC_IRQHandler()
+              into the function of corresponding ADC interruption vector
               ADCx_IRQHandler().
 
     (#) Optionally, in case of usage of DMA:
@@ -143,8 +143,8 @@
               using function HAL_DMA_Init().
          (++) Configure the NVIC for DMA
               using function HAL_NVIC_EnableIRQ(DMAx_Channelx_IRQn)
-         (++) Insert the ADC interruption handler function HAL_ADC_IRQHandler() 
-              into the function of corresponding DMA interruption vector 
+         (++) Insert the ADC interruption handler function HAL_ADC_IRQHandler()
+              into the function of corresponding DMA interruption vector
               DMAx_Channelx_IRQHandler().
 
      *** Configuration of ADC, groups regular/injected, channels parameters ***
@@ -155,13 +155,13 @@
         and regular group parameters (conversion trigger, sequencer, ...)
         using function HAL_ADC_Init().
 
-    (#) Configure the channels for regular group parameters (channel number, 
+    (#) Configure the channels for regular group parameters (channel number,
         channel rank into sequencer, ..., into regular group)
         using function HAL_ADC_ConfigChannel().
 
-    (#) Optionally, configure the injected group parameters (conversion trigger, 
+    (#) Optionally, configure the injected group parameters (conversion trigger,
         sequencer, ..., of injected group)
-        and the channels for injected group parameters (channel number, 
+        and the channels for injected group parameters (channel number,
         channel rank into sequencer, ..., into injected group)
         using function HAL_ADCEx_InjectedConfigChannel().
 
@@ -169,7 +169,7 @@
         monitored, thresholds, ...)
         using function HAL_ADC_AnalogWDGConfig().
 
-    (#) Optionally, for devices with several ADC instances: configure the 
+    (#) Optionally, for devices with several ADC instances: configure the
         multimode parameters
         using function HAL_ADCEx_MultiModeConfigChannel().
 
@@ -187,26 +187,26 @@
         (++) ADC conversion by polling:
           (+++) Activate the ADC peripheral and start conversions
                 using function HAL_ADC_Start()
-          (+++) Wait for ADC conversion completion 
+          (+++) Wait for ADC conversion completion
                 using function HAL_ADC_PollForConversion()
                 (or for injected group: HAL_ADCEx_InjectedPollForConversion() )
-          (+++) Retrieve conversion results 
+          (+++) Retrieve conversion results
                 using function HAL_ADC_GetValue()
                 (or for injected group: HAL_ADCEx_InjectedGetValue() )
-          (+++) Stop conversion and disable the ADC peripheral 
+          (+++) Stop conversion and disable the ADC peripheral
                 using function HAL_ADC_Stop()
 
-        (++) ADC conversion by interruption: 
+        (++) ADC conversion by interruption:
           (+++) Activate the ADC peripheral and start conversions
                 using function HAL_ADC_Start_IT()
           (+++) Wait for ADC conversion completion by call of function
                 HAL_ADC_ConvCpltCallback()
                 (this function must be implemented in user program)
                 (or for injected group: HAL_ADCEx_InjectedConvCpltCallback() )
-          (+++) Retrieve conversion results 
+          (+++) Retrieve conversion results
                 using function HAL_ADC_GetValue()
                 (or for injected group: HAL_ADCEx_InjectedGetValue() )
-          (+++) Stop conversion and disable the ADC peripheral 
+          (+++) Stop conversion and disable the ADC peripheral
                 using function HAL_ADC_Stop_IT()
 
         (++) ADC conversion with transfer by DMA:
@@ -217,10 +217,10 @@
                 (these functions must be implemented in user program)
           (+++) Conversion results are automatically transferred by DMA into
                 destination variable address.
-          (+++) Stop conversion and disable the ADC peripheral 
+          (+++) Stop conversion and disable the ADC peripheral
                 using function HAL_ADC_Stop_DMA()
 
-        (++) For devices with several ADCs: ADC multimode conversion 
+        (++) For devices with several ADCs: ADC multimode conversion
              with transfer by DMA:
           (+++) Activate the ADC peripheral (slave)
                 using function HAL_ADC_Start()
@@ -274,24 +274,24 @@
                (+++) HAL_RCCEx_PeriphCLKConfig(&RCC_PeriphClkInitStructure) (optional, if configured before)
 
              (+++) For example, in case of device with 4 ADCs:
-               (+++) if((hadc->Instance == ADC1) || (hadc->Instance == ADC2))   
-               (+++) {                                                          
+               (+++) if((hadc->Instance == ADC1) || (hadc->Instance == ADC2))
+               (+++) {
                (+++)   __HAL_RCC_ADC12_FORCE_RESET()                            (optional)
                (+++)   __HAL_RCC_ADC12_RELEASE_RESET()                          (optional)
                (+++)   __HAL_RCC_ADC12_CLK_DISABLE()                            (mandatory)
                (+++)   PeriphClkInit.PeriphClockSelection = RCC_PERIPHCLK_ADC   (optional, if configured before)
                (+++)   PeriphClkInit.Adc12ClockSelection = RCC_ADC12PLLCLK_OFF  (optional, if configured before)
                (+++)   HAL_RCCEx_PeriphCLKConfig(&RCC_PeriphClkInitStructure)   (optional, if configured before)
-               (+++) }                                                          
-               (+++) else                                                       
-               (+++) {                                                          
+               (+++) }
+               (+++) else
+               (+++) {
                (+++)   __HAL_RCC_ADC32_FORCE_RESET()                            (optional)
                (+++)   __HAL_RCC_ADC32_RELEASE_RESET()                          (optional)
                (+++)   __HAL_RCC_ADC34_CLK_DISABLE()                            (mandatory)
                (+++)   PeriphClkInit.Adc34ClockSelection = RCC_ADC34PLLCLK_OFF  (optional, if configured before)
                (+++)   HAL_RCCEx_PeriphCLKConfig(&RCC_PeriphClkInitStructure)   (optional, if configured before)
-               (+++) }                                                          
-      
+               (+++) }
+
         (++) For STM32F37x devices:
              (+++) Example:
                    Into HAL_ADC_MspDeInit() (recommended code location) or with
@@ -315,7 +315,7 @@
               using function HAL_NVIC_DisableIRQ(DMAx_Channelx_IRQn)
 
     [..]
-    
+
     *** Callback registration ***
     =============================================
     [..]
@@ -380,7 +380,7 @@
      When the compilation flag USE_HAL_ADC_REGISTER_CALLBACKS is set to 0 or
      not defined, the callback registration feature is not available and all callbacks
      are set to the corresponding weak functions.
-  
+
     @endverbatim
   ******************************************************************************
   * @attention
@@ -409,7 +409,7 @@
   */
 
 #ifdef HAL_ADC_MODULE_ENABLED
-    
+
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
 /* Private macro -------------------------------------------------------------*/
@@ -419,53 +419,54 @@
 
 /** @defgroup ADC_Exported_Functions ADC Exported Functions
   * @{
-  */ 
+  */
 
 /** @defgroup ADC_Exported_Functions_Group1 Initialization and de-initialization functions
- *  @brief    Initialization and Configuration functions 
+ *  @brief    Initialization and Configuration functions
  *
-@verbatim    
+@verbatim
  ===============================================================================
               ##### Initialization and de-initialization functions #####
  ===============================================================================
     [..]  This section provides functions allowing to:
-      (+) Initialize and configure the ADC. 
-      (+) De-initialize the ADC. 
-         
+      (+) Initialize and configure the ADC.
+      (+) De-initialize the ADC.
+
 @endverbatim
   * @{
   */
 
 /**
-  * @brief  Initializes the ADC peripheral and regular group according to  
+  * @brief  Initializes the ADC peripheral and regular group according to
   *         parameters specified in structure "ADC_InitTypeDef".
   * @note   As prerequisite, ADC clock must be configured at RCC top level
   *         depending on both possible clock sources: PLL clock or AHB clock.
-  *         See commented example code below that can be copied and uncommented 
+  *         See commented example code below that can be copied and uncommented
   *         into HAL_ADC_MspInit().
   * @note   Possibility to update parameters on the fly:
   *         This function initializes the ADC MSP (HAL_ADC_MspInit()) only when
   *         coming from ADC state reset. Following calls to this function can
-  *         be used to reconfigure some parameters of ADC_InitTypeDef  
-  *         structure on the fly, without modifying MSP configuration. If ADC  
+  *         be used to reconfigure some parameters of ADC_InitTypeDef
+  *         structure on the fly, without modifying MSP configuration. If ADC
   *         MSP has to be modified again, HAL_ADC_DeInit() must be called
   *         before HAL_ADC_Init().
   *         The setting of these parameters is conditioned to ADC state.
-  *         For parameters constraints, see comments of structure 
+  *         For parameters constraints, see comments of structure
   *         "ADC_InitTypeDef".
-  * @note   This function configures the ADC within 2 scopes: scope of entire 
-  *         ADC and scope of regular group. For parameters details, see comments 
+  * @note   This function configures the ADC within 2 scopes: scope of entire
+  *         ADC and scope of regular group. For parameters details, see comments
   *         of structure "ADC_InitTypeDef".
-  * @note   For devices with several ADCs: parameters related to common ADC 
+  * @note   For devices with several ADCs: parameters related to common ADC
   *         registers (ADC clock mode) are set only if all ADCs sharing the
   *         same common group are disabled.
-  *         If this is not the case, these common parameters setting are  
+  *         If this is not the case, these common parameters setting are
   *         bypassed without error reporting: it can be the intended behaviour in
   *         case of update of a parameter of ADC_InitTypeDef on the fly,
   *         without  disabling the other ADCs sharing the same common group.
   * @param  hadc ADC handle
   * @retval HAL status
   */
+#if 0
 __weak HAL_StatusTypeDef HAL_ADC_Init(ADC_HandleTypeDef* hadc)
 {
   /* Prevent unused argument(s) compilation warning */
@@ -473,23 +474,24 @@ __weak HAL_StatusTypeDef HAL_ADC_Init(ADC_HandleTypeDef* hadc)
 
   /* Note : This function is defined into this file for library reference. */
   /*        Function content is located into file stm32f3xx_hal_adc_ex.c   */
-  
+
   /* Return function status */
   return HAL_ERROR;
 }
+#endif
 
 /**
   * @brief  Deinitialize the ADC peripheral registers to their default reset
   *         values, with deinitialization of the ADC MSP.
-  * @note   For devices with several ADCs: reset of ADC common registers is done 
+  * @note   For devices with several ADCs: reset of ADC common registers is done
   *         only if all ADCs sharing the same common group are disabled.
-  *         If this is not the case, reset of these common parameters reset is  
+  *         If this is not the case, reset of these common parameters reset is
   *         bypassed without error reporting: it can be the intended behaviour in
-  *         case of reset of a single ADC while the other ADCs sharing the same 
+  *         case of reset of a single ADC while the other ADCs sharing the same
   *         common group is still running.
   * @note   For devices with several ADCs: Global reset of all ADCs sharing a
   *         common group is possible.
-  *         As this function is intended to reset a single ADC, to not impact 
+  *         As this function is intended to reset a single ADC, to not impact
   *         other ADCs, instructions for global reset of multiple ADCs have been
   *         let commented below.
   *         If needed, the example code can be copied and uncommented into
@@ -504,11 +506,11 @@ __weak HAL_StatusTypeDef HAL_ADC_DeInit(ADC_HandleTypeDef* hadc)
 
   /* Note : This function is defined into this file for library reference. */
   /*        Function content is located into file stm32f3xx_hal_adc_ex.c   */
-  
+
   /* Return function status */
   return HAL_ERROR;
 }
-    
+
 /**
   * @brief  Initializes the ADC MSP.
   * @param  hadc ADC handle
@@ -521,7 +523,7 @@ __weak void HAL_ADC_MspInit(ADC_HandleTypeDef* hadc)
 
   /* NOTE : This function should not be modified. When the callback is needed,
             function HAL_ADC_MspInit must be implemented in the user file.
-   */ 
+   */
 }
 
 /**
@@ -536,7 +538,7 @@ __weak void HAL_ADC_MspDeInit(ADC_HandleTypeDef* hadc)
 
   /* NOTE : This function should not be modified. When the callback is needed,
             function HAL_ADC_MspDeInit must be implemented in the user file.
-   */ 
+   */
 }
 
 #if (USE_HAL_ADC_REGISTER_CALLBACKS == 1)
@@ -562,7 +564,7 @@ __weak void HAL_ADC_MspDeInit(ADC_HandleTypeDef* hadc)
 HAL_StatusTypeDef HAL_ADC_RegisterCallback(ADC_HandleTypeDef *hadc, HAL_ADC_CallbackIDTypeDef CallbackID, pADC_CallbackTypeDef pCallback)
 {
   HAL_StatusTypeDef status = HAL_OK;
-  
+
   if (pCallback == NULL)
   {
     /* Update the error code */
@@ -570,7 +572,7 @@ HAL_StatusTypeDef HAL_ADC_RegisterCallback(ADC_HandleTypeDef *hadc, HAL_ADC_Call
 
     return HAL_ERROR;
   }
-  
+
   if ((hadc->State & HAL_ADC_STATE_READY) != 0)
   {
     switch (CallbackID)
@@ -578,31 +580,31 @@ HAL_StatusTypeDef HAL_ADC_RegisterCallback(ADC_HandleTypeDef *hadc, HAL_ADC_Call
       case HAL_ADC_CONVERSION_COMPLETE_CB_ID :
         hadc->ConvCpltCallback = pCallback;
         break;
-      
+
       case HAL_ADC_CONVERSION_HALF_CB_ID :
         hadc->ConvHalfCpltCallback = pCallback;
         break;
-      
+
       case HAL_ADC_LEVEL_OUT_OF_WINDOW_1_CB_ID :
         hadc->LevelOutOfWindowCallback = pCallback;
         break;
-      
+
       case HAL_ADC_ERROR_CB_ID :
         hadc->ErrorCallback = pCallback;
         break;
-      
+
       case HAL_ADC_INJ_CONVERSION_COMPLETE_CB_ID :
         hadc->InjectedConvCpltCallback = pCallback;
         break;
-      
+
       case HAL_ADC_MSPINIT_CB_ID :
         hadc->MspInitCallback = pCallback;
         break;
-      
+
       case HAL_ADC_MSPDEINIT_CB_ID :
         hadc->MspDeInitCallback = pCallback;
         break;
-      
+
       default :
         /* Update the error code */
         hadc->ErrorCode |= HAL_ADC_ERROR_INVALID_CALLBACK;
@@ -619,15 +621,15 @@ HAL_StatusTypeDef HAL_ADC_RegisterCallback(ADC_HandleTypeDef *hadc, HAL_ADC_Call
       case HAL_ADC_MSPINIT_CB_ID :
         hadc->MspInitCallback = pCallback;
         break;
-      
+
       case HAL_ADC_MSPDEINIT_CB_ID :
         hadc->MspDeInitCallback = pCallback;
         break;
-      
+
       default :
         /* Update the error code */
         hadc->ErrorCode |= HAL_ADC_ERROR_INVALID_CALLBACK;
-      
+
         /* Return error status */
         status = HAL_ERROR;
         break;
@@ -637,11 +639,11 @@ HAL_StatusTypeDef HAL_ADC_RegisterCallback(ADC_HandleTypeDef *hadc, HAL_ADC_Call
   {
     /* Update the error code */
     hadc->ErrorCode |= HAL_ADC_ERROR_INVALID_CALLBACK;
-    
+
     /* Return error status */
     status =  HAL_ERROR;
   }
-  
+
   return status;
 }
 
@@ -666,7 +668,7 @@ HAL_StatusTypeDef HAL_ADC_RegisterCallback(ADC_HandleTypeDef *hadc, HAL_ADC_Call
 HAL_StatusTypeDef HAL_ADC_UnRegisterCallback(ADC_HandleTypeDef *hadc, HAL_ADC_CallbackIDTypeDef CallbackID)
 {
   HAL_StatusTypeDef status = HAL_OK;
-  
+
   if ((hadc->State & HAL_ADC_STATE_READY) != 0)
   {
     switch (CallbackID)
@@ -674,35 +676,35 @@ HAL_StatusTypeDef HAL_ADC_UnRegisterCallback(ADC_HandleTypeDef *hadc, HAL_ADC_Ca
       case HAL_ADC_CONVERSION_COMPLETE_CB_ID :
         hadc->ConvCpltCallback = HAL_ADC_ConvCpltCallback;
         break;
-      
+
       case HAL_ADC_CONVERSION_HALF_CB_ID :
         hadc->ConvHalfCpltCallback = HAL_ADC_ConvHalfCpltCallback;
         break;
-      
+
       case HAL_ADC_LEVEL_OUT_OF_WINDOW_1_CB_ID :
         hadc->LevelOutOfWindowCallback = HAL_ADC_LevelOutOfWindowCallback;
         break;
-      
+
       case HAL_ADC_ERROR_CB_ID :
         hadc->ErrorCallback = HAL_ADC_ErrorCallback;
         break;
-      
+
       case HAL_ADC_INJ_CONVERSION_COMPLETE_CB_ID :
         hadc->InjectedConvCpltCallback = HAL_ADCEx_InjectedConvCpltCallback;
         break;
-      
+
       case HAL_ADC_MSPINIT_CB_ID :
         hadc->MspInitCallback = HAL_ADC_MspInit; /* Legacy weak MspInit              */
         break;
-      
+
       case HAL_ADC_MSPDEINIT_CB_ID :
         hadc->MspDeInitCallback = HAL_ADC_MspDeInit; /* Legacy weak MspDeInit            */
         break;
-      
+
       default :
         /* Update the error code */
         hadc->ErrorCode |= HAL_ADC_ERROR_INVALID_CALLBACK;
-        
+
         /* Return error status */
         status =  HAL_ERROR;
         break;
@@ -715,15 +717,15 @@ HAL_StatusTypeDef HAL_ADC_UnRegisterCallback(ADC_HandleTypeDef *hadc, HAL_ADC_Ca
       case HAL_ADC_MSPINIT_CB_ID :
         hadc->MspInitCallback = HAL_ADC_MspInit;                   /* Legacy weak MspInit              */
         break;
-        
+
       case HAL_ADC_MSPDEINIT_CB_ID :
         hadc->MspDeInitCallback = HAL_ADC_MspDeInit;               /* Legacy weak MspDeInit            */
         break;
-        
+
       default :
         /* Update the error code */
         hadc->ErrorCode |= HAL_ADC_ERROR_INVALID_CALLBACK;
-        
+
         /* Return error status */
         status =  HAL_ERROR;
         break;
@@ -733,11 +735,11 @@ HAL_StatusTypeDef HAL_ADC_UnRegisterCallback(ADC_HandleTypeDef *hadc, HAL_ADC_Ca
   {
     /* Update the error code */
     hadc->ErrorCode |= HAL_ADC_ERROR_INVALID_CALLBACK;
-    
+
     /* Return error status */
     status =  HAL_ERROR;
   }
-  
+
   return status;
 }
 
@@ -748,12 +750,12 @@ HAL_StatusTypeDef HAL_ADC_UnRegisterCallback(ADC_HandleTypeDef *hadc, HAL_ADC_Ca
   */
 
 /** @defgroup ADC_Exported_Functions_Group2 Input and Output operation functions
- *  @brief    IO operation functions 
+ *  @brief    IO operation functions
  *
-@verbatim   
+@verbatim
  ===============================================================================
              ##### IO operation functions #####
- ===============================================================================  
+ ===============================================================================
     [..]  This section provides functions allowing to:
       (+) Start conversion of regular group.
       (+) Stop conversion of regular group.
@@ -765,20 +767,21 @@ HAL_StatusTypeDef HAL_ADC_UnRegisterCallback(ADC_HandleTypeDef *hadc, HAL_ADC_Ca
       (+) Handle ADC interrupt request
       (+) Start conversion of regular group and enable DMA transfer.
       (+) Stop conversion of regular group and disable ADC DMA transfer.
-               
+
 @endverbatim
   * @{
   */
 /**
   * @brief  Enables ADC, starts conversion of regular group.
   *         Interruptions enabled in this function: None.
-  * @note:  Case of multimode enabled (for devices with several ADCs): This 
-  *         function must be called for ADC slave first, then ADC master. 
-  *         For ADC slave, ADC is enabled only (conversion is not started).  
+  * @note:  Case of multimode enabled (for devices with several ADCs): This
+  *         function must be called for ADC slave first, then ADC master.
+  *         For ADC slave, ADC is enabled only (conversion is not started).
   *         For ADC master, ADC is enabled and multimode conversion is started.
   * @param  hadc ADC handle
   * @retval HAL status
   */
+#if 0
 __weak HAL_StatusTypeDef HAL_ADC_Start(ADC_HandleTypeDef* hadc)
 {
   /* Prevent unused argument(s) compilation warning */
@@ -787,21 +790,23 @@ __weak HAL_StatusTypeDef HAL_ADC_Start(ADC_HandleTypeDef* hadc)
   /* Return function status */
   return HAL_ERROR;
 }
+#endif
 
 /**
-  * @brief  Stop ADC conversion of regular group (and injected group in 
+  * @brief  Stop ADC conversion of regular group (and injected group in
   *         case of auto_injection mode), disable ADC peripheral.
-  * @note:  ADC peripheral disable is forcing stop of potential 
+  * @note:  ADC peripheral disable is forcing stop of potential
   *         conversion on injected group. If injected group is under use, it
   *         should be preliminarily stopped using HAL_ADCEx_InjectedStop function.
-  * @note:  Case of multimode enabled (for devices with several ADCs): This 
+  * @note:  Case of multimode enabled (for devices with several ADCs): This
   *         function must be called for ADC master first, then ADC slave.
-  *         For ADC master, converson is stopped and ADC is disabled. 
+  *         For ADC master, converson is stopped and ADC is disabled.
   *         For ADC slave, ADC is disabled only (conversion stop of ADC master
   *         has already stopped conversion of ADC slave).
   * @param  hadc ADC handle
   * @retval HAL status.
   */
+#if 0
 __weak HAL_StatusTypeDef HAL_ADC_Stop(ADC_HandleTypeDef* hadc)
 {
   /* Prevent unused argument(s) compilation warning */
@@ -809,10 +814,11 @@ __weak HAL_StatusTypeDef HAL_ADC_Stop(ADC_HandleTypeDef* hadc)
 
   /* Note : This function is defined into this file for library reference. */
   /*        Function content is located into file stm32f3xx_hal_adc_ex.c   */
-  
+
   /* Return function status */
   return HAL_ERROR;
 }
+#endif
 
 /**
   * @brief  Wait for regular group conversion to be completed.
@@ -828,7 +834,7 @@ __weak HAL_StatusTypeDef HAL_ADC_PollForConversion(ADC_HandleTypeDef* hadc, uint
 
   /* Note : This function is defined into this file for library reference. */
   /*        Function content is located into file stm32f3xx_hal_adc_ex.c   */
-  
+
   /* Return function status */
   return HAL_ERROR;
 }
@@ -855,7 +861,7 @@ __weak HAL_StatusTypeDef HAL_ADC_PollForEvent(ADC_HandleTypeDef* hadc, uint32_t 
 
   /* Note : This function is defined into this file for library reference. */
   /*        Function content is located into file stm32f3xx_hal_adc_ex.c   */
-  
+
   /* Return function status */
   return HAL_ERROR;
 }
@@ -863,14 +869,14 @@ __weak HAL_StatusTypeDef HAL_ADC_PollForEvent(ADC_HandleTypeDef* hadc, uint32_t 
 /**
   * @brief  Enables ADC, starts conversion of regular group with interruption.
   *         Interruptions enabled in this function:
-  *          - EOC (end of conversion of regular group) or EOS (end of 
-  *            sequence of regular group) depending on ADC initialization 
+  *          - EOC (end of conversion of regular group) or EOS (end of
+  *            sequence of regular group) depending on ADC initialization
   *            parameter "EOCSelection" (if available)
   *          - overrun (if available)
   *         Each of these interruptions has its dedicated callback function.
-  * @note:  Case of multimode enabled (for devices with several ADCs): This 
-  *         function must be called for ADC slave first, then ADC master. 
-  *         For ADC slave, ADC is enabled only (conversion is not started).  
+  * @note:  Case of multimode enabled (for devices with several ADCs): This
+  *         function must be called for ADC slave first, then ADC master.
+  *         For ADC slave, ADC is enabled only (conversion is not started).
   *         For ADC master, ADC is enabled and multimode conversion is started.
   * @param  hadc ADC handle
   * @retval HAL status
@@ -882,21 +888,21 @@ __weak HAL_StatusTypeDef HAL_ADC_Start_IT(ADC_HandleTypeDef* hadc)
 
   /* Note : This function is defined into this file for library reference. */
   /*        Function content is located into file stm32f3xx_hal_adc_ex.c   */
-  
+
   /* Return function status */
   return HAL_ERROR;
 }
 
 /**
-  * @brief  Stop ADC conversion of regular group (and injected group in 
-  *         case of auto_injection mode), disable interruption of 
+  * @brief  Stop ADC conversion of regular group (and injected group in
+  *         case of auto_injection mode), disable interruption of
   *         end-of-conversion, disable ADC peripheral.
-  * @note:  ADC peripheral disable is forcing stop of potential 
+  * @note:  ADC peripheral disable is forcing stop of potential
   *         conversion on injected group. If injected group is under use, it
   *         should be preliminarily stopped using HAL_ADCEx_InjectedStop function.
-  * @note:  Case of multimode enabled (for devices with several ADCs): This 
+  * @note:  Case of multimode enabled (for devices with several ADCs): This
   *         function must be called for ADC master first, then ADC slave.
-  *         For ADC master, conversion is stopped and ADC is disabled. 
+  *         For ADC master, conversion is stopped and ADC is disabled.
   *         For ADC slave, ADC is disabled only (conversion stop of ADC master
   *         has already stopped conversion of ADC slave).
   * @param  hadc ADC handle
@@ -909,7 +915,7 @@ __weak HAL_StatusTypeDef HAL_ADC_Stop_IT(ADC_HandleTypeDef* hadc)
 
   /* Note : This function is defined into this file for library reference. */
   /*        Function content is located into file stm32f3xx_hal_adc_ex.c   */
-  
+
   /* Return function status */
   return HAL_ERROR;
 }
@@ -922,8 +928,8 @@ __weak HAL_StatusTypeDef HAL_ADC_Stop_IT(ADC_HandleTypeDef* hadc)
   *          - DMA half transfer
   *          - overrun (if available)
   *         Each of these interruptions has its dedicated callback function.
-  * @note:  Case of multimode enabled (for devices with several ADCs): This 
-  *         function is for single-ADC mode only. For multimode, use the 
+  * @note:  Case of multimode enabled (for devices with several ADCs): This
+  *         function is for single-ADC mode only. For multimode, use the
   *         dedicated MultimodeStart function.
   * @param  hadc ADC handle
   * @param  pData The destination Buffer address.
@@ -939,20 +945,20 @@ __weak HAL_StatusTypeDef HAL_ADC_Start_DMA(ADC_HandleTypeDef* hadc, uint32_t* pD
 
   /* Note : This function is defined into this file for library reference. */
   /*        Function content is located into file stm32f3xx_hal_adc_ex.c   */
-  
+
   /* Return function status */
   return HAL_ERROR;
 }
 
 /**
-  * @brief  Stop ADC conversion of regular group (and injected group in 
-  *         case of auto_injection mode), disable ADC DMA transfer, disable 
+  * @brief  Stop ADC conversion of regular group (and injected group in
+  *         case of auto_injection mode), disable ADC DMA transfer, disable
   *         ADC peripheral.
-  * @note:  ADC peripheral disable is forcing stop of potential 
+  * @note:  ADC peripheral disable is forcing stop of potential
   *         conversion on injected group. If injected group is under use, it
   *         should be preliminarily stopped using HAL_ADCEx_InjectedStop function.
-  * @note:  Case of multimode enabled (for devices with several ADCs): This 
-  *         function is for single-ADC mode only. For multimode, use the 
+  * @note:  Case of multimode enabled (for devices with several ADCs): This
+  *         function is for single-ADC mode only. For multimode, use the
   *         dedicated MultimodeStop function.
   * @param  hadc ADC handle
   * @retval HAL status.
@@ -964,7 +970,7 @@ __weak HAL_StatusTypeDef HAL_ADC_Stop_DMA(ADC_HandleTypeDef* hadc)
 
   /* Note : This function is defined into this file for library reference. */
   /*        Function content is located into file stm32f3xx_hal_adc_ex.c   */
-  
+
   /* Return function status */
   return HAL_ERROR;
 }
@@ -982,13 +988,13 @@ __weak uint32_t HAL_ADC_GetValue(ADC_HandleTypeDef* hadc)
 {
   /* Note : This function is defined into this file for library reference. */
   /*        Function content is located into file stm32f3xx_hal_adc_ex.c   */
-  
-  /* Return ADC converted value */ 
+
+  /* Return ADC converted value */
   return hadc->Instance->DR;
 }
 
 /**
-  * @brief  Handles ADC interrupt request.  
+  * @brief  Handles ADC interrupt request.
   * @param  hadc ADC handle
   * @retval None
   */
@@ -1002,7 +1008,7 @@ __weak void HAL_ADC_IRQHandler(ADC_HandleTypeDef* hadc)
 }
 
 /**
-  * @brief  Conversion complete callback in non blocking mode 
+  * @brief  Conversion complete callback in non blocking mode
   * @param  hadc ADC handle
   * @retval None
   */
@@ -1017,7 +1023,7 @@ __weak void HAL_ADC_ConvCpltCallback(ADC_HandleTypeDef* hadc)
 }
 
 /**
-  * @brief  Conversion DMA half-transfer callback in non blocking mode 
+  * @brief  Conversion DMA half-transfer callback in non blocking mode
   * @param  hadc ADC handle
   * @retval None
   */
@@ -1032,7 +1038,7 @@ __weak void HAL_ADC_ConvHalfCpltCallback(ADC_HandleTypeDef* hadc)
 }
 
 /**
-  * @brief  Analog watchdog callback in non blocking mode. 
+  * @brief  Analog watchdog callback in non blocking mode.
   * @param  hadc ADC handle
   * @retval None
   */
@@ -1067,16 +1073,16 @@ __weak void HAL_ADC_ErrorCallback(ADC_HandleTypeDef *hadc)
   */
 
 /** @defgroup ADC_Exported_Functions_Group3 Peripheral Control functions
- *  @brief    Peripheral Control functions 
+ *  @brief    Peripheral Control functions
  *
-@verbatim   
+@verbatim
  ===============================================================================
              ##### Peripheral Control functions #####
- ===============================================================================  
+ ===============================================================================
     [..]  This section provides functions allowing to:
       (+) Configure channels on regular group
       (+) Configure the analog watchdog
-      
+
 @endverbatim
   * @{
   */
@@ -1088,17 +1094,17 @@ __weak void HAL_ADC_ErrorCallback(ADC_HandleTypeDef *hadc)
   *         Vbat/VrefInt/TempSensor.
   *         The recommended sampling time is at least:
   *          - For devices STM32F37x: 17.1us for temperature sensor
-  *          - For the other STM32F3 devices: 2.2us for each of channels 
+  *          - For the other STM32F3 devices: 2.2us for each of channels
   *            Vbat/VrefInt/TempSensor.
-  *         These internal paths can be be disabled using function 
+  *         These internal paths can be be disabled using function
   *         HAL_ADC_DeInit().
   * @note   Possibility to update parameters on the fly:
-  *         This function initializes channel into regular group, following  
-  *         calls to this function can be used to reconfigure some parameters 
-  *         of structure "ADC_ChannelConfTypeDef" on the fly, without reseting 
+  *         This function initializes channel into regular group, following
+  *         calls to this function can be used to reconfigure some parameters
+  *         of structure "ADC_ChannelConfTypeDef" on the fly, without reseting
   *         the ADC.
   *         The setting of these parameters is conditioned to ADC state.
-  *         For parameters constraints, see comments of structure 
+  *         For parameters constraints, see comments of structure
   *         "ADC_ChannelConfTypeDef".
   * @param  hadc ADC handle
   * @param  sConfig Structure of ADC channel for regular group.
@@ -1112,7 +1118,7 @@ __weak HAL_StatusTypeDef HAL_ADC_ConfigChannel(ADC_HandleTypeDef* hadc, ADC_Chan
 
   /* Note : This function is defined into this file for library reference. */
   /*        Function content is located into file stm32f3xx_hal_adc_ex.c   */
-  
+
   /* Return function status */
   return HAL_ERROR;
 }
@@ -1120,12 +1126,12 @@ __weak HAL_StatusTypeDef HAL_ADC_ConfigChannel(ADC_HandleTypeDef* hadc, ADC_Chan
 /**
   * @brief  Configures the analog watchdog.
   * @note   Possibility to update parameters on the fly:
-  *         This function initializes the selected analog watchdog, following  
-  *         calls to this function can be used to reconfigure some parameters 
-  *         of structure "ADC_AnalogWDGConfTypeDef" on the fly, without reseting 
+  *         This function initializes the selected analog watchdog, following
+  *         calls to this function can be used to reconfigure some parameters
+  *         of structure "ADC_AnalogWDGConfTypeDef" on the fly, without reseting
   *         the ADC.
   *         The setting of these parameters is conditioned to ADC state.
-  *         For parameters constraints, see comments of structure 
+  *         For parameters constraints, see comments of structure
   *         "ADC_AnalogWDGConfTypeDef".
   * @param  hadc ADC handle
   * @param  AnalogWDGConfig Structure of ADC analog watchdog configuration
@@ -1139,7 +1145,7 @@ __weak HAL_StatusTypeDef HAL_ADC_AnalogWDGConfig(ADC_HandleTypeDef* hadc, ADC_An
 
   /* Note : This function is defined into this file for library reference. */
   /*        Function content is located into file stm32f3xx_hal_adc_ex.c   */
-  
+
   /* Return function status */
   return HAL_ERROR;
 }
@@ -1149,27 +1155,27 @@ __weak HAL_StatusTypeDef HAL_ADC_AnalogWDGConfig(ADC_HandleTypeDef* hadc, ADC_An
   */
 
 /** @defgroup ADC_Exported_Functions_Group4 Peripheral State functions
- *  @brief   ADC Peripheral State functions 
+ *  @brief   ADC Peripheral State functions
  *
-@verbatim   
+@verbatim
  ===============================================================================
             ##### Peripheral state and errors functions #####
  ===============================================================================
     [..]
-    This subsection provides functions to get in run-time the status of the  
+    This subsection provides functions to get in run-time the status of the
     peripheral.
       (+) Check the ADC state
       (+) Check the ADC error code
-         
+
 @endverbatim
   * @{
   */
-  
+
 /**
   * @brief  return the ADC state
   * @note   ADC state machine is managed by bitfield, state must be compared
   *         with bit by bit.
-  *         For example:                                                         
+  *         For example:
   *           " if (HAL_IS_BIT_SET(HAL_ADC_GetState(hadc1), HAL_ADC_STATE_REG_BUSY)) "
   *           " if (HAL_IS_BIT_SET(HAL_ADC_GetState(hadc1), HAL_ADC_STATE_AWD1)    ) "
   * @param  hadc ADC handle
@@ -1179,7 +1185,7 @@ uint32_t HAL_ADC_GetState(ADC_HandleTypeDef* hadc)
 {
   /* Check the parameters */
   assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
-  
+
   /* Return ADC state */
   return hadc->State;
 }
@@ -1197,7 +1203,7 @@ uint32_t HAL_ADC_GetError(ADC_HandleTypeDef *hadc)
 /**
   * @}
   */
-       
+
 /**
   * @}
   */
@@ -1205,10 +1211,10 @@ uint32_t HAL_ADC_GetError(ADC_HandleTypeDef *hadc)
 #endif /* HAL_ADC_MODULE_ENABLED */
 /**
   * @}
-  */ 
+  */
 
 /**
   * @}
-  */ 
+  */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libs/HALf3/src/stm32f3xx_hal_adc_ex.c
+++ b/libs/HALf3/src/stm32f3xx_hal_adc_ex.c
@@ -1,0 +1,7557 @@
+/**
+  ******************************************************************************
+  * @file    stm32f3xx_hal_adc_ex.c
+  * @author  MCD Application Team
+  * @brief   This file provides firmware functions to manage the following 
+  *          functionalities of the Analog to Digital Convertor (ADC)
+  *          peripheral:
+  *           + Operation functions
+  *             ++ Start, stop, get result of conversions of injected
+  *                group, using 2 possible modes: polling, interruption.
+  *             ++ Multimode feature (available on devices with 2 ADCs or more)
+  *             ++ Calibration (ADC automatic self-calibration)
+  *           + Control functions
+  *             ++ Channels configuration on injected group
+  *          Other functions (generic functions) are available in file 
+  *          "stm32f3xx_hal_adc.c".
+  *         
+  @verbatim
+  [..] 
+  (@) Sections "ADC peripheral features" and "How to use this driver" are
+      available in file of generic functions "stm32f3xx_hal_adc.c".
+  [..]
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) 2016 STMicroelectronics.
+  * All rights reserved.</center></h2>
+  *
+  * This software component is licensed by ST under BSD 3-Clause license,
+  * the "License"; You may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at:
+  *                        opensource.org/licenses/BSD-3-Clause
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f3xx_hal.h"
+
+/** @addtogroup STM32F3xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup ADCEx ADCEx
+  * @brief ADC Extended HAL module driver
+  * @{
+  */
+
+#ifdef HAL_ADC_MODULE_ENABLED
+    
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/** @defgroup ADCEx_Private_Constants ADCEx Private Constants
+  * @{
+  */
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+  /* Fixed timeout values for ADC calibration, enable settling time, disable  */
+  /* settling time.                                                           */
+  /* Values defined to be higher than worst cases: low clock frequency,       */
+  /* maximum prescalers.                                                      */
+  /* Ex of profile low frequency : Clock source at 0.5 MHz, ADC clock         */
+  /* prescaler 256 (devices STM32F30xx), sampling time 7.5 ADC clock cycles,  */
+  /* resolution 12 bits.                                                      */
+  /* Unit: ms                                                                 */
+  #define ADC_CALIBRATION_TIMEOUT         ( 10U)
+  #define ADC_ENABLE_TIMEOUT              (  2U)
+  #define ADC_DISABLE_TIMEOUT             (  2U)
+  #define ADC_STOP_CONVERSION_TIMEOUT     ( 11U)
+
+  /* Timeout to wait for current conversion on going to be completed.         */
+  /* Timeout fixed to worst case, for 1 channel.                              */
+  /*   - maximum sampling time (601.5 adc_clk)                                */
+  /*   - ADC resolution (Tsar 12 bits= 12.5 adc_clk)                          */
+  /*   - ADC clock (from PLL with prescaler 256 (devices STM32F30xx))         */
+  /* Unit: cycles of CPU clock.                                               */
+  #define ADC_CONVERSION_TIME_MAX_CPU_CYCLES ( 156928U)
+    
+  /* Delay for ADC stabilization time (ADC voltage regulator start-up time)   */
+  /* Maximum delay is 10us (refer to device datasheet, param. TADCVREG_STUP). */
+  /* Unit: us                                                                 */
+  #define ADC_STAB_DELAY_US               ( 10U)
+    
+  /* Delay for temperature sensor stabilization time.                         */
+  /* Maximum delay is 10us (refer device datasheet, parameter tSTART).        */
+  /* Unit: us                                                                 */
+  #define ADC_TEMPSENSOR_DELAY_US         ( 10U)
+    
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+
+#if defined(STM32F373xC) || defined(STM32F378xx)
+  /* Timeout values for ADC enable and disable settling time.                 */
+  /* Values defined to be higher than worst cases: low clocks freq,           */
+  /* maximum prescaler.                                                       */
+  /* Ex of profile low frequency : Clock source at 0.1 MHz, ADC clock         */
+  /* prescaler 4U, sampling time 12.5 ADC clock cycles, resolution 12 bits.    */
+  /* Unit: ms                                                                 */
+  #define ADC_ENABLE_TIMEOUT              ( 2U)
+  #define ADC_DISABLE_TIMEOUT             ( 2U)
+
+  /* Delay for ADC calibration:                                               */
+  /* Hardware prerequisite before starting a calibration: the ADC must have   */
+  /* been in power-on state for at least two ADC clock cycles.                */
+  /* Unit: ADC clock cycles                                                   */
+  #define ADC_PRECALIBRATION_DELAY_ADCCLOCKCYCLES       ( 2U)
+
+  /* Timeout value for ADC calibration                                        */
+  /* Value defined to be higher than worst cases: low clocks freq,            */
+  /* maximum prescaler.                                                       */
+  /* Ex of profile low frequency : Clock source at 0.1 MHz, ADC clock         */
+  /* prescaler 4U, sampling time 12.5 ADC clock cycles, resolution 12 bits.    */
+  /* Unit: ms                                                                 */
+  #define ADC_CALIBRATION_TIMEOUT         ( 10U)
+
+  /* Delay for ADC stabilization time.                                        */
+  /* Maximum delay is 1us (refer to device datasheet, parameter tSTAB).       */
+  /* Unit: us                                                                 */
+  #define ADC_STAB_DELAY_US               ( 1U)
+
+  /* Delay for temperature sensor stabilization time.                         */
+  /* Maximum delay is 10us (refer to device datasheet, parameter tSTART).     */
+  /* Unit: us                                                                 */
+  #define ADC_TEMPSENSOR_DELAY_US         ( 10U)
+
+  /* Maximum number of CPU cycles corresponding to 1 ADC cycle                */
+  /* Value fixed to worst case: clock prescalers slowing down ADC clock to    */
+  /* minimum frequency                                                        */
+  /*   - AHB prescaler: 16                                                    */
+  /*   - ADC prescaler: 8                                                     */
+  /* Unit: cycles of CPU clock.                                               */
+  #define ADC_CYCLE_WORST_CASE_CPU_CYCLES ( 128U)
+
+  /* ADC conversion cycles (unit: ADC clock cycles)                           */
+  /* (selected sampling time + conversion time of 12.5 ADC clock cycles, with */
+  /* resolution 12 bits)                                                      */
+  #define ADC_CONVERSIONCLOCKCYCLES_SAMPLETIME_1CYCLE5    ( 14U)
+  #define ADC_CONVERSIONCLOCKCYCLES_SAMPLETIME_7CYCLES5   ( 20U)
+  #define ADC_CONVERSIONCLOCKCYCLES_SAMPLETIME_13CYCLES5  ( 26U)
+  #define ADC_CONVERSIONCLOCKCYCLES_SAMPLETIME_28CYCLES5  ( 41U)
+  #define ADC_CONVERSIONCLOCKCYCLES_SAMPLETIME_41CYCLES5  ( 54U)
+  #define ADC_CONVERSIONCLOCKCYCLES_SAMPLETIME_55CYCLES5  ( 68U)
+  #define ADC_CONVERSIONCLOCKCYCLES_SAMPLETIME_71CYCLES5  ( 84U)
+  #define ADC_CONVERSIONCLOCKCYCLES_SAMPLETIME_239CYCLES5 (252U)
+#endif /* STM32F373xC || STM32F378xx */
+/**
+  * @}
+  */
+
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+static HAL_StatusTypeDef ADC_Enable(ADC_HandleTypeDef* hadc);
+static HAL_StatusTypeDef ADC_Disable(ADC_HandleTypeDef* hadc);
+static HAL_StatusTypeDef ADC_ConversionStop(ADC_HandleTypeDef* hadc, uint32_t ConversionGroup);
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+
+#if defined(STM32F373xC) || defined(STM32F378xx)
+static HAL_StatusTypeDef ADC_Enable(ADC_HandleTypeDef* hadc);
+static HAL_StatusTypeDef ADC_ConversionStop_Disable(ADC_HandleTypeDef* hadc);
+#endif /* STM32F373xC || STM32F378xx */
+
+static void ADC_DMAConvCplt(DMA_HandleTypeDef *hdma);
+static void ADC_DMAHalfConvCplt(DMA_HandleTypeDef *hdma);
+static void ADC_DMAError(DMA_HandleTypeDef *hdma);
+
+/* Exported functions --------------------------------------------------------*/
+
+/** @defgroup ADCEx_Exported_Functions ADCEx Exported Functions
+  * @{
+  */
+
+/** @defgroup ADCEx_Exported_Functions_Group1 ADCEx Initialization and de-initialization functions
+  * @brief    ADC Extended Initialization and Configuration functions
+  *
+@verbatim    
+ ===============================================================================
+              ##### Initialization and de-initialization functions #####
+ ===============================================================================
+    [..]  This section provides functions allowing to:
+      (+) Initialize and configure the ADC. 
+      (+) De-initialize the ADC.
+
+@endverbatim
+  * @{
+  */
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+/**
+  * @brief  Initializes the ADC peripheral and regular group according to  
+  *         parameters specified in structure "ADC_InitTypeDef".
+  * @note   As prerequisite, ADC clock must be configured at RCC top level
+  *         depending on possible clock sources: AHB clock or PLL clock.
+  *         See commented example code below that can be copied and uncommented 
+  *         into HAL_ADC_MspInit().
+  * @note   Possibility to update parameters on the fly:
+  *         This function initializes the ADC MSP (HAL_ADC_MspInit()) only when
+  *         coming from ADC state reset. Following calls to this function can
+  *         be used to reconfigure some parameters of ADC_InitTypeDef  
+  *         structure on the fly, without modifying MSP configuration. If ADC  
+  *         MSP has to be modified again, HAL_ADC_DeInit() must be called
+  *         before HAL_ADC_Init().
+  *         The setting of these parameters is conditioned by ADC state.
+  *         For parameters constraints, see comments of structure 
+  *         "ADC_InitTypeDef".
+  * @note   This function configures the ADC within 2 scopes: scope of entire 
+  *         ADC and scope of regular group. For parameters details, see comments 
+  *         of structure "ADC_InitTypeDef".
+  * @note   For devices with several ADCs: parameters related to common ADC 
+  *         registers (ADC clock mode) are set only if all ADCs sharing the
+  *         same common group are disabled.
+  *         If this is not the case, these common parameters setting are  
+  *         bypassed without error reporting: it can be the intended behaviour in
+  *         case of update of a parameter of ADC_InitTypeDef on the fly,
+  *         without  disabling the other ADCs sharing the same common group.
+  * @param  hadc ADC handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADC_Init(ADC_HandleTypeDef* hadc)
+{
+  HAL_StatusTypeDef tmp_hal_status = HAL_OK;
+  ADC_Common_TypeDef *tmpADC_Common;
+  ADC_HandleTypeDef tmphadcSharingSameCommonRegister;
+  uint32_t tmpCFGR = 0U;
+  __IO uint32_t wait_loop_index = 0U;
+  
+  /* Check ADC handle */
+  if(hadc == NULL)
+  {
+    return HAL_ERROR;
+  }
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  assert_param(IS_ADC_CLOCKPRESCALER(hadc->Init.ClockPrescaler));
+  assert_param(IS_ADC_RESOLUTION(hadc->Init.Resolution));
+  assert_param(IS_ADC_DATA_ALIGN(hadc->Init.DataAlign)); 
+  assert_param(IS_ADC_SCAN_MODE(hadc->Init.ScanConvMode));
+  assert_param(IS_FUNCTIONAL_STATE(hadc->Init.ContinuousConvMode));
+  assert_param(IS_ADC_EXTTRIG_EDGE(hadc->Init.ExternalTrigConvEdge));
+  assert_param(IS_ADC_EXTTRIG(hadc->Init.ExternalTrigConv));
+  assert_param(IS_FUNCTIONAL_STATE(hadc->Init.DMAContinuousRequests));
+  assert_param(IS_ADC_EOC_SELECTION(hadc->Init.EOCSelection));
+  assert_param(IS_ADC_OVERRUN(hadc->Init.Overrun));
+  assert_param(IS_FUNCTIONAL_STATE(hadc->Init.LowPowerAutoWait));
+  
+  if(hadc->Init.ScanConvMode != ADC_SCAN_DISABLE)
+  {
+    assert_param(IS_ADC_REGULAR_NB_CONV(hadc->Init.NbrOfConversion));
+    assert_param(IS_FUNCTIONAL_STATE(hadc->Init.DiscontinuousConvMode));
+    if(hadc->Init.DiscontinuousConvMode != DISABLE)
+    {
+      assert_param(IS_ADC_REGULAR_DISCONT_NUMBER(hadc->Init.NbrOfDiscConversion));
+    }
+  }
+    
+  /* Configuration of ADC core parameters and ADC MSP related parameters */
+  if (HAL_IS_BIT_CLR(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL))
+  {
+    /* As prerequisite, into HAL_ADC_MspInit(), ADC clock must be configured  */
+    /* at RCC top level.                                                      */
+    /* Refer to header of this file for more details on clock enabling        */
+    /* procedure.                                                             */
+    
+    /* Actions performed only if ADC is coming from state reset:              */
+    /* - Initialization of ADC MSP                                            */
+    /* - ADC voltage regulator enable                                         */
+    if (hadc->State == HAL_ADC_STATE_RESET)
+    {
+      /* Initialize ADC error code */
+      ADC_CLEAR_ERRORCODE(hadc);
+      
+      /* Initialize HAL ADC API internal variables */
+      hadc->InjectionConfig.ChannelCount = 0U;
+      hadc->InjectionConfig.ContextQueue = 0U;
+      
+      /* Allocate lock resource and initialize it */
+      hadc->Lock = HAL_UNLOCKED;
+      
+#if (USE_HAL_ADC_REGISTER_CALLBACKS == 1)
+    /* Init the ADC Callback settings */
+    hadc->ConvCpltCallback              = HAL_ADC_ConvCpltCallback;                 /* Legacy weak callback */
+    hadc->ConvHalfCpltCallback          = HAL_ADC_ConvHalfCpltCallback;             /* Legacy weak callback */
+    hadc->LevelOutOfWindowCallback      = HAL_ADC_LevelOutOfWindowCallback;         /* Legacy weak callback */
+    hadc->ErrorCallback                 = HAL_ADC_ErrorCallback;                    /* Legacy weak callback */
+    hadc->InjectedConvCpltCallback      = HAL_ADCEx_InjectedConvCpltCallback;       /* Legacy weak callback */
+    
+    if (hadc->MspInitCallback == NULL)
+    {
+      hadc->MspInitCallback = HAL_ADC_MspInit; /* Legacy weak MspInit  */
+    }
+    
+    /* Init the low level hardware */
+    hadc->MspInitCallback(hadc);
+#else
+    /* Init the low level hardware */
+    HAL_ADC_MspInit(hadc);
+#endif /* USE_HAL_ADC_REGISTER_CALLBACKS */
+      
+      /* Enable voltage regulator (if disabled at this step) */
+      if (HAL_IS_BIT_CLR(hadc->Instance->CR, ADC_CR_ADVREGEN_0))
+      {
+        /* Note: The software must wait for the startup time of the ADC       */
+        /*       voltage regulator before launching a calibration or          */
+        /*       enabling the ADC. This temporization must be implemented by  */ 
+        /*       software and is equal to 10 us in the worst case             */
+        /*       process/temperature/power supply.                            */
+        
+        /* Disable the ADC (if not already disabled) */
+        tmp_hal_status = ADC_Disable(hadc);
+        
+        /* Check if ADC is effectively disabled */
+        /* Configuration of ADC parameters if previous preliminary actions    */ 
+        /* are correctly completed.                                           */
+        if (HAL_IS_BIT_CLR(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL) &&
+            (tmp_hal_status == HAL_OK)                                  )
+        {
+          /* Set ADC state */
+          ADC_STATE_CLR_SET(hadc->State,
+                            HAL_ADC_STATE_REG_BUSY | HAL_ADC_STATE_INJ_BUSY,
+                            HAL_ADC_STATE_BUSY_INTERNAL);
+          
+          /* Set the intermediate state before moving the ADC voltage         */
+          /* regulator to state enable.                                       */
+          CLEAR_BIT(hadc->Instance->CR, (ADC_CR_ADVREGEN_1 | ADC_CR_ADVREGEN_0));
+          /* Set ADVREGEN bits to 0x01U */
+          SET_BIT(hadc->Instance->CR, ADC_CR_ADVREGEN_0);
+          
+          /* Delay for ADC stabilization time.                                */
+          /* Compute number of CPU cycles to wait for */
+          wait_loop_index = (ADC_STAB_DELAY_US * (SystemCoreClock / 1000000U));
+          while(wait_loop_index != 0U)
+          {
+            wait_loop_index--;
+          }
+        }
+      }
+    }
+    
+    /* Verification that ADC voltage regulator is correctly enabled, whether  */
+    /* or not ADC is coming from state reset (if any potential problem of     */
+    /* clocking, voltage regulator would not be enabled).                     */
+    if (HAL_IS_BIT_CLR(hadc->Instance->CR, ADC_CR_ADVREGEN_0) ||
+        HAL_IS_BIT_SET(hadc->Instance->CR, ADC_CR_ADVREGEN_1)   )
+    {
+      /* Update ADC state machine to error */
+      ADC_STATE_CLR_SET(hadc->State,
+                        HAL_ADC_STATE_BUSY_INTERNAL,
+                        HAL_ADC_STATE_ERROR_INTERNAL);
+      
+      /* Set ADC error code to ADC IP internal error */
+      SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_INTERNAL);
+      
+      tmp_hal_status = HAL_ERROR;
+    }
+  }
+
+  
+  /* Configuration of ADC parameters if previous preliminary actions are      */ 
+  /* correctly completed and if there is no conversion on going on regular    */
+  /* group (ADC may already be enabled at this point if HAL_ADC_Init() is     */
+  /* called to update a parameter on the fly).                                */
+  if (HAL_IS_BIT_CLR(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL) &&
+      (tmp_hal_status == HAL_OK)                                &&
+      (ADC_IS_CONVERSION_ONGOING_REGULAR(hadc) == RESET)          )
+  {
+    /* Set ADC state */
+    ADC_STATE_CLR_SET(hadc->State,
+                      HAL_ADC_STATE_REG_BUSY,
+                      HAL_ADC_STATE_BUSY_INTERNAL);
+    
+    /* Configuration of common ADC parameters                                 */
+    
+    /* Pointer to the common control register to which is belonging hadc      */
+    /* (Depending on STM32F3 product, there may be up to 4 ADC and 2 common   */
+    /* control registers)                                                     */
+    tmpADC_Common = ADC_COMMON_REGISTER(hadc);
+    
+    /* Set handle of the other ADC sharing the same common register           */
+    ADC_COMMON_ADC_OTHER(hadc, &tmphadcSharingSameCommonRegister);
+    
+    
+    /* Parameters update conditioned to ADC state:                            */
+    /* Parameters that can be updated only when ADC is disabled:              */
+    /*  - Multimode clock configuration                                       */
+    if ((ADC_IS_ENABLE(hadc) == RESET)                                   &&
+        ((tmphadcSharingSameCommonRegister.Instance == NULL)         ||
+         (ADC_IS_ENABLE(&tmphadcSharingSameCommonRegister) == RESET)   )   )
+    {
+      /* Reset configuration of ADC common register CCR:                      */
+      /*   - ADC clock mode: CKMODE                                           */
+      /* Some parameters of this register are not reset, since they are set   */
+      /* by other functions and must be kept in case of usage of this         */
+      /* function on the fly (update of a parameter of ADC_InitTypeDef        */
+      /* without needing to reconfigure all other ADC groups/channels         */
+      /* parameters):                                                         */
+      /*   - multimode related parameters: MDMA, DMACFG, DELAY, MULTI (set    */
+      /*     into HAL_ADCEx_MultiModeConfigChannel() )                        */
+      /*   - internal measurement paths: Vbat, temperature sensor, Vref       */
+      /*     (set into HAL_ADC_ConfigChannel() or                             */
+      /*     HAL_ADCEx_InjectedConfigChannel() )                              */
+     
+      MODIFY_REG(tmpADC_Common->CCR       ,
+                 ADC_CCR_CKMODE           ,
+                 hadc->Init.ClockPrescaler );
+    }
+      
+      
+    /* Configuration of ADC:                                                  */
+    /*  - resolution                                                          */
+    /*  - data alignment                                                      */
+    /*  - external trigger to start conversion                                */
+    /*  - external trigger polarity                                           */
+    /*  - continuous conversion mode                                          */
+    /*  - overrun                                                             */
+    /*  - discontinuous mode                                                  */
+    SET_BIT(tmpCFGR, ADC_CFGR_CONTINUOUS((uint32_t)hadc->Init.ContinuousConvMode) |
+                     ADC_CFGR_OVERRUN(hadc->Init.Overrun)               |
+                     hadc->Init.DataAlign                               |
+                     hadc->Init.Resolution                               );
+    
+    /* Enable discontinuous mode only if continuous mode is disabled */
+    if (hadc->Init.DiscontinuousConvMode == ENABLE)
+    {
+      if (hadc->Init.ContinuousConvMode == DISABLE)
+      {
+        /* Enable the selected ADC regular discontinuous mode */
+        /* Set the number of channels to be converted in discontinuous mode */
+        SET_BIT(tmpCFGR, ADC_CFGR_DISCEN                                            |
+                         ADC_CFGR_DISCONTINUOUS_NUM(hadc->Init.NbrOfDiscConversion)  );
+      }
+      else
+      {
+        /* ADC regular group discontinuous was intended to be enabled,        */
+        /* but ADC regular group modes continuous and sequencer discontinuous */
+        /* cannot be enabled simultaneously.                                  */
+        
+        /* Update ADC state machine to error */
+        ADC_STATE_CLR_SET(hadc->State,
+                          HAL_ADC_STATE_BUSY_INTERNAL,
+                          HAL_ADC_STATE_ERROR_CONFIG);
+        
+        /* Set ADC error code to ADC IP internal error */
+        SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_INTERNAL);
+      }
+    }
+    
+    /* Enable external trigger if trigger selection is different of software  */
+    /* start.                                                                 */
+    /* Note: This configuration keeps the hardware feature of parameter       */
+    /*       ExternalTrigConvEdge "trigger edge none" equivalent to           */
+    /*       software start.                                                  */
+    if (hadc->Init.ExternalTrigConv != ADC_SOFTWARE_START)
+    {
+      SET_BIT(tmpCFGR, ADC_CFGR_EXTSEL_SET(hadc, hadc->Init.ExternalTrigConv) |
+                       hadc->Init.ExternalTrigConvEdge                         );
+    }
+    
+    /* Parameters update conditioned to ADC state:                            */
+    /* Parameters that can be updated when ADC is disabled or enabled without */
+    /* conversion on going on regular and injected groups:                    */
+    /*  - DMA continuous request                                              */
+    /*  - LowPowerAutoWait feature                                            */
+    if (ADC_IS_CONVERSION_ONGOING_REGULAR_INJECTED(hadc) == RESET)
+    {
+      CLEAR_BIT(hadc->Instance->CFGR, ADC_CFGR_AUTDLY |
+                                      ADC_CFGR_DMACFG  );
+      
+      SET_BIT(tmpCFGR, ADC_CFGR_AUTOWAIT((uint32_t)hadc->Init.LowPowerAutoWait) |
+                       ADC_CFGR_DMACONTREQ((uint32_t)hadc->Init.DMAContinuousRequests) );
+    }
+    
+    /* Update ADC configuration register with previous settings */
+    MODIFY_REG(hadc->Instance->CFGR,
+               ADC_CFGR_DISCNUM |
+               ADC_CFGR_DISCEN  |
+               ADC_CFGR_CONT    |
+               ADC_CFGR_OVRMOD  |
+               ADC_CFGR_EXTSEL  |
+               ADC_CFGR_EXTEN   |
+               ADC_CFGR_ALIGN   |
+               ADC_CFGR_RES        ,
+               tmpCFGR              );
+    
+    
+    /* Configuration of regular group sequencer:                              */
+    /* - if scan mode is disabled, regular channels sequence length is set to */
+    /*   0x00: 1 channel converted (channel on regular rank 1U)                */
+    /*   Parameter "NbrOfConversion" is discarded.                            */
+    /*   Note: Scan mode is not present by hardware on this device, but       */
+    /*   emulated by software for alignment over all STM32 devices.           */
+    /* - if scan mode is enabled, regular channels sequence length is set to  */
+    /*   parameter "NbrOfConversion"                                          */   
+    if (hadc->Init.ScanConvMode == ADC_SCAN_ENABLE)
+    {
+      /* Set number of ranks in regular group sequencer */     
+      MODIFY_REG(hadc->Instance->SQR1                     ,
+                 ADC_SQR1_L                               ,
+                 (hadc->Init.NbrOfConversion - (uint8_t)1U) );  
+    }
+    else
+    {
+      CLEAR_BIT(hadc->Instance->SQR1, ADC_SQR1_L);
+    }
+    
+    /* Set ADC error code to none */
+    ADC_CLEAR_ERRORCODE(hadc);
+    
+    /* Set the ADC state */
+    ADC_STATE_CLR_SET(hadc->State,
+                      HAL_ADC_STATE_BUSY_INTERNAL,
+                      HAL_ADC_STATE_READY);
+  }
+  else
+  {
+    /* Update ADC state machine to error */
+    ADC_STATE_CLR_SET(hadc->State,
+                      HAL_ADC_STATE_BUSY_INTERNAL,
+                      HAL_ADC_STATE_ERROR_INTERNAL);
+    
+    tmp_hal_status = HAL_ERROR; 
+  }
+  
+  
+  /* Return function status */
+  return tmp_hal_status;
+}
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+
+#if defined(STM32F373xC) || defined(STM32F378xx)
+/**
+  * @brief  Initializes the ADC peripheral and regular group according to  
+  *         parameters specified in structure "ADC_InitTypeDef".
+  * @note   As prerequisite, ADC clock must be configured at RCC top level
+  *         (clock source APB2).
+  *         See commented example code below that can be copied and uncommented 
+  *         into HAL_ADC_MspInit().
+  * @note   Possibility to update parameters on the fly:
+  *         This function initializes the ADC MSP (HAL_ADC_MspInit()) only when
+  *         coming from ADC state reset. Following calls to this function can
+  *         be used to reconfigure some parameters of ADC_InitTypeDef  
+  *         structure on the fly, without modifying MSP configuration. If ADC  
+  *         MSP has to be modified again, HAL_ADC_DeInit() must be called
+  *         before HAL_ADC_Init().
+  *         The setting of these parameters is conditioned to ADC state.
+  *         For parameters constraints, see comments of structure 
+  *         "ADC_InitTypeDef".
+  * @note   This function configures the ADC within 2 scopes: scope of entire 
+  *         ADC and scope of regular group. For parameters details, see comments 
+  *         of structure "ADC_InitTypeDef".
+  * @param  hadc ADC handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADC_Init(ADC_HandleTypeDef* hadc)
+{
+  HAL_StatusTypeDef tmp_hal_status = HAL_OK;
+  uint32_t tmp_cr1 = 0U;
+  uint32_t tmp_cr2 = 0U;
+  uint32_t tmp_sqr1 = 0U;
+  
+  /* Check ADC handle */
+  if(hadc == NULL)
+  {
+    return HAL_ERROR;
+  }
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  assert_param(IS_ADC_DATA_ALIGN(hadc->Init.DataAlign));
+  assert_param(IS_ADC_SCAN_MODE(hadc->Init.ScanConvMode));
+  assert_param(IS_FUNCTIONAL_STATE(hadc->Init.ContinuousConvMode));
+  assert_param(IS_ADC_EXTTRIG(hadc->Init.ExternalTrigConv));
+  
+  if(hadc->Init.ScanConvMode != ADC_SCAN_DISABLE)
+  {
+    assert_param(IS_ADC_REGULAR_NB_CONV(hadc->Init.NbrOfConversion));
+    assert_param(IS_FUNCTIONAL_STATE(hadc->Init.DiscontinuousConvMode));
+    if(hadc->Init.DiscontinuousConvMode != DISABLE)
+    {
+      assert_param(IS_ADC_REGULAR_DISCONT_NUMBER(hadc->Init.NbrOfDiscConversion));
+    }
+  }
+  
+  /* As prerequisite, into HAL_ADC_MspInit(), ADC clock must be configured    */
+  /* at RCC top level.                                                        */
+  /* Refer to header of this file for more details on clock enabling          */
+  /* procedure.                                                               */
+
+  /* Actions performed only if ADC is coming from state reset:                */
+  /* - Initialization of ADC MSP                                              */
+  if (hadc->State == HAL_ADC_STATE_RESET)
+  {
+    /* Initialize ADC error code */
+    ADC_CLEAR_ERRORCODE(hadc);
+    
+    /* Allocate lock resource and initialize it */
+    hadc->Lock = HAL_UNLOCKED;
+    
+#if (USE_HAL_ADC_REGISTER_CALLBACKS == 1)
+    /* Init the ADC Callback settings */
+    hadc->ConvCpltCallback              = HAL_ADC_ConvCpltCallback;                 /* Legacy weak callback */
+    hadc->ConvHalfCpltCallback          = HAL_ADC_ConvHalfCpltCallback;             /* Legacy weak callback */
+    hadc->LevelOutOfWindowCallback      = HAL_ADC_LevelOutOfWindowCallback;         /* Legacy weak callback */
+    hadc->ErrorCallback                 = HAL_ADC_ErrorCallback;                    /* Legacy weak callback */
+    hadc->InjectedConvCpltCallback      = HAL_ADCEx_InjectedConvCpltCallback;       /* Legacy weak callback */
+    
+    if (hadc->MspInitCallback == NULL)
+    {
+      hadc->MspInitCallback = HAL_ADC_MspInit; /* Legacy weak MspInit  */
+    }
+    
+    /* Init the low level hardware */
+    hadc->MspInitCallback(hadc);
+#else
+    /* Init the low level hardware */
+    HAL_ADC_MspInit(hadc);
+#endif /* USE_HAL_ADC_REGISTER_CALLBACKS */
+  }
+  
+  /* Stop potential conversion on going, on regular and injected groups */
+  /* Disable ADC peripheral */
+  /* Note: In case of ADC already enabled, precaution to not launch an        */
+  /*       unwanted conversion while modifying register CR2 by writing 1 to   */
+  /*       bit ADON.                                                          */
+  tmp_hal_status = ADC_ConversionStop_Disable(hadc);
+  
+  
+  /* Configuration of ADC parameters if previous preliminary actions are      */ 
+  /* correctly completed.                                                     */
+  if (HAL_IS_BIT_CLR(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL) &&
+      (tmp_hal_status == HAL_OK)                                  )
+  {
+    /* Set ADC state */
+    ADC_STATE_CLR_SET(hadc->State,
+                      HAL_ADC_STATE_REG_BUSY | HAL_ADC_STATE_INJ_BUSY,
+                      HAL_ADC_STATE_BUSY_INTERNAL);
+    
+    /* Set ADC parameters */
+    
+    /* Configuration of ADC:                                                  */
+    /*  - data alignment                                                      */
+    /*  - external trigger to start conversion                                */
+    /*  - external trigger polarity (always set to 1U, because needed for all  */
+    /*    triggers: external trigger of SW start)                             */
+    /*  - continuous conversion mode                                          */
+    /* Note: External trigger polarity (ADC_CR2_EXTTRIG) is set into          */
+    /*       HAL_ADC_Start_xxx functions because if set in this function,     */
+    /*       a conversion on injected group would start a conversion also on  */
+    /*       regular group after ADC enabling.                                */
+    tmp_cr2 |= (hadc->Init.DataAlign                             |
+                hadc->Init.ExternalTrigConv                      |
+                ADC_CR2_CONTINUOUS((uint32_t)hadc->Init.ContinuousConvMode) );
+    
+    /* Configuration of ADC:                                                  */
+    /*  - scan mode                                                           */
+    /*  - discontinuous mode disable/enable                                   */
+    /*  - discontinuous mode number of conversions                            */
+    tmp_cr1 |= (ADC_CR1_SCAN_SET(hadc->Init.ScanConvMode));
+
+    /* Enable discontinuous mode only if continuous mode is disabled */
+    /* Note: If parameter "Init.ScanConvMode" is set to disable, parameter    */
+    /*       discontinuous is set anyway, but will have no effect on ADC HW.  */
+    if (hadc->Init.DiscontinuousConvMode == ENABLE)
+    {
+      if (hadc->Init.ContinuousConvMode == DISABLE)
+      {
+        /* Enable the selected ADC regular discontinuous mode */
+        /* Set the number of channels to be converted in discontinuous mode */
+      tmp_cr1 |= (ADC_CR1_DISCEN                                           |
+                  ADC_CR1_DISCONTINUOUS_NUM(hadc->Init.NbrOfDiscConversion) );
+      }
+      else
+      {
+        /* ADC regular group discontinuous was intended to be enabled,        */
+        /* but ADC regular group modes continuous and sequencer discontinuous */
+        /* cannot be enabled simultaneously.                                  */
+        
+        /* Update ADC state machine to error */
+        SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_CONFIG);
+        
+        /* Set ADC error code to ADC IP internal error */
+        SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_INTERNAL);
+      }
+    }
+    
+    /* Update ADC configuration register CR1 with previous settings */
+      MODIFY_REG(hadc->Instance->CR1,
+                 ADC_CR1_SCAN    |
+                 ADC_CR1_DISCEN  |
+                 ADC_CR1_DISCNUM    ,
+                 tmp_cr1             );
+    
+    /* Update ADC configuration register CR2 with previous settings */
+      MODIFY_REG(hadc->Instance->CR2,
+                 ADC_CR2_ALIGN   |
+                 ADC_CR2_EXTSEL  |
+                 ADC_CR2_EXTTRIG |
+                 ADC_CR2_CONT       ,
+                 tmp_cr2             );
+    
+    /* Configuration of regular group sequencer:                              */
+    /* - if scan mode is disabled, regular channels sequence length is set to */
+    /*   0x00: 1 channel converted (channel on regular rank 1U)                */
+    /*   Parameter "NbrOfConversion" is discarded.                            */
+    /*   Note: Scan mode is present by hardware on this device and, if        */
+    /*   disabled, discards automatically nb of conversions. Anyway, nb of    */
+    /*   conversions is forced to 0x00 for alignment over all STM32 devices.  */
+    /* - if scan mode is enabled, regular channels sequence length is set to  */
+    /*   parameter "NbrOfConversion"                                          */
+    if (ADC_CR1_SCAN_SET(hadc->Init.ScanConvMode) == ADC_SCAN_ENABLE)
+    {
+      tmp_sqr1 = ADC_SQR1_L_SHIFT(hadc->Init.NbrOfConversion);
+    }
+    
+    MODIFY_REG(hadc->Instance->SQR1,
+               ADC_SQR1_L          ,
+               tmp_sqr1             );
+    
+    /* Check back that ADC registers have effectively been configured to      */
+    /* ensure of no potential problem of ADC core IP clocking.                */
+    /* Check through register CR2 (excluding bits set in other functions:     */
+    /* execution control bits (ADON, JSWSTART, SWSTART), regular group bits   */
+    /* (DMA), injected group bits (JEXTTRIG and JEXTSEL), channel internal    */
+    /* measurement path bit (TSVREFE).                                        */
+    if (READ_BIT(hadc->Instance->CR2, ~(ADC_CR2_ADON | ADC_CR2_DMA |
+                                        ADC_CR2_SWSTART | ADC_CR2_JSWSTART |
+                                        ADC_CR2_JEXTTRIG | ADC_CR2_JEXTSEL |
+                                        ADC_CR2_TSVREFE                     ))
+         == tmp_cr2)
+    {
+      /* Set ADC error code to none */
+      ADC_CLEAR_ERRORCODE(hadc);
+      
+      /* Set the ADC state */
+      ADC_STATE_CLR_SET(hadc->State,
+                        HAL_ADC_STATE_BUSY_INTERNAL,
+                        HAL_ADC_STATE_READY);
+    }
+    else
+    {
+      /* Update ADC state machine to error */
+      ADC_STATE_CLR_SET(hadc->State,
+                        HAL_ADC_STATE_BUSY_INTERNAL,
+                        HAL_ADC_STATE_ERROR_INTERNAL);
+      
+      /* Set ADC error code to ADC IP internal error */
+      SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_INTERNAL);
+      
+      tmp_hal_status = HAL_ERROR;
+    }
+  
+  }
+  else
+  {
+    /* Update ADC state machine to error */
+    SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL);
+        
+    tmp_hal_status = HAL_ERROR;
+  }
+  
+  /* Return function status */
+  return tmp_hal_status;
+}
+#endif /* STM32F373xC || STM32F378xx */
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+/**
+  * @brief  Deinitialize the ADC peripheral registers to their default reset
+  *         values, with deinitialization of the ADC MSP.
+  * @note   For devices with several ADCs: reset of ADC common registers is done 
+  *         only if all ADCs sharing the same common group are disabled.
+  *         If this is not the case, reset of these common parameters reset is  
+  *         bypassed without error reporting: it can be the intended behaviour in
+  *         case of reset of a single ADC while the other ADCs sharing the same 
+  *         common group is still running.
+  * @note   For devices with several ADCs: Global reset of all ADCs sharing a
+  *         common group is possible.
+  *         As this function is intended to reset a single ADC, to not impact 
+  *         other ADCs, instructions for global reset of multiple ADCs have been
+  *         let commented below.
+  *         If needed, the example code can be copied and uncommented into
+  *         function HAL_ADC_MspDeInit().
+  * @param  hadc ADC handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADC_DeInit(ADC_HandleTypeDef* hadc)
+{
+  HAL_StatusTypeDef tmp_hal_status = HAL_OK;
+  ADC_Common_TypeDef *tmpADC_Common;
+  ADC_HandleTypeDef tmphadcSharingSameCommonRegister;
+  
+  /* Check ADC handle */
+  if(hadc == NULL)
+  {
+     return HAL_ERROR;
+  }
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  
+  /* Set ADC state */
+  SET_BIT(hadc->State, HAL_ADC_STATE_BUSY_INTERNAL);
+  
+  /* Stop potential conversion on going, on regular and injected groups */
+  tmp_hal_status = ADC_ConversionStop(hadc, ADC_REGULAR_INJECTED_GROUP);
+  
+  /* Disable ADC peripheral if conversions are effectively stopped */
+  if (tmp_hal_status == HAL_OK)
+  {
+    /* Flush register JSQR: queue sequencer reset when injected queue         */
+    /* sequencer is enabled and ADC disabled.                                 */
+    /* Enable injected queue sequencer after injected conversion stop         */
+    SET_BIT(hadc->Instance->CFGR, ADC_CFGR_JQM);
+    
+    /* Disable the ADC peripheral */
+    tmp_hal_status = ADC_Disable(hadc);
+    
+    /* Check if ADC is effectively disabled */
+    if (tmp_hal_status == HAL_OK)
+    {
+      /* Change ADC state */
+      hadc->State = HAL_ADC_STATE_READY;
+    }
+    else
+    {      
+      tmp_hal_status = HAL_ERROR;
+    }
+  }
+  
+  
+  /* Configuration of ADC parameters if previous preliminary actions are      */ 
+  /* correctly completed.                                                     */
+  if (tmp_hal_status == HAL_OK)
+  {
+    /* ========== Reset ADC registers ========== */
+    /* Reset register IER */
+    __HAL_ADC_DISABLE_IT(hadc, (ADC_IT_AWD3  | ADC_IT_AWD2 | ADC_IT_AWD1 |
+                                ADC_IT_JQOVF | ADC_IT_OVR  |
+                                ADC_IT_JEOS  | ADC_IT_JEOC |
+                                ADC_IT_EOS   | ADC_IT_EOC  |
+                                ADC_IT_EOSMP | ADC_IT_RDY                 ) );
+    
+    /* Reset register ISR */
+    __HAL_ADC_CLEAR_FLAG(hadc, (ADC_FLAG_AWD3  | ADC_FLAG_AWD2 | ADC_FLAG_AWD1 |
+                                ADC_FLAG_JQOVF | ADC_FLAG_OVR  |
+                                ADC_FLAG_JEOS  | ADC_FLAG_JEOC |
+                                ADC_FLAG_EOS   | ADC_FLAG_EOC  |
+                                ADC_FLAG_EOSMP | ADC_FLAG_RDY                   ) );
+    
+    /* Reset register CR */
+    /* Bits ADC_CR_JADSTP, ADC_CR_ADSTP, ADC_CR_JADSTART, ADC_CR_ADSTART are  */
+    /* in access mode "read-set": no direct reset applicable.                 */
+    /* Reset Calibration mode to default setting (single ended):              */
+    /* Disable voltage regulator:                                             */
+    /* Note: Voltage regulator disable is conditioned to ADC state disabled:  */
+    /*       already done above.                                              */
+    /* Note: Voltage regulator disable is intended for power saving.          */
+    /* Sequence to disable voltage regulator:                                 */
+    /* 1. Set the intermediate state before moving the ADC voltage regulator  */
+    /*    to disable state.                                                   */
+    CLEAR_BIT(hadc->Instance->CR, ADC_CR_ADVREGEN_1 | ADC_CR_ADVREGEN_0 | ADC_CR_ADCALDIF);
+    /* 2. Set ADVREGEN bits to 0x10U */
+    SET_BIT(hadc->Instance->CR, ADC_CR_ADVREGEN_1);
+        
+    /* Reset register CFGR */
+    CLEAR_BIT(hadc->Instance->CFGR, ADC_CFGR_AWD1CH  | ADC_CFGR_JAUTO   | ADC_CFGR_JAWD1EN |   
+                                    ADC_CFGR_AWD1EN  | ADC_CFGR_AWD1SGL | ADC_CFGR_JQM     |     
+                                    ADC_CFGR_JDISCEN | ADC_CFGR_DISCNUM | ADC_CFGR_DISCEN  | 
+                                    ADC_CFGR_AUTDLY  | ADC_CFGR_CONT    | ADC_CFGR_OVRMOD  |     
+                                    ADC_CFGR_EXTEN   | ADC_CFGR_EXTSEL  | ADC_CFGR_ALIGN   |     
+                                    ADC_CFGR_RES     | ADC_CFGR_DMACFG  | ADC_CFGR_DMAEN    );
+    
+    /* Reset register SMPR1 */
+    CLEAR_BIT(hadc->Instance->SMPR1, ADC_SMPR1_SMP9 | ADC_SMPR1_SMP8 | ADC_SMPR1_SMP7 | 
+                                     ADC_SMPR1_SMP6 | ADC_SMPR1_SMP5 | ADC_SMPR1_SMP4 | 
+                                     ADC_SMPR1_SMP3 | ADC_SMPR1_SMP2 | ADC_SMPR1_SMP1  );
+    
+    /* Reset register SMPR2 */
+    CLEAR_BIT(hadc->Instance->SMPR2, ADC_SMPR2_SMP18 | ADC_SMPR2_SMP17 | ADC_SMPR2_SMP16 | 
+                                     ADC_SMPR2_SMP15 | ADC_SMPR2_SMP14 | ADC_SMPR2_SMP13 | 
+                                     ADC_SMPR2_SMP12 | ADC_SMPR2_SMP11 | ADC_SMPR2_SMP10  );
+    
+    /* Reset register TR1 */
+    CLEAR_BIT(hadc->Instance->TR1, ADC_TR1_HT1 | ADC_TR1_LT1);
+    
+    /* Reset register TR2 */
+    CLEAR_BIT(hadc->Instance->TR2, ADC_TR2_HT2 | ADC_TR2_LT2);
+    
+    /* Reset register TR3 */
+    CLEAR_BIT(hadc->Instance->TR3, ADC_TR3_HT3 | ADC_TR3_LT3);
+    
+    /* Reset register SQR1 */
+    CLEAR_BIT(hadc->Instance->SQR1, ADC_SQR1_SQ4 | ADC_SQR1_SQ3 | ADC_SQR1_SQ2 | 
+                                    ADC_SQR1_SQ1 | ADC_SQR1_L);
+    
+    /* Reset register SQR2 */
+    CLEAR_BIT(hadc->Instance->SQR2, ADC_SQR2_SQ9 | ADC_SQR2_SQ8 | ADC_SQR2_SQ7 | 
+                                    ADC_SQR2_SQ6 | ADC_SQR2_SQ5);
+    
+    /* Reset register SQR3 */
+    CLEAR_BIT(hadc->Instance->SQR3, ADC_SQR3_SQ14 | ADC_SQR3_SQ13 | ADC_SQR3_SQ12 | 
+                                    ADC_SQR3_SQ11 | ADC_SQR3_SQ10);
+    
+    /* Reset register SQR4 */
+    CLEAR_BIT(hadc->Instance->SQR4, ADC_SQR4_SQ16 | ADC_SQR4_SQ15);
+    
+    /* Reset register DR */
+    /* bits in access mode read only, no direct reset applicable*/
+      
+    /* Reset register OFR1 */
+    CLEAR_BIT(hadc->Instance->OFR1, ADC_OFR1_OFFSET1_EN | ADC_OFR1_OFFSET1_CH | ADC_OFR1_OFFSET1);
+    /* Reset register OFR2 */
+    CLEAR_BIT(hadc->Instance->OFR2, ADC_OFR2_OFFSET2_EN | ADC_OFR2_OFFSET2_CH | ADC_OFR2_OFFSET2);
+    /* Reset register OFR3 */
+    CLEAR_BIT(hadc->Instance->OFR3, ADC_OFR3_OFFSET3_EN | ADC_OFR3_OFFSET3_CH | ADC_OFR3_OFFSET3);
+    /* Reset register OFR4 */
+    CLEAR_BIT(hadc->Instance->OFR4, ADC_OFR4_OFFSET4_EN | ADC_OFR4_OFFSET4_CH | ADC_OFR4_OFFSET4);
+    
+    /* Reset registers JDR1, JDR2, JDR3, JDR4 */
+    /* bits in access mode read only, no direct reset applicable*/
+    
+    /* Reset register AWD2CR */
+    CLEAR_BIT(hadc->Instance->AWD2CR, ADC_AWD2CR_AWD2CH);
+    
+    /* Reset register AWD3CR */
+    CLEAR_BIT(hadc->Instance->AWD3CR, ADC_AWD3CR_AWD3CH);
+    
+    /* Reset register DIFSEL */
+    CLEAR_BIT(hadc->Instance->DIFSEL, ADC_DIFSEL_DIFSEL);
+    
+    /* Reset register CALFACT */
+    CLEAR_BIT(hadc->Instance->CALFACT, ADC_CALFACT_CALFACT_D | ADC_CALFACT_CALFACT_S);
+
+    
+    
+    
+    
+    
+    /* ========== Reset common ADC registers ========== */
+    
+    /* Pointer to the common control register to which is belonging hadc      */
+    /* (Depending on STM32F3 product, there may be up to 4 ADC and 2 common   */
+    /* control registers)                                                     */
+    tmpADC_Common = ADC_COMMON_REGISTER(hadc);
+    
+    /* Set handle of the other ADC sharing the same common register           */
+    ADC_COMMON_ADC_OTHER(hadc, &tmphadcSharingSameCommonRegister);
+    
+    /* Software is allowed to change common parameters only when all ADCs of  */
+    /* the common group are disabled.                                         */
+    if ((ADC_IS_ENABLE(hadc) == RESET)                                  &&
+        ( (tmphadcSharingSameCommonRegister.Instance == NULL) ||
+          (ADC_IS_ENABLE(&tmphadcSharingSameCommonRegister) == RESET) )   )
+    {
+      /* Reset configuration of ADC common register CCR:
+        - clock mode: CKMODE
+        - multimode related parameters: MDMA, DMACFG, DELAY, MULTI (set into
+          HAL_ADCEx_MultiModeConfigChannel() )
+        - internal measurement paths: Vbat, temperature sensor, Vref (set into
+          HAL_ADC_ConfigChannel() or HAL_ADCEx_InjectedConfigChannel() )
+      */
+      CLEAR_BIT(tmpADC_Common->CCR, ADC_CCR_CKMODE |
+                                    ADC_CCR_VBATEN |
+                                    ADC_CCR_TSEN   |
+                                    ADC_CCR_VREFEN |
+                                    ADC_CCR_MDMA   |
+                                    ADC_CCR_DMACFG |
+                                    ADC_CCR_DELAY  |
+                                    ADC_CCR_MULTI   );
+      
+      /* Other ADC common registers (CSR, CDR) are in access mode read only,
+         no direct reset applicable */
+    }
+    
+    
+    /* ========== Hard reset and clock disable of ADC peripheral ========== */
+    /* Into HAL_ADC_MspDeInit(), ADC clock can be hard reset and disabled     */
+    /* at RCC top level.                                                      */
+    /* Refer to header of this file for more details on clock disabling       */
+    /* procedure.                                                             */
+    
+
+#if (USE_HAL_ADC_REGISTER_CALLBACKS == 1)
+    if (hadc->MspDeInitCallback == NULL)
+    {
+      hadc->MspDeInitCallback = HAL_ADC_MspDeInit; /* Legacy weak MspDeInit  */
+    }
+    
+    /* DeInit the low level hardware */
+    hadc->MspDeInitCallback(hadc);
+#else
+    /* DeInit the low level hardware */
+    HAL_ADC_MspDeInit(hadc);
+#endif /* USE_HAL_ADC_REGISTER_CALLBACKS */
+    
+    /* Set ADC error code to none */
+    ADC_CLEAR_ERRORCODE(hadc);
+    
+    /* Set ADC state */
+    hadc->State = HAL_ADC_STATE_RESET;
+  }
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+
+  
+  /* Return function status */
+  return tmp_hal_status;
+}
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+
+#if defined(STM32F373xC) || defined(STM32F378xx)
+/**
+  * @brief  Deinitialize the ADC peripheral registers to its default reset values.
+  * @param  hadc ADC handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADC_DeInit(ADC_HandleTypeDef* hadc)
+{ 
+  HAL_StatusTypeDef tmp_hal_status = HAL_OK;
+  
+  /* Check ADC handle */
+  if(hadc == NULL)
+  {
+     return HAL_ERROR;
+  }
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  
+  /* Set ADC state */
+  SET_BIT(hadc->State, HAL_ADC_STATE_BUSY_INTERNAL);
+  
+  /* Stop potential conversion on going, on regular and injected groups */
+  /* Disable ADC peripheral */
+  tmp_hal_status = ADC_ConversionStop_Disable(hadc);
+  
+  
+  /* Configuration of ADC parameters if previous preliminary actions are      */ 
+  /* correctly completed.                                                     */
+  if (tmp_hal_status == HAL_OK)
+  {
+    /* ========== Reset ADC registers ========== */
+    /* Reset register SR */
+    __HAL_ADC_CLEAR_FLAG(hadc, (ADC_FLAG_AWD | ADC_FLAG_JEOC | ADC_FLAG_EOC |
+                                ADC_FLAG_JSTRT | ADC_FLAG_STRT));
+                         
+    /* Reset register CR1 */
+    CLEAR_BIT(hadc->Instance->CR1, (ADC_CR1_AWDEN   | ADC_CR1_JAWDEN | ADC_CR1_DISCNUM | 
+                                    ADC_CR1_JDISCEN | ADC_CR1_DISCEN | ADC_CR1_JAUTO   | 
+                                    ADC_CR1_AWDSGL  | ADC_CR1_SCAN   | ADC_CR1_JEOCIE  |   
+                                    ADC_CR1_AWDIE   | ADC_CR1_EOCIE  | ADC_CR1_AWDCH    ));
+    
+    /* Reset register CR2 */
+    CLEAR_BIT(hadc->Instance->CR2, (ADC_CR2_TSVREFE | ADC_CR2_SWSTART | ADC_CR2_JSWSTART | 
+                                    ADC_CR2_EXTTRIG | ADC_CR2_EXTSEL  | ADC_CR2_JEXTTRIG |  
+                                    ADC_CR2_JEXTSEL | ADC_CR2_ALIGN   | ADC_CR2_DMA      |        
+                                    ADC_CR2_RSTCAL  | ADC_CR2_CAL     | ADC_CR2_CONT     |          
+                                    ADC_CR2_ADON                                          ));
+    
+    /* Reset register SMPR1 */
+    CLEAR_BIT(hadc->Instance->SMPR1, (ADC_SMPR1_SMP18 | ADC_SMPR1_SMP17 | ADC_SMPR1_SMP15 | 
+                                      ADC_SMPR1_SMP15 | ADC_SMPR1_SMP14 | ADC_SMPR1_SMP13 | 
+                                      ADC_SMPR1_SMP12 | ADC_SMPR1_SMP11 | ADC_SMPR1_SMP10  ));
+    
+    /* Reset register SMPR2 */
+    CLEAR_BIT(hadc->Instance->SMPR2, (ADC_SMPR2_SMP9 | ADC_SMPR2_SMP8 | ADC_SMPR2_SMP7 | 
+                                      ADC_SMPR2_SMP6 | ADC_SMPR2_SMP5 | ADC_SMPR2_SMP4 | 
+                                      ADC_SMPR2_SMP3 | ADC_SMPR2_SMP2 | ADC_SMPR2_SMP1 | 
+                                      ADC_SMPR2_SMP0                                    ));
+
+    /* Reset register JOFR1 */
+    CLEAR_BIT(hadc->Instance->JOFR1, ADC_JOFR1_JOFFSET1);
+    /* Reset register JOFR2 */
+    CLEAR_BIT(hadc->Instance->JOFR2, ADC_JOFR2_JOFFSET2);
+    /* Reset register JOFR3 */
+    CLEAR_BIT(hadc->Instance->JOFR3, ADC_JOFR3_JOFFSET3);
+    /* Reset register JOFR4 */
+    CLEAR_BIT(hadc->Instance->JOFR4, ADC_JOFR4_JOFFSET4);
+    
+    /* Reset register HTR */
+    CLEAR_BIT(hadc->Instance->HTR, ADC_HTR_HT);
+    /* Reset register LTR */
+    CLEAR_BIT(hadc->Instance->LTR, ADC_LTR_LT);
+    
+    /* Reset register SQR1 */
+    CLEAR_BIT(hadc->Instance->SQR1, ADC_SQR1_L    |
+                                    ADC_SQR1_SQ16 | ADC_SQR1_SQ15 | 
+                                    ADC_SQR1_SQ14 | ADC_SQR1_SQ13  );
+    
+    /* Reset register SQR1 */
+    CLEAR_BIT(hadc->Instance->SQR1, ADC_SQR1_L    |
+                                    ADC_SQR1_SQ16 | ADC_SQR1_SQ15 | 
+                                    ADC_SQR1_SQ14 | ADC_SQR1_SQ13  );
+    
+    /* Reset register SQR2 */
+    CLEAR_BIT(hadc->Instance->SQR2, ADC_SQR2_SQ12 | ADC_SQR2_SQ11 | ADC_SQR2_SQ10 | 
+                                    ADC_SQR2_SQ9  | ADC_SQR2_SQ8  | ADC_SQR2_SQ7   );
+    
+    /* Reset register SQR3 */
+    CLEAR_BIT(hadc->Instance->SQR3, ADC_SQR3_SQ6 | ADC_SQR3_SQ5 | ADC_SQR3_SQ4 | 
+                                    ADC_SQR3_SQ3 | ADC_SQR3_SQ2 | ADC_SQR3_SQ1  );
+    
+    /* Reset register JSQR */
+    CLEAR_BIT(hadc->Instance->JSQR, ADC_JSQR_JL |
+                                    ADC_JSQR_JSQ4 | ADC_JSQR_JSQ3 | 
+                                    ADC_JSQR_JSQ2 | ADC_JSQR_JSQ1  );
+    
+    /* Reset register JSQR */
+    CLEAR_BIT(hadc->Instance->JSQR, ADC_JSQR_JL |
+                                    ADC_JSQR_JSQ4 | ADC_JSQR_JSQ3 | 
+                                    ADC_JSQR_JSQ2 | ADC_JSQR_JSQ1  );
+    
+    /* Reset register DR */
+    /* bits in access mode read only, no direct reset applicable*/
+    
+    /* Reset registers JDR1, JDR2, JDR3, JDR4 */
+    /* bits in access mode read only, no direct reset applicable*/
+    
+    /* Reset VBAT measurement path, in case of enabled before by selecting    */
+    /* channel ADC_CHANNEL_VBAT. */
+    SYSCFG->CFGR1 &= ~(SYSCFG_CFGR1_VBAT);
+    
+    
+    /* ========== Hard reset ADC peripheral ========== */
+    /* Performs a global reset of the entire ADC peripheral: ADC state is     */
+    /* forced to a similar state after device power-on.                       */
+    /* If needed, copy-paste and uncomment the following reset code into      */
+    /* function "void HAL_ADC_MspInit(ADC_HandleTypeDef* hadc)":              */
+    /*                                                                        */
+    /*  __HAL_RCC_ADC1_FORCE_RESET()                                          */
+    /*  __HAL_RCC_ADC1_RELEASE_RESET()                                        */
+    
+#if (USE_HAL_ADC_REGISTER_CALLBACKS == 1)
+    if (hadc->MspDeInitCallback == NULL)
+    {
+      hadc->MspDeInitCallback = HAL_ADC_MspDeInit; /* Legacy weak MspDeInit  */
+    }
+    
+    /* DeInit the low level hardware */
+    hadc->MspDeInitCallback(hadc);
+#else
+    /* DeInit the low level hardware */
+    HAL_ADC_MspDeInit(hadc);
+#endif /* USE_HAL_ADC_REGISTER_CALLBACKS */
+    
+    /* Set ADC error code to none */
+    ADC_CLEAR_ERRORCODE(hadc);
+    
+    /* Set ADC state */
+    hadc->State = HAL_ADC_STATE_RESET;
+  
+  }
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+  
+  /* Return function status */
+  return tmp_hal_status;
+}
+#endif /* STM32F373xC || STM32F378xx */
+
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_Exported_Functions_Group2 ADCEx Input and Output operation functions
+  * @brief    ADC Extended IO operation functions
+  *
+@verbatim   
+ ===============================================================================
+             ##### IO operation functions #####
+ ===============================================================================  
+    [..]  This section provides functions allowing to:
+      (+) Start conversion of regular group.
+      (+) Stop conversion of regular group.
+      (+) Poll for conversion complete on regular group.
+      (+) Poll for conversion event.
+      (+) Get result of regular channel conversion.
+      (+) Start conversion of regular group and enable interruptions.
+      (+) Stop conversion of regular group and disable interruptions.
+      (+) Handle ADC interrupt request
+      (+) Start conversion of regular group and enable DMA transfer.
+      (+) Stop conversion of regular group and disable ADC DMA transfer.
+
+      (+) Start conversion of injected group.
+      (+) Stop conversion of injected group.
+      (+) Poll for conversion complete on injected group.
+      (+) Get result of injected channel conversion.
+      (+) Start conversion of injected group and enable interruptions.
+      (+) Stop conversion of injected group and disable interruptions.
+
+      (+) Start multimode and enable DMA transfer.
+      (+) Stop multimode and disable ADC DMA transfer.
+      (+) Get result of multimode conversion.
+
+      (+) Perform the ADC self-calibration for single or differential ending.
+      (+) Get calibration factors for single or differential ending.
+      (+) Set calibration factors for single or differential ending.
+
+@endverbatim
+  * @{
+  */
+  
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+/**
+  * @brief  Enables ADC, starts conversion of regular group.
+  *         Interruptions enabled in this function: None.
+  * @note   Case of multimode enabled (for devices with several ADCs):
+  *         if ADC is slave, ADC is enabled only (conversion is not started).
+  *         if ADC is master, ADC is enabled and multimode conversion is started.
+  * @param  hadc ADC handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADC_Start(ADC_HandleTypeDef* hadc)
+{
+  HAL_StatusTypeDef tmp_hal_status = HAL_OK;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  
+  /* Perform ADC enable and conversion start if no conversion is on going */
+  if (ADC_IS_CONVERSION_ONGOING_REGULAR(hadc) == RESET)
+  {
+    /* Process locked */
+    __HAL_LOCK(hadc);
+    
+    /* Enable the ADC peripheral */
+    tmp_hal_status = ADC_Enable(hadc);
+    
+    /* Start conversion if ADC is effectively enabled */
+    if (tmp_hal_status == HAL_OK)
+    {
+      /* Set ADC state                                                        */
+      /* - Clear state bitfield related to regular group conversion results   */
+      /* - Set state bitfield related to regular operation                    */
+      ADC_STATE_CLR_SET(hadc->State,
+                        HAL_ADC_STATE_READY | HAL_ADC_STATE_REG_EOC | HAL_ADC_STATE_REG_OVR | HAL_ADC_STATE_REG_EOSMP,
+                        HAL_ADC_STATE_REG_BUSY);
+      
+      /* Set group injected state (from auto-injection) and multimode state   */
+      /* for all cases of multimode: independent mode, multimode ADC master   */
+      /* or multimode ADC slave (for devices with several ADCs):              */
+      if (ADC_NONMULTIMODE_OR_MULTIMODEMASTER(hadc))
+      {
+        /* Set ADC state (ADC independent or master) */
+        CLEAR_BIT(hadc->State, HAL_ADC_STATE_MULTIMODE_SLAVE);
+        
+        /* If conversions on group regular are also triggering group injected,*/
+        /* update ADC state.                                                  */
+        if (READ_BIT(hadc->Instance->CFGR, ADC_CFGR_JAUTO) != RESET)
+        {
+          ADC_STATE_CLR_SET(hadc->State, HAL_ADC_STATE_INJ_EOC, HAL_ADC_STATE_INJ_BUSY);  
+        }
+      }
+      else
+      {
+        /* Set ADC state (ADC slave) */
+        SET_BIT(hadc->State, HAL_ADC_STATE_MULTIMODE_SLAVE);
+        
+        /* If conversions on group regular are also triggering group injected,*/
+        /* update ADC state.                                                  */
+        if (ADC_MULTIMODE_AUTO_INJECTED(hadc))
+        {
+          ADC_STATE_CLR_SET(hadc->State, HAL_ADC_STATE_INJ_EOC, HAL_ADC_STATE_INJ_BUSY);
+        }
+      }
+      
+      /* State machine update: Check if an injected conversion is ongoing */
+      if (HAL_IS_BIT_SET(hadc->State, HAL_ADC_STATE_INJ_BUSY))
+      {
+        /* Reset ADC error code fields related to conversions on group regular*/
+        CLEAR_BIT(hadc->ErrorCode, (HAL_ADC_ERROR_OVR | HAL_ADC_ERROR_DMA));         
+      }
+      else
+      {
+        /* Reset ADC all error code fields */
+        ADC_CLEAR_ERRORCODE(hadc);
+      }
+      
+      /* Process unlocked */
+      /* Unlock before starting ADC conversions: in case of potential         */
+      /* interruption, to let the process to ADC IRQ Handler.                 */
+      __HAL_UNLOCK(hadc);
+      
+      /* Clear regular group conversion flag and overrun flag */
+      /* (To ensure of no unknown state from potential previous ADC           */
+      /* operations)                                                          */
+      __HAL_ADC_CLEAR_FLAG(hadc, (ADC_FLAG_EOC | ADC_FLAG_EOS | ADC_FLAG_OVR));
+      
+      /* Enable conversion of regular group.                                  */
+      /* If software start has been selected, conversion starts immediately.  */
+      /* If external trigger has been selected, conversion will start at next */
+      /* trigger event.                                                       */
+      /* Case of multimode enabled (for devices with several ADCs):           */
+      /*  - if ADC is slave, ADC is enabled only (conversion is not started). */
+      /*  - if ADC is master, ADC is enabled and conversion is started.       */
+      if (ADC_NONMULTIMODE_REG_OR_MULTIMODEMASTER(hadc))
+      {
+        SET_BIT(hadc->Instance->CR, ADC_CR_ADSTART);
+      }
+    }
+    else
+    {
+      /* Process unlocked */
+      __HAL_UNLOCK(hadc);
+    }
+  }
+  else
+  {
+    tmp_hal_status = HAL_BUSY;
+  }
+  
+  /* Return function status */
+  return tmp_hal_status;
+}
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+
+#if defined(STM32F373xC) || defined(STM32F378xx)
+/**
+  * @brief  Enables ADC, starts conversion of regular group.
+  *         Interruptions enabled in this function: None.
+  * @param  hadc ADC handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADC_Start(ADC_HandleTypeDef* hadc)
+{
+  HAL_StatusTypeDef tmp_hal_status = HAL_OK;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  
+  /* Process locked */
+  __HAL_LOCK(hadc);
+   
+  /* Enable the ADC peripheral */
+  tmp_hal_status = ADC_Enable(hadc);
+  
+  /* Start conversion if ADC is effectively enabled */
+  if (tmp_hal_status == HAL_OK)
+  {
+    /* Set ADC state                                                          */
+    /* - Clear state bitfield related to regular group conversion results     */
+    /* - Set state bitfield related to regular operation                      */
+    ADC_STATE_CLR_SET(hadc->State,
+                      HAL_ADC_STATE_READY | HAL_ADC_STATE_REG_EOC,
+                      HAL_ADC_STATE_REG_BUSY);
+    
+    /* Set group injected state (from auto-injection) */
+    /* If conversions on group regular are also triggering group injected,    */
+    /* update ADC state.                                                      */
+    if (READ_BIT(hadc->Instance->CR1, ADC_CR1_JAUTO) != RESET)
+    {
+      ADC_STATE_CLR_SET(hadc->State, HAL_ADC_STATE_INJ_EOC, HAL_ADC_STATE_INJ_BUSY);  
+    }
+    
+    /* State machine update: Check if an injected conversion is ongoing */
+    if (HAL_IS_BIT_SET(hadc->State, HAL_ADC_STATE_INJ_BUSY))
+    {
+      /* Reset ADC error code fields related to conversions on group regular */
+      CLEAR_BIT(hadc->ErrorCode, (HAL_ADC_ERROR_OVR | HAL_ADC_ERROR_DMA));         
+    }
+    else
+    {
+      /* Reset ADC all error code fields */
+      ADC_CLEAR_ERRORCODE(hadc);
+    }
+    
+    /* Process unlocked */
+    /* Unlock before starting ADC conversions: in case of potential           */
+    /* interruption, to let the process to ADC IRQ Handler.                   */
+    __HAL_UNLOCK(hadc);
+    
+    /* Clear regular group conversion flag and overrun flag */
+    /* (To ensure of no unknown state from potential previous ADC operations) */
+    __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_EOC);
+    
+    /* Enable conversion of regular group.                                    */
+    /* If software start has been selected, conversion starts immediately.    */
+    /* If external trigger has been selected, conversion will start at next   */
+    /* trigger event.                                                         */
+    /* Note: Alternate trigger for single conversion could be to force an     */
+    /*       additional set of bit ADON "hadc->Instance->CR2 |= ADC_CR2_ADON;"*/
+    if (ADC_IS_SOFTWARE_START_REGULAR(hadc))
+    {
+      /* Start ADC conversion on regular group with SW start */
+      SET_BIT(hadc->Instance->CR2, (ADC_CR2_SWSTART | ADC_CR2_EXTTRIG));
+    }
+    else
+    {
+      /* Start ADC conversion on regular group with external trigger */
+      SET_BIT(hadc->Instance->CR2, ADC_CR2_EXTTRIG);
+    }
+  }
+
+  /* Return function status */
+  return tmp_hal_status;
+}
+#endif /* STM32F373xC || STM32F378xx */
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+/**
+  * @brief  Stop ADC conversion of both groups regular and injected,
+  *         disable ADC peripheral.
+  * @note   ADC peripheral disable is forcing interruption of potential 
+  *         conversion on injected group. If injected group is under use,
+  *         it should be preliminarily stopped using function
+  *         @ref HAL_ADCEx_InjectedStop().
+  *         To stop ADC conversion only on ADC group regular
+  *         while letting ADC group injected conversions running,
+  *         use function @ref HAL_ADCEx_RegularStop().
+  * @param  hadc ADC handle
+  * @retval HAL status.
+  */
+HAL_StatusTypeDef HAL_ADC_Stop(ADC_HandleTypeDef* hadc)
+{
+  HAL_StatusTypeDef tmp_hal_status = HAL_OK;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  
+  /* Process locked */
+  __HAL_LOCK(hadc);
+  
+  /* 1. Stop potential conversion on going, on regular and injected groups */
+  tmp_hal_status = ADC_ConversionStop(hadc, ADC_REGULAR_INJECTED_GROUP);
+  
+  /* Disable ADC peripheral if conversions are effectively stopped */
+  if (tmp_hal_status == HAL_OK)
+  {
+    /* 2. Disable the ADC peripheral */
+    tmp_hal_status = ADC_Disable(hadc);
+    
+    /* Check if ADC is effectively disabled */
+    if (tmp_hal_status == HAL_OK)
+    {
+      /* Set ADC state */
+      ADC_STATE_CLR_SET(hadc->State,
+                        HAL_ADC_STATE_REG_BUSY | HAL_ADC_STATE_INJ_BUSY,
+                        HAL_ADC_STATE_READY);
+    }
+  }
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+  
+  /* Return function status */
+  return tmp_hal_status;
+}
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+
+#if defined(STM32F373xC) || defined(STM32F378xx)
+/**
+  * @brief  Stop ADC conversion of regular group (and injected channels in 
+  *         case of auto_injection mode), disable ADC peripheral.
+  * @note   ADC peripheral disable is forcing interruption of potential 
+  *         conversion on injected group. If injected group is under use, it
+  *         should be preliminarily stopped using HAL_ADCEx_InjectedStop function.
+  * @param  hadc ADC handle
+  * @retval HAL status.
+  */
+HAL_StatusTypeDef HAL_ADC_Stop(ADC_HandleTypeDef* hadc)
+{
+  HAL_StatusTypeDef tmp_hal_status = HAL_OK;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+     
+  /* Process locked */
+  __HAL_LOCK(hadc);
+  
+  /* Stop potential conversion on going, on regular and injected groups */
+  /* Disable ADC peripheral */
+  tmp_hal_status = ADC_ConversionStop_Disable(hadc);
+  
+  /* Check if ADC is effectively disabled */
+  if (tmp_hal_status == HAL_OK)
+  {
+    /* Set ADC state */
+    ADC_STATE_CLR_SET(hadc->State,
+                      HAL_ADC_STATE_REG_BUSY | HAL_ADC_STATE_INJ_BUSY,
+                      HAL_ADC_STATE_READY);
+  }
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+  
+  /* Return function status */
+  return tmp_hal_status;
+}
+#endif /* STM32F373xC || STM32F378xx */
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+/**
+  * @brief  Wait for regular group conversion to be completed.
+  * @note   ADC conversion flags EOS (end of sequence) and EOC (end of
+  *         conversion) are cleared by this function, with an exception:
+  *         if low power feature "LowPowerAutoWait" is enabled, flags are 
+  *         not cleared to not interfere with this feature until data register
+  *         is read using function HAL_ADC_GetValue().
+  * @note   This function cannot be used in a particular setup: ADC configured 
+  *         in DMA mode and polling for end of each conversion (ADC init
+  *         parameter "EOCSelection" set to ADC_EOC_SINGLE_CONV).
+  *         In this case, DMA resets the flag EOC and polling cannot be
+  *         performed on each conversion. Nevertheless, polling can still 
+  *         be performed on the complete sequence (ADC init
+  *         parameter "EOCSelection" set to ADC_EOC_SEQ_CONV).
+  * @param  hadc ADC handle
+  * @param  Timeout Timeout value in millisecond.
+  * @note   Depending on init parameter "EOCSelection", flags EOS or EOC is 
+  *         checked and cleared depending on autodelay status (bit AUTDLY).     
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADC_PollForConversion(ADC_HandleTypeDef* hadc, uint32_t Timeout)
+{
+  uint32_t tickstart;
+  uint32_t tmp_Flag_EOC;
+  ADC_Common_TypeDef *tmpADC_Common;
+  uint32_t tmp_cfgr     = 0x0U;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+
+/* If end of conversion selected to end of sequence */
+  if (hadc->Init.EOCSelection == ADC_EOC_SEQ_CONV)
+  {
+    tmp_Flag_EOC = ADC_FLAG_EOS;
+  }
+  /* If end of conversion selected to end of each conversion */
+  else /* ADC_EOC_SINGLE_CONV */
+  {
+    /* Verification that ADC configuration is compliant with polling for      */
+    /* each conversion:                                                       */
+    /* Particular case is ADC configured in DMA mode and ADC sequencer with   */
+    /* several ranks and polling for end of each conversion.                  */
+    /* For code simplicity sake, this particular case is generalized to       */
+    /* ADC configured in DMA mode and and polling for end of each conversion. */
+    
+    /* Pointer to the common control register to which is belonging hadc      */
+    /* (Depending on STM32F3 product, there may have up to 4 ADC and 2 common */
+    /* control registers)                                                     */
+    tmpADC_Common = ADC_COMMON_REGISTER(hadc);
+    
+    /* Check DMA configuration, depending on MultiMode set or not */
+    if (READ_BIT(tmpADC_Common->CCR, ADC_CCR_MULTI) == ADC_MODE_INDEPENDENT)
+    {
+      if (HAL_IS_BIT_SET(hadc->Instance->CFGR, ADC_CFGR_DMAEN))
+      {
+        /* Update ADC state machine to error */
+        SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_CONFIG);
+        
+        /* Process unlocked */
+        __HAL_UNLOCK(hadc);
+        
+        return HAL_ERROR;
+      }
+    }
+    else
+    {
+      /* MultiMode is enabled, Common Control Register MDMA bits must be checked */
+      if (READ_BIT(tmpADC_Common->CCR, ADC_CCR_MDMA) != RESET)
+      {
+        /* Update ADC state machine to error */
+        SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_CONFIG);
+        
+        /* Process unlocked */
+        __HAL_UNLOCK(hadc);
+        
+        return HAL_ERROR;
+      }
+    }
+    
+    tmp_Flag_EOC = (ADC_FLAG_EOC | ADC_FLAG_EOS);
+
+  }
+  
+  /* Get relevant register CFGR in ADC instance of ADC master or slave      */
+  /* in function of multimode state (for devices with multimode             */
+  /* available).                                                            */
+  if(ADC_NONMULTIMODE_OR_MULTIMODEMASTER(hadc))
+  {
+    tmp_cfgr = READ_REG(hadc->Instance->CFGR); 
+  }
+  else
+  {
+    tmp_cfgr = READ_REG(ADC_MASTER_INSTANCE(hadc)->CFGR);
+  }
+  
+  /* Get tick count */
+  tickstart = HAL_GetTick();  
+  
+  /* Wait until End of Conversion or End of Sequence flag is raised */
+  while(HAL_IS_BIT_CLR(hadc->Instance->ISR, tmp_Flag_EOC))
+  {
+    /* Check if timeout is disabled (set to infinite wait) */
+    if(Timeout != HAL_MAX_DELAY)
+    {
+      if((Timeout == 0U) || ((HAL_GetTick() - tickstart) > Timeout))
+      {
+        /* Update ADC state machine to timeout */
+        SET_BIT(hadc->State, HAL_ADC_STATE_TIMEOUT);
+        
+        /* Process unlocked */
+        __HAL_UNLOCK(hadc);
+        
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+  
+  /* Update ADC state machine */
+  SET_BIT(hadc->State, HAL_ADC_STATE_REG_EOC);
+  
+  /* Determine whether any further conversion upcoming on group regular       */
+  /* by external trigger, continuous mode or scan sequence on going.          */
+  if(ADC_IS_SOFTWARE_START_REGULAR(hadc)           && 
+     (READ_BIT (tmp_cfgr, ADC_CFGR_CONT) == RESET)   )
+  {
+    /* If End of Sequence is reached, disable interrupts */
+    if( __HAL_ADC_GET_FLAG(hadc, ADC_FLAG_EOS) )
+    {
+      /* Allowed to modify bits ADC_IT_EOC/ADC_IT_EOS only if bit             */
+      /* ADSTART==0 (no conversion on going)                                  */
+      if (ADC_IS_CONVERSION_ONGOING_REGULAR(hadc) == RESET)
+      {        
+        /* Set ADC state */
+        CLEAR_BIT(hadc->State, HAL_ADC_STATE_REG_BUSY);   
+        
+        if (HAL_IS_BIT_CLR(hadc->State, HAL_ADC_STATE_INJ_BUSY))
+        {
+          SET_BIT(hadc->State, HAL_ADC_STATE_READY);
+        }
+      }
+      else
+      {
+        /* Change ADC state to error state */
+        SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_CONFIG);
+        
+        /* Set ADC error code to ADC IP internal error */
+        SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_INTERNAL);
+      }
+    }
+  }
+  
+  /* Clear end of conversion flag of regular group if low power feature       */
+  /* "LowPowerAutoWait " is disabled, to not interfere with this feature      */
+  /* until data register is read using function HAL_ADC_GetValue().           */
+  if (READ_BIT (tmp_cfgr, ADC_CFGR_AUTDLY) == RESET)
+  {
+    /* Clear regular group conversion flag */
+    /* (EOC or EOS depending on HAL ADC initialization parameter) */
+    __HAL_ADC_CLEAR_FLAG(hadc, tmp_Flag_EOC);
+  }
+  
+  /* Return ADC state */
+  return HAL_OK;
+}
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+
+#if defined(STM32F373xC) || defined(STM32F378xx)
+/**
+  * @brief  Wait for regular group conversion to be completed.
+  * @note   This function cannot be used in a particular setup: ADC configured 
+  *         in DMA mode.
+  *         In this case, DMA resets the flag EOC and polling cannot be
+  *         performed on each conversion.
+  * @note   On STM32F37x devices, limitation in case of sequencer enabled
+  *         (several ranks selected): polling cannot be done on each 
+  *         conversion inside the sequence. In this case, polling is replaced by
+  *         wait for maximum conversion time.
+  * @param  hadc ADC handle
+  * @param  Timeout Timeout value in millisecond.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADC_PollForConversion(ADC_HandleTypeDef* hadc, uint32_t Timeout)
+{
+  uint32_t tickstart;
+  
+  /* Variables for polling in case of scan mode enabled */
+  uint32_t Conversion_Timeout_CPU_cycles_max = 0U;
+  uint32_t Conversion_Timeout_CPU_cycles = 0U;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  
+  /* Verification that ADC configuration is compliant with polling for        */
+  /* each conversion:                                                         */
+  /* Particular case is ADC configured in DMA mode                            */
+  if (HAL_IS_BIT_SET(hadc->Instance->CR2, ADC_CR2_DMA))
+  {
+    /* Update ADC state machine to error */
+    SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_CONFIG);
+    
+    /* Process unlocked */
+    __HAL_UNLOCK(hadc);
+    
+    return HAL_ERROR;
+  }
+  
+  /* Get tick count */
+  tickstart = HAL_GetTick();
+  
+  /* Polling for end of conversion: differentiation if single/sequence        */
+  /* conversion.                                                              */
+  /*  - If single conversion for regular group (Scan mode disabled or enabled */
+  /*    with NbrOfConversion =1U), flag EOC is used to determine the           */
+  /*    conversion completion.                                                */
+  /*  - If sequence conversion for regular group (scan mode enabled and       */
+  /*    NbrOfConversion >=2U), flag EOC is set only at the end of the          */
+  /*    sequence.                                                             */
+  /*    To poll for each conversion, the maximum conversion time is computed  */
+  /*    from ADC conversion time (selected sampling time + conversion time of */
+  /*    12.5 ADC clock cycles) and APB2/ADC clock prescalers (depending on    */
+  /*    settings, conversion time range can be from 28 to 32256 CPU cycles).  */
+  /*    As flag EOC is not set after each conversion, no timeout status can   */
+  /*    be set.                                                               */
+  if (HAL_IS_BIT_CLR(hadc->Instance->CR1, ADC_CR1_SCAN) &&
+      HAL_IS_BIT_CLR(hadc->Instance->SQR1, ADC_SQR1_L)    )
+  {
+    /* Wait until End of Conversion flag is raised */
+    while(HAL_IS_BIT_CLR(hadc->Instance->SR, ADC_FLAG_EOC))
+    {
+      /* Check if timeout is disabled (set to infinite wait) */
+      if(Timeout != HAL_MAX_DELAY)
+      {
+        if((Timeout == 0U) || ((HAL_GetTick() - tickstart) > Timeout))
+        {
+          /* Update ADC state machine to timeout */
+          SET_BIT(hadc->State, HAL_ADC_STATE_TIMEOUT);
+          
+          /* Process unlocked */
+          __HAL_UNLOCK(hadc);
+          
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+  }
+  else
+  {
+    /* Replace polling by wait for maximum conversion time */
+    /* Calculation of CPU cycles corresponding to ADC conversion cycles.      */
+    /* Retrieve ADC clock prescaler and ADC maximum conversion cycles on all  */
+    /* channels.                                                              */
+    Conversion_Timeout_CPU_cycles_max = ADC_CLOCK_PRESCALER_RANGE() ;
+    Conversion_Timeout_CPU_cycles_max *= ADC_CONVCYCLES_MAX_RANGE(hadc);
+    
+    /* Poll with maximum conversion time */
+    while(Conversion_Timeout_CPU_cycles < Conversion_Timeout_CPU_cycles_max)
+    {
+      /* Check if timeout is disabled (set to infinite wait) */
+      if(Timeout != HAL_MAX_DELAY)
+      {
+        if((Timeout == 0U) || ((HAL_GetTick() - tickstart ) > Timeout))
+        {
+          /* Update ADC state machine to timeout */
+          SET_BIT(hadc->State, HAL_ADC_STATE_TIMEOUT);
+          
+          /* Process unlocked */
+          __HAL_UNLOCK(hadc);
+          
+          return HAL_TIMEOUT;
+        }
+      }
+      Conversion_Timeout_CPU_cycles ++;
+    }
+  }
+  
+  /* Clear regular group conversion flag */
+  __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_STRT | ADC_FLAG_EOC);
+  
+  /* Update ADC state machine */
+  SET_BIT(hadc->State, HAL_ADC_STATE_REG_EOC);
+  
+  /* Determine whether any further conversion upcoming on group regular       */
+  /* by external trigger, continuous mode or scan sequence on going.          */
+  /* Note: On STM32F37x devices, in case of sequencer enabled                 */
+  /*       (several ranks selected), end of conversion flag is raised         */
+  /*       at the end of the sequence.                                        */
+  if(ADC_IS_SOFTWARE_START_REGULAR(hadc)        && 
+     (hadc->Init.ContinuousConvMode == DISABLE)   )
+  {   
+    /* Set ADC state */
+    CLEAR_BIT(hadc->State, HAL_ADC_STATE_REG_BUSY);   
+
+    if (HAL_IS_BIT_CLR(hadc->State, HAL_ADC_STATE_INJ_BUSY))
+    { 
+      SET_BIT(hadc->State, HAL_ADC_STATE_READY);
+    }
+  }
+  
+  /* Return ADC state */
+  return HAL_OK;
+}
+#endif /* STM32F373xC || STM32F378xx */
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+/**
+  * @brief  Poll for conversion event.
+  * @param  hadc ADC handle
+  * @param  EventType the ADC event type.
+  *          This parameter can be one of the following values:
+  *            @arg ADC_AWD1_EVENT: ADC Analog watchdog 1 event (main analog watchdog, present on all STM32 devices)
+  *            @arg ADC_AWD2_EVENT: ADC Analog watchdog 2 event (additional analog watchdog, not present on all STM32 families)
+  *            @arg ADC_AWD3_EVENT: ADC Analog watchdog 3 event (additional analog watchdog, not present on all STM32 families)
+  *            @arg ADC_OVR_EVENT: ADC Overrun event
+  *            @arg ADC_JQOVF_EVENT: ADC Injected context queue overflow event
+  * @param  Timeout Timeout value in millisecond.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADC_PollForEvent(ADC_HandleTypeDef* hadc, uint32_t EventType, uint32_t Timeout)
+{
+  uint32_t tickstart; 
+
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  assert_param(IS_ADC_EVENT_TYPE(EventType));
+  
+  /* Get start tick count */
+  tickstart = HAL_GetTick();  
+  
+  /* Check selected event flag */
+  while(__HAL_ADC_GET_FLAG(hadc, EventType) == RESET)
+  {
+    /* Check if timeout is disabled (set to infinite wait) */
+    if(Timeout != HAL_MAX_DELAY)
+    {
+      if((Timeout == 0U) || ((HAL_GetTick() - tickstart ) > Timeout))
+      {
+        /* Update ADC state machine to timeout */
+        SET_BIT(hadc->State, HAL_ADC_STATE_TIMEOUT);
+        
+        /* Process unlocked */
+        __HAL_UNLOCK(hadc);
+        
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+
+  
+  switch(EventType)
+  {
+  /* Analog watchdog (level out of window) event */
+  /* Note: In case of several analog watchdog enabled, if needed to know      */
+  /* which one triggered and on which ADCx, test ADC state of analog watchdog */
+  /* flags HAL_ADC_STATE_AWD1/2U/3 using function "HAL_ADC_GetState()".        */
+  /* For example:                                                             */
+  /*  " if (HAL_IS_BIT_SET(HAL_ADC_GetState(hadc1), HAL_ADC_STATE_AWD1)) "    */
+  /*  " if (HAL_IS_BIT_SET(HAL_ADC_GetState(hadc1), HAL_ADC_STATE_AWD2)) "    */
+  /*  " if (HAL_IS_BIT_SET(HAL_ADC_GetState(hadc1), HAL_ADC_STATE_AWD3)) "    */
+  /* Check analog watchdog 1 flag */
+  case ADC_AWD_EVENT:
+    /* Set ADC state */
+    SET_BIT(hadc->State, HAL_ADC_STATE_AWD1);
+     
+    /* Clear ADC analog watchdog flag */
+    __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_AWD1);
+    break;
+  
+  /* Check analog watchdog 2 flag */
+  case ADC_AWD2_EVENT:
+    /* Set ADC state */
+    SET_BIT(hadc->State, HAL_ADC_STATE_AWD2);
+      
+    /* Clear ADC analog watchdog flag */
+    __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_AWD2);
+    break;
+  
+  /* Check analog watchdog 3 flag */
+  case ADC_AWD3_EVENT:
+    /* Set ADC state */
+    SET_BIT(hadc->State, HAL_ADC_STATE_AWD3);
+      
+    /* Clear ADC analog watchdog flag */
+    __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_AWD3);
+    break;
+  
+  /* Injected context queue overflow event */
+  case ADC_JQOVF_EVENT:
+    /* Set ADC state */
+    SET_BIT(hadc->State, HAL_ADC_STATE_INJ_JQOVF);
+      
+    /* Set ADC error code to Injected context queue overflow */
+    SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_JQOVF);
+    
+    /* Clear ADC Injected context queue overflow flag */
+    __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_JQOVF);
+    break;
+     
+  /* Overrun event */
+  default: /* Case ADC_OVR_EVENT */
+    /* If overrun is set to overwrite previous data, overrun event is not     */
+    /* considered as an error.                                                */
+    /* (cf ref manual "Managing conversions without using the DMA and without */
+    /* overrun ")                                                             */
+    if (hadc->Init.Overrun == ADC_OVR_DATA_PRESERVED)
+    {
+      /* Set ADC state */
+      SET_BIT(hadc->State, HAL_ADC_STATE_REG_OVR);
+        
+      /* Set ADC error code to overrun */
+      SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_OVR);
+    }
+    
+    /* Clear ADC Overrun flag */
+    __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_OVR);
+    break;
+  }
+  
+  /* Return ADC state */
+  return HAL_OK;
+}
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+
+#if defined(STM32F373xC) || defined(STM32F378xx)
+/**
+  * @brief  Poll for conversion event.
+  * @param  hadc ADC handle
+  * @param  EventType the ADC event type.
+  *          This parameter can be one of the following values:
+  *            @arg ADC_AWD_EVENT: ADC Analog watchdog event.
+  * @param  Timeout Timeout value in millisecond.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADC_PollForEvent(ADC_HandleTypeDef* hadc, uint32_t EventType, uint32_t Timeout)
+{
+  uint32_t tickstart; 
+
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  assert_param(IS_ADC_EVENT_TYPE(EventType));
+  
+  tickstart = HAL_GetTick();   
+      
+  /* Check selected event flag */
+  while(__HAL_ADC_GET_FLAG(hadc, EventType) == RESET)
+  {
+    /* Check if timeout is disabled (set to infinite wait) */
+    if(Timeout != HAL_MAX_DELAY)
+    {
+      if((Timeout == 0U) || ((HAL_GetTick() - tickstart) > Timeout))
+      {
+        /* Update ADC state machine to timeout */
+        SET_BIT(hadc->State, HAL_ADC_STATE_TIMEOUT);
+        
+        /* Process unlocked */
+        __HAL_UNLOCK(hadc);
+        
+        return HAL_ERROR;
+      }
+    }
+  }
+  
+  /* Analog watchdog (level out of window) event */
+    /* Set ADC state */
+    SET_BIT(hadc->State, HAL_ADC_STATE_AWD1);
+    
+  /* Clear ADC analog watchdog flag */
+  __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_AWD);
+  
+  /* Return ADC state */
+  return HAL_OK;
+}
+#endif /* STM32F373xC || STM32F378xx */
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+/**
+  * @brief  Enables ADC, starts conversion of regular group with interruption.
+  *         Interruptions enabled in this function:
+  *          - EOC (end of conversion of regular group) or EOS (end of 
+  *            sequence of regular group) depending on ADC initialization 
+  *            parameter "EOCSelection"
+  *          - overrun, depending on ADC initialization parameter "Overrun"
+  *         Each of these interruptions has its dedicated callback function.
+  * @note   Case of multimode enabled (for devices with several ADCs): This 
+  *         function must be called for ADC slave first, then ADC master. 
+  *         For ADC slave, ADC is enabled only (conversion is not started).  
+  *         For ADC master, ADC is enabled and multimode conversion is started.
+  * @param  hadc ADC handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADC_Start_IT(ADC_HandleTypeDef* hadc)
+{
+  HAL_StatusTypeDef tmp_hal_status = HAL_OK;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  
+  /* Perform ADC enable and conversion start if no conversion is on going */
+  if (ADC_IS_CONVERSION_ONGOING_REGULAR(hadc) == RESET)
+  {
+    /* Process locked */
+    __HAL_LOCK(hadc);
+    
+    /* Enable the ADC peripheral */
+    tmp_hal_status = ADC_Enable(hadc);
+    
+    /* Start conversion if ADC is effectively enabled */
+    if (tmp_hal_status == HAL_OK)
+    {
+      /* Set ADC state                                                        */
+      /* - Clear state bitfield related to regular group conversion results   */
+      /* - Set state bitfield related to regular operation                    */
+      ADC_STATE_CLR_SET(hadc->State,
+                        HAL_ADC_STATE_READY | HAL_ADC_STATE_REG_EOC | HAL_ADC_STATE_REG_OVR | HAL_ADC_STATE_REG_EOSMP,
+                        HAL_ADC_STATE_REG_BUSY);
+      
+      /* Set group injected state (from auto-injection) and multimode state   */
+      /* for all cases of multimode: independent mode, multimode ADC master   */
+      /* or multimode ADC slave (for devices with several ADCs):              */
+      if (ADC_NONMULTIMODE_OR_MULTIMODEMASTER(hadc))
+      {
+        /* Set ADC state (ADC independent or master) */
+        CLEAR_BIT(hadc->State, HAL_ADC_STATE_MULTIMODE_SLAVE);
+        
+        /* If conversions on group regular are also triggering group injected,*/
+        /* update ADC state.                                                  */
+        if (READ_BIT(hadc->Instance->CFGR, ADC_CFGR_JAUTO) != RESET)
+        {
+          ADC_STATE_CLR_SET(hadc->State, HAL_ADC_STATE_INJ_EOC, HAL_ADC_STATE_INJ_BUSY);  
+        }
+      }
+      else
+      {
+        /* Set ADC state (ADC slave) */
+        SET_BIT(hadc->State, HAL_ADC_STATE_MULTIMODE_SLAVE);
+        
+        /* If conversions on group regular are also triggering group injected,*/
+        /* update ADC state.                                                  */
+        if (ADC_MULTIMODE_AUTO_INJECTED(hadc))
+        {
+          ADC_STATE_CLR_SET(hadc->State, HAL_ADC_STATE_INJ_EOC, HAL_ADC_STATE_INJ_BUSY);
+        }
+      }
+      
+      /* State machine update: Check if an injected conversion is ongoing */
+      if (HAL_IS_BIT_SET(hadc->State, HAL_ADC_STATE_INJ_BUSY))
+      {
+        /* Reset ADC error code fields related to conversions on group regular*/
+        CLEAR_BIT(hadc->ErrorCode, (HAL_ADC_ERROR_OVR | HAL_ADC_ERROR_DMA));         
+      }
+      else
+      {
+        /* Reset ADC all error code fields */
+        ADC_CLEAR_ERRORCODE(hadc);
+      }
+      
+      /* Process unlocked */
+      /* Unlock before starting ADC conversions: in case of potential         */
+      /* interruption, to let the process to ADC IRQ Handler.                 */
+      __HAL_UNLOCK(hadc);
+      
+      /* Clear regular group conversion flag and overrun flag */
+      /* (To ensure of no unknown state from potential previous ADC           */
+      /* operations)                                                          */
+      __HAL_ADC_CLEAR_FLAG(hadc, (ADC_FLAG_EOC | ADC_FLAG_EOS | ADC_FLAG_OVR));
+      
+      /* Enable ADC end of conversion interrupt */
+      /* Enable ADC overrun interrupt */  
+      switch(hadc->Init.EOCSelection)
+      {
+        case ADC_EOC_SEQ_CONV: 
+          __HAL_ADC_DISABLE_IT(hadc, ADC_IT_EOC);
+          __HAL_ADC_ENABLE_IT(hadc, (ADC_IT_EOS));
+          break;
+        /* case ADC_EOC_SINGLE_CONV */
+        default:
+          __HAL_ADC_ENABLE_IT(hadc, (ADC_IT_EOC | ADC_IT_EOS));
+          break;
+      }
+      
+      /* If overrun is set to overwrite previous data (default setting),      */
+      /* overrun interrupt is not activated (overrun event is not considered  */
+      /* as an error).                                                        */
+      /* (cf ref manual "Managing conversions without using the DMA and       */
+      /* without overrun ")                                                   */
+      if (hadc->Init.Overrun == ADC_OVR_DATA_PRESERVED)
+      {
+        __HAL_ADC_DISABLE_IT(hadc, ADC_IT_OVR);
+      }
+      
+      /* Enable conversion of regular group.                                  */
+      /* If software start has been selected, conversion starts immediately.  */
+      /* If external trigger has been selected, conversion will start at next */
+      /* trigger event.                                                       */
+      /* Case of multimode enabled (for devices with several ADCs):           */
+      /*  - if ADC is slave, ADC is enabled only (conversion is not started). */
+      /*  - if ADC is master, ADC is enabled and conversion is started.       */
+      if (ADC_NONMULTIMODE_REG_OR_MULTIMODEMASTER(hadc))
+      {
+        SET_BIT(hadc->Instance->CR, ADC_CR_ADSTART);
+      }
+    }
+    else
+    {
+      /* Process unlocked */
+      __HAL_UNLOCK(hadc);
+    }
+  }
+  else
+  {
+    tmp_hal_status = HAL_BUSY;
+  }
+  
+  /* Return function status */
+  return tmp_hal_status;
+}
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+
+#if defined(STM32F373xC) || defined(STM32F378xx)
+/**
+  * @brief  Enables ADC, starts conversion of regular group with interruption.
+  *         Interruptions enabled in this function:
+  *          - EOC (end of conversion of regular group)
+  *         Each of these interruptions has its dedicated callback function.
+  * @param  hadc ADC handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADC_Start_IT(ADC_HandleTypeDef* hadc)
+{
+  HAL_StatusTypeDef tmp_hal_status = HAL_OK;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  
+  /* Process locked */
+  __HAL_LOCK(hadc);
+    
+  /* Enable the ADC peripheral */
+  tmp_hal_status = ADC_Enable(hadc);
+  
+  /* Start conversion if ADC is effectively enabled */
+  if (tmp_hal_status == HAL_OK)
+  {
+    /* Set ADC state                                                          */
+    /* - Clear state bitfield related to regular group conversion results     */
+    /* - Set state bitfield related to regular operation                      */
+    ADC_STATE_CLR_SET(hadc->State,
+                      HAL_ADC_STATE_READY | HAL_ADC_STATE_REG_EOC,
+                      HAL_ADC_STATE_REG_BUSY);
+    
+    /* Set group injected state (from auto-injection) */
+    /* If conversions on group regular are also triggering group injected,    */
+    /* update ADC state.                                                      */
+    if (READ_BIT(hadc->Instance->CR1, ADC_CR1_JAUTO) != RESET)
+    {
+      ADC_STATE_CLR_SET(hadc->State, HAL_ADC_STATE_INJ_EOC, HAL_ADC_STATE_INJ_BUSY);  
+    }
+    
+    /* State machine update: Check if an injected conversion is ongoing */
+    if (HAL_IS_BIT_SET(hadc->State, HAL_ADC_STATE_INJ_BUSY))
+    {
+      /* Reset ADC error code fields related to conversions on group regular */
+      CLEAR_BIT(hadc->ErrorCode, (HAL_ADC_ERROR_OVR | HAL_ADC_ERROR_DMA));         
+    }
+    else
+    {
+      /* Reset ADC all error code fields */
+      ADC_CLEAR_ERRORCODE(hadc);
+    }
+    
+    /* Process unlocked */
+    /* Unlock before starting ADC conversions: in case of potential           */
+    /* interruption, to let the process to ADC IRQ Handler.                   */
+    __HAL_UNLOCK(hadc);
+    
+    /* Clear regular group conversion flag and overrun flag */
+    /* (To ensure of no unknown state from potential previous ADC operations) */
+    __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_EOC);
+    
+    /* Enable end of conversion interrupt for regular group */
+    __HAL_ADC_ENABLE_IT(hadc, ADC_IT_EOC);
+    
+    /* Enable conversion of regular group.                                    */
+    /* If software start has been selected, conversion starts immediately.    */
+    /* If external trigger has been selected, conversion will start at next   */
+    /* trigger event.                                                         */
+    if (ADC_IS_SOFTWARE_START_REGULAR(hadc))
+    {
+      /* Start ADC conversion on regular group with SW start */
+      SET_BIT(hadc->Instance->CR2, (ADC_CR2_SWSTART | ADC_CR2_EXTTRIG));
+    }
+    else
+    {
+      /* Start ADC conversion on regular group with external trigger */
+      SET_BIT(hadc->Instance->CR2, ADC_CR2_EXTTRIG);
+    }
+  }
+  
+  /* Return function status */
+  return tmp_hal_status;
+}
+#endif /* STM32F373xC || STM32F378xx */
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+/**
+  * @brief  Stop ADC conversion of both groups regular and injected,
+  *         disable ADC peripheral.
+  *         Interruptions disabled in this function:
+  *          - EOC (end of conversion of regular group) and EOS (end of 
+  *            sequence of regular group)
+  *          - overrun
+  * @note   ADC peripheral disable is forcing interruption of potential 
+  *         conversion on injected group. If injected group is under use,
+  *         it should be preliminarily stopped using function
+  *         @ref HAL_ADCEx_InjectedStop().
+  *         To stop ADC conversion only on ADC group regular
+  *         while letting ADC group injected conversions running,
+  *         use function @ref HAL_ADCEx_RegularStop_IT().
+  * @param  hadc ADC handle
+  * @retval HAL status.
+  */
+HAL_StatusTypeDef HAL_ADC_Stop_IT(ADC_HandleTypeDef* hadc)
+{
+  HAL_StatusTypeDef tmp_hal_status = HAL_OK;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  
+  /* Process locked */
+  __HAL_LOCK(hadc);
+  
+  /* 1. Stop potential conversion on going, on regular and injected groups */
+  tmp_hal_status = ADC_ConversionStop(hadc, ADC_REGULAR_INJECTED_GROUP);
+  
+  /* Disable ADC peripheral if conversions are effectively stopped */
+  if (tmp_hal_status == HAL_OK)
+  {
+    /* Disable ADC end of conversion interrupt for regular group */
+    /* Disable ADC overrun interrupt */
+    __HAL_ADC_DISABLE_IT(hadc, (ADC_IT_EOC | ADC_IT_EOS | ADC_IT_OVR));
+    
+    /* 2. Disable the ADC peripheral */
+    tmp_hal_status = ADC_Disable(hadc);
+    
+    /* Check if ADC is effectively disabled */
+    if (tmp_hal_status == HAL_OK)
+    {
+      /* Set ADC state */
+      ADC_STATE_CLR_SET(hadc->State,
+                        HAL_ADC_STATE_REG_BUSY | HAL_ADC_STATE_INJ_BUSY,
+                        HAL_ADC_STATE_READY);
+    }
+  }
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+  
+  /* Return function status */
+  return tmp_hal_status;
+}
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+
+#if defined(STM32F373xC) || defined(STM32F378xx)
+/**
+  * @brief  Stop ADC conversion of regular group (and injected group in 
+  *         case of auto_injection mode), disable interrution of 
+  *         end-of-conversion, disable ADC peripheral.
+  * @param  hadc ADC handle
+  * @retval None
+  */
+HAL_StatusTypeDef HAL_ADC_Stop_IT(ADC_HandleTypeDef* hadc)
+{
+  HAL_StatusTypeDef tmp_hal_status = HAL_OK;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+     
+  /* Process locked */
+  __HAL_LOCK(hadc);
+  
+  /* Stop potential conversion on going, on regular and injected groups */
+  /* Disable ADC peripheral */
+  tmp_hal_status = ADC_ConversionStop_Disable(hadc);
+  
+  /* Check if ADC is effectively disabled */
+  if (tmp_hal_status == HAL_OK)
+  {
+    /* Disable ADC end of conversion interrupt for regular group */
+    __HAL_ADC_DISABLE_IT(hadc, ADC_IT_EOC);
+    
+    /* Set ADC state */
+    ADC_STATE_CLR_SET(hadc->State,
+                      HAL_ADC_STATE_REG_BUSY | HAL_ADC_STATE_INJ_BUSY,
+                      HAL_ADC_STATE_READY);
+  }
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+  
+  /* Return function status */
+  return tmp_hal_status;
+}
+#endif /* STM32F373xC || STM32F378xx */
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+/**
+  * @brief  Enables ADC, starts conversion of regular group and transfers result
+  *         through DMA.
+  *         Interruptions enabled in this function:
+  *          - DMA transfer complete
+  *          - DMA half transfer
+  *          - overrun
+  *         Each of these interruptions has its dedicated callback function.
+  * @note   Case of multimode enabled (for devices with several ADCs): This 
+  *         function is for single-ADC mode only. For multimode, use the 
+  *         dedicated MultimodeStart function.
+  * @param  hadc ADC handle
+  * @param  pData The destination Buffer address.
+  * @param  Length The length of data to be transferred from ADC peripheral to memory.
+  * @retval None
+  */
+HAL_StatusTypeDef HAL_ADC_Start_DMA(ADC_HandleTypeDef* hadc, uint32_t* pData, uint32_t Length)
+{
+  HAL_StatusTypeDef tmp_hal_status = HAL_OK;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  
+  /* Perform ADC enable and conversion start if no conversion is on going */
+  if (ADC_IS_CONVERSION_ONGOING_REGULAR(hadc) == RESET)
+  {
+    /* Process locked */
+    __HAL_LOCK(hadc);
+    
+    /* Verification if multimode is disabled (for devices with several ADC)   */
+    /* If multimode is enabled, dedicated function multimode conversion       */
+    /* start DMA must be used.                                                */
+    if(ADC_COMMON_CCR_MULTI(hadc) == RESET)
+    {
+      /* Enable the ADC peripheral */
+      tmp_hal_status = ADC_Enable(hadc);
+      
+      /* Start conversion if ADC is effectively enabled */
+      if (tmp_hal_status == HAL_OK)
+      {
+        /* Set ADC state                                                      */
+        /* - Clear state bitfield related to regular group conversion results */
+        /* - Set state bitfield related to regular operation                  */
+        ADC_STATE_CLR_SET(hadc->State,
+                          HAL_ADC_STATE_READY | HAL_ADC_STATE_REG_EOC | HAL_ADC_STATE_REG_OVR | HAL_ADC_STATE_REG_EOSMP,
+                          HAL_ADC_STATE_REG_BUSY);
+        
+        /* Set group injected state (from auto-injection) and multimode state */
+        /* for all cases of multimode: independent mode, multimode ADC master */
+        /* or multimode ADC slave (for devices with several ADCs):            */
+        if (ADC_NONMULTIMODE_OR_MULTIMODEMASTER(hadc))
+        {
+          /* Set ADC state (ADC independent or master) */
+          CLEAR_BIT(hadc->State, HAL_ADC_STATE_MULTIMODE_SLAVE);
+          
+          /* If conversions on group regular are also triggering group injected,*/
+          /* update ADC state.                                                  */
+          if (READ_BIT(hadc->Instance->CFGR, ADC_CFGR_JAUTO) != RESET)
+          {
+            ADC_STATE_CLR_SET(hadc->State, HAL_ADC_STATE_INJ_EOC, HAL_ADC_STATE_INJ_BUSY);  
+          }
+        }
+        else
+        {
+          /* Set ADC state (ADC slave) */
+          SET_BIT(hadc->State, HAL_ADC_STATE_MULTIMODE_SLAVE);
+          
+          /* If conversions on group regular are also triggering group injected,*/
+          /* update ADC state.                                                  */
+          if (ADC_MULTIMODE_AUTO_INJECTED(hadc))
+          {
+            ADC_STATE_CLR_SET(hadc->State, HAL_ADC_STATE_INJ_EOC, HAL_ADC_STATE_INJ_BUSY);
+          }
+        }
+        
+        /* State machine update: Check if an injected conversion is ongoing */
+        if (HAL_IS_BIT_SET(hadc->State, HAL_ADC_STATE_INJ_BUSY))
+        {
+          /* Reset ADC error code fields related to conversions on group regular*/
+          CLEAR_BIT(hadc->ErrorCode, (HAL_ADC_ERROR_OVR | HAL_ADC_ERROR_DMA));         
+        }
+        else
+        {
+          /* Reset ADC all error code fields */
+          ADC_CLEAR_ERRORCODE(hadc);
+        }
+        
+        /* Process unlocked */
+        /* Unlock before starting ADC conversions: in case of potential         */
+        /* interruption, to let the process to ADC IRQ Handler.                 */
+        __HAL_UNLOCK(hadc);
+        
+        
+        /* Set the DMA transfer complete callback */
+        hadc->DMA_Handle->XferCpltCallback = ADC_DMAConvCplt;
+
+        /* Set the DMA half transfer complete callback */
+        hadc->DMA_Handle->XferHalfCpltCallback = ADC_DMAHalfConvCplt;
+        
+        /* Set the DMA error callback */
+        hadc->DMA_Handle->XferErrorCallback = ADC_DMAError;
+
+              
+        /* Manage ADC and DMA start: ADC overrun interruption, DMA start, ADC */
+        /* start (in case of SW start):                                       */
+        
+        /* Clear regular group conversion flag and overrun flag */
+        /* (To ensure of no unknown state from potential previous ADC         */
+        /* operations)                                                        */
+        __HAL_ADC_CLEAR_FLAG(hadc, (ADC_FLAG_EOC | ADC_FLAG_EOS | ADC_FLAG_OVR));
+        
+        /* Enable ADC overrun interrupt */
+        __HAL_ADC_ENABLE_IT(hadc, ADC_IT_OVR);
+        
+        /* Enable ADC DMA mode */
+        SET_BIT(hadc->Instance->CFGR, ADC_CFGR_DMAEN);
+        
+        /* Start the DMA channel */
+        HAL_DMA_Start_IT(hadc->DMA_Handle, (uint32_t)&hadc->Instance->DR, (uint32_t)pData, Length);
+                 
+        /* Enable conversion of regular group.                                */
+        /* If software start has been selected, conversion starts immediately.*/
+        /* If external trigger has been selected, conversion will start at    */
+        /* next trigger event.                                                */
+        SET_BIT(hadc->Instance->CR, ADC_CR_ADSTART);
+        
+      }
+      else
+      {
+        /* Process unlocked */
+        __HAL_UNLOCK(hadc);
+      }
+    }
+    else
+    {
+      tmp_hal_status = HAL_ERROR;
+      
+      /* Process unlocked */
+      __HAL_UNLOCK(hadc);
+    }
+  }
+  else
+  {
+    tmp_hal_status = HAL_BUSY;
+  }
+  
+  /* Return function status */
+  return tmp_hal_status;
+}
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+
+#if defined(STM32F373xC) || defined(STM32F378xx)
+/**
+  * @brief  Enables ADC, starts conversion of regular group and transfers result
+  *         through DMA.
+  *         Interruptions enabled in this function:
+  *          - DMA transfer complete
+  *          - DMA half transfer
+  *         Each of these interruptions has its dedicated callback function.
+  * @note   For devices with several ADCs: This function is for single-ADC mode 
+  *         only. For multimode, use the dedicated MultimodeStart function.
+  * @param  hadc ADC handle
+  * @param  pData The destination Buffer address.
+  * @param  Length The length of data to be transferred from ADC peripheral to memory.
+  * @retval None
+  */
+HAL_StatusTypeDef HAL_ADC_Start_DMA(ADC_HandleTypeDef* hadc, uint32_t* pData, uint32_t Length)
+{
+  HAL_StatusTypeDef tmp_hal_status = HAL_OK;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  
+  /* Process locked */
+  __HAL_LOCK(hadc);
+    
+  /* Enable the ADC peripheral */
+  tmp_hal_status = ADC_Enable(hadc);
+  
+  /* Start conversion if ADC is effectively enabled */
+  if (tmp_hal_status == HAL_OK)
+  {
+    /* Set ADC state                                                          */
+    /* - Clear state bitfield related to regular group conversion results     */
+    /* - Set state bitfield related to regular operation                      */
+    ADC_STATE_CLR_SET(hadc->State,
+                      HAL_ADC_STATE_READY | HAL_ADC_STATE_REG_EOC,
+                      HAL_ADC_STATE_REG_BUSY);
+    
+    /* Set group injected state (from auto-injection) */
+    /* If conversions on group regular are also triggering group injected,    */
+    /* update ADC state.                                                      */
+    if (READ_BIT(hadc->Instance->CR1, ADC_CR1_JAUTO) != RESET)
+    {
+      ADC_STATE_CLR_SET(hadc->State, HAL_ADC_STATE_INJ_EOC, HAL_ADC_STATE_INJ_BUSY);  
+    }
+    
+    /* State machine update: Check if an injected conversion is ongoing */
+    if (HAL_IS_BIT_SET(hadc->State, HAL_ADC_STATE_INJ_BUSY))
+    {
+      /* Reset ADC error code fields related to conversions on group regular */
+      CLEAR_BIT(hadc->ErrorCode, (HAL_ADC_ERROR_OVR | HAL_ADC_ERROR_DMA));         
+    }
+    else
+    {
+      /* Reset ADC all error code fields */
+      ADC_CLEAR_ERRORCODE(hadc);
+    }
+    
+    /* Process unlocked */
+    /* Unlock before starting ADC conversions: in case of potential           */
+    /* interruption, to let the process to ADC IRQ Handler.                   */
+    __HAL_UNLOCK(hadc);
+    
+    /* Set the DMA transfer complete callback */
+    hadc->DMA_Handle->XferCpltCallback = ADC_DMAConvCplt;
+       
+    /* Set the DMA half transfer complete callback */
+    hadc->DMA_Handle->XferHalfCpltCallback = ADC_DMAHalfConvCplt;
+    
+    /* Set the DMA error callback */
+    hadc->DMA_Handle->XferErrorCallback = ADC_DMAError;
+
+    
+    /* Manage ADC and DMA start: ADC overrun interruption, DMA start, ADC     */
+    /* start (in case of SW start):                                           */
+    
+    /* Clear regular group conversion flag and overrun flag */
+    /* (To ensure of no unknown state from potential previous ADC operations) */
+    __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_EOC);
+    
+    /* Enable ADC DMA mode */
+    hadc->Instance->CR2 |= ADC_CR2_DMA;
+    
+    /* Start the DMA channel */
+    HAL_DMA_Start_IT(hadc->DMA_Handle, (uint32_t)&hadc->Instance->DR, (uint32_t)pData, Length);
+
+    /* Enable conversion of regular group.                                    */
+    /* If software start has been selected, conversion starts immediately.    */
+    /* If external trigger has been selected, conversion will start at next   */
+    /* trigger event.                                                         */
+    /* Note: Alternate trigger for single conversion could be to force an     */
+    /*       additional set of bit ADON "hadc->Instance->CR2 |= ADC_CR2_ADON;"*/
+    if (ADC_IS_SOFTWARE_START_REGULAR(hadc))
+    {
+      /* Start ADC conversion on regular group with SW start */
+      SET_BIT(hadc->Instance->CR2, (ADC_CR2_SWSTART | ADC_CR2_EXTTRIG));
+    }
+    else
+    {
+      /* Start ADC conversion on regular group with external trigger */
+      SET_BIT(hadc->Instance->CR2, ADC_CR2_EXTTRIG);
+    }
+  }
+
+  /* Return function status */
+  return tmp_hal_status;
+}
+#endif /* STM32F373xC || STM32F378xx */
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+/**
+  * @brief  Stop ADC conversion of both groups regular and injected,
+  *         disable ADC DMA transfer, disable ADC peripheral.
+  *         Interruptions disabled in this function:
+  *          - DMA transfer complete
+  *          - DMA half transfer
+  *          - overrun
+  * @note   ADC peripheral disable is forcing interruption of potential 
+  *         conversion on injected group. If injected group is under use,
+  *         it should be preliminarily stopped using function
+  *         @ref HAL_ADCEx_InjectedStop().
+  *         To stop ADC conversion only on ADC group regular
+  *         while letting ADC group injected conversions running,
+  *         use function @ref HAL_ADCEx_RegularStop_DMA().
+  * @note   Case of multimode enabled (for devices with several ADCs): This 
+  *         function is for single-ADC mode only. For multimode, use the 
+  *         dedicated MultimodeStop function.
+  * @param  hadc ADC handle
+  * @retval HAL status.
+  */
+HAL_StatusTypeDef HAL_ADC_Stop_DMA(ADC_HandleTypeDef* hadc)
+{  
+  HAL_StatusTypeDef tmp_hal_status = HAL_OK;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+
+  /* Process locked */
+  __HAL_LOCK(hadc);
+  
+  /* 1. Stop potential conversion on going, on regular and injected groups */
+  tmp_hal_status = ADC_ConversionStop(hadc, ADC_REGULAR_INJECTED_GROUP);
+  
+  /* Disable ADC peripheral if conversions are effectively stopped */
+  if (tmp_hal_status == HAL_OK)
+  {
+    /* Disable ADC DMA (ADC DMA configuration ADC_CFGR_DMACFG is kept) */
+    CLEAR_BIT(hadc->Instance->CFGR, ADC_CFGR_DMAEN);
+    
+    /* Disable the DMA channel (in case of DMA in circular mode or stop while */
+    /* while DMA transfer is on going)                                        */
+    if (hadc->DMA_Handle->State == HAL_DMA_STATE_BUSY)
+    {
+      tmp_hal_status = HAL_DMA_Abort(hadc->DMA_Handle);   
+      
+      /* Check if DMA channel effectively disabled */
+      if (tmp_hal_status != HAL_OK)
+      {
+        /* Update ADC state machine to error */
+        SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_DMA);     
+      }
+    }
+
+    /* Disable ADC overrun interrupt */
+    __HAL_ADC_DISABLE_IT(hadc, ADC_IT_OVR);
+    
+    /* 2. Disable the ADC peripheral */
+    /* Update "tmp_hal_status" only if DMA channel disabling passed,          */
+    /* to retain a potential failing status.                                  */
+    if (tmp_hal_status == HAL_OK)
+    {
+      tmp_hal_status = ADC_Disable(hadc);
+    }
+    else
+    {
+      ADC_Disable(hadc);
+    }
+    
+    /* Check if ADC is effectively disabled */
+    if (tmp_hal_status == HAL_OK)
+    {
+      /* Set ADC state */
+      ADC_STATE_CLR_SET(hadc->State,
+                        HAL_ADC_STATE_REG_BUSY | HAL_ADC_STATE_INJ_BUSY,
+                        HAL_ADC_STATE_READY);
+    }
+    
+  }
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+  
+  /* Return function status */
+  return tmp_hal_status;
+}
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+
+#if defined(STM32F373xC) || defined(STM32F378xx)
+/**
+  * @brief  Stop ADC conversion of regular group (and injected group in 
+  *         case of auto_injection mode), disable ADC DMA transfer, disable 
+  *         ADC peripheral.
+  * @note   ADC peripheral disable is forcing interruption of potential 
+  *         conversion on injected group. If injected group is under use, it
+  *         should be preliminarily stopped using HAL_ADCEx_InjectedStop function.
+  * @note   For devices with several ADCs: This function is for single-ADC mode 
+  *         only. For multimode, use the dedicated MultimodeStop function.
+  * @param  hadc ADC handle
+  * @retval HAL status.
+  */
+HAL_StatusTypeDef HAL_ADC_Stop_DMA(ADC_HandleTypeDef* hadc)
+{
+  HAL_StatusTypeDef tmp_hal_status = HAL_OK;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+     
+  /* Process locked */
+  __HAL_LOCK(hadc);
+  
+  /* Stop potential conversion on going, on regular and injected groups */
+  /* Disable ADC peripheral */
+  tmp_hal_status = ADC_ConversionStop_Disable(hadc);
+  
+  /* Check if ADC is effectively disabled */
+  if (tmp_hal_status == HAL_OK)
+  {
+    /* Disable ADC DMA mode */
+    hadc->Instance->CR2 &= ~ADC_CR2_DMA;
+
+    /* Disable the DMA channel (in case of DMA in circular mode or stop while */
+    /* while DMA transfer is on going)                                        */
+    tmp_hal_status = HAL_DMA_Abort(hadc->DMA_Handle);
+    
+    /* Check if DMA channel effectively disabled */
+    if (tmp_hal_status == HAL_OK)
+    {
+      /* Set ADC state */
+      ADC_STATE_CLR_SET(hadc->State,
+                        HAL_ADC_STATE_REG_BUSY | HAL_ADC_STATE_INJ_BUSY,
+                        HAL_ADC_STATE_READY);
+    }
+    else
+    {
+      /* Update ADC state machine to error */
+      SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_DMA);
+    }
+  }
+    
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+    
+  /* Return function status */
+  return tmp_hal_status;
+}
+#endif /* STM32F373xC || STM32F378xx */
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+/**
+  * @brief  Get ADC regular group conversion result.
+  * @note   Reading register DR automatically clears ADC flag EOC
+  *         (ADC group regular end of unitary conversion).
+  * @note   This function does not clear ADC flag EOS 
+  *         (ADC group regular end of sequence conversion).
+  *         Occurrence of flag EOS rising:
+  *          - If sequencer is composed of 1 rank, flag EOS is equivalent
+  *            to flag EOC.
+  *          - If sequencer is composed of several ranks, during the scan
+  *            sequence flag EOC only is raised, at the end of the scan sequence
+  *            both flags EOC and EOS are raised.
+  *         To clear this flag, either use function: 
+  *         in programming model IT: @ref HAL_ADC_IRQHandler(), in programming
+  *         model polling: @ref HAL_ADC_PollForConversion() 
+  *         or @ref __HAL_ADC_CLEAR_FLAG(&hadc, ADC_FLAG_EOS).
+  * @param  hadc ADC handle
+  * @retval ADC group regular conversion data
+  */
+uint32_t HAL_ADC_GetValue(ADC_HandleTypeDef* hadc)
+{
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+
+  /* Note: ADC flag EOC is not cleared here by software because               */
+  /*       automatically cleared by hardware when reading register DR.        */
+  
+  /* Return ADC converted value */ 
+  return hadc->Instance->DR;
+}
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+
+#if defined(STM32F373xC) || defined(STM32F378xx)
+/**
+  * @brief  Get ADC regular group conversion result.
+  * @note   Reading register DR automatically clears ADC flag EOC
+  *         (ADC group regular end of unitary conversion).
+  * @note   This function does not clear ADC flag EOS 
+  *         (ADC group regular end of sequence conversion).
+  *         Occurrence of flag EOS rising:
+  *          - If sequencer is composed of 1 rank, flag EOS is equivalent
+  *            to flag EOC.
+  *          - If sequencer is composed of several ranks, during the scan
+  *            sequence flag EOC only is raised, at the end of the scan sequence
+  *            both flags EOC and EOS are raised.
+  *         To clear this flag, either use function: 
+  *         in programming model IT: @ref HAL_ADC_IRQHandler(), in programming
+  *         model polling: @ref HAL_ADC_PollForConversion() 
+  *         or @ref __HAL_ADC_CLEAR_FLAG(&hadc, ADC_FLAG_EOS).
+  * @param  hadc ADC handle
+  * @retval ADC group regular conversion data
+  */
+uint32_t HAL_ADC_GetValue(ADC_HandleTypeDef* hadc)
+{
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+
+  /* Note: EOC flag is not cleared here by software because automatically     */
+  /*       cleared by hardware when reading register DR.                      */
+  
+  /* Return ADC converted value */ 
+  return hadc->Instance->DR;
+}
+#endif /* STM32F373xC || STM32F378xx */
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+/**
+  * @brief  Handles ADC interrupt request.  
+  * @param  hadc ADC handle
+  * @retval None
+  */
+void HAL_ADC_IRQHandler(ADC_HandleTypeDef* hadc)
+{
+  uint32_t overrun_error = 0U; /* flag set if overrun occurrence has to be considered as an error */
+  ADC_Common_TypeDef *tmpADC_Common;
+  uint32_t tmp_cfgr     = 0x0U;
+  uint32_t tmp_cfgr_jqm = 0x0U;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  assert_param(IS_FUNCTIONAL_STATE(hadc->Init.ContinuousConvMode));
+  assert_param(IS_ADC_EOC_SELECTION(hadc->Init.EOCSelection));
+  
+  /* ========== Check End of Conversion flag for regular group ========== */
+  if( (__HAL_ADC_GET_FLAG(hadc, ADC_FLAG_EOC) && __HAL_ADC_GET_IT_SOURCE(hadc, ADC_IT_EOC)) || 
+      (__HAL_ADC_GET_FLAG(hadc, ADC_FLAG_EOS) && __HAL_ADC_GET_IT_SOURCE(hadc, ADC_IT_EOS))   )
+  {
+    /* Update state machine on conversion status if not in error state */
+    if (HAL_IS_BIT_CLR(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL))
+    {
+      /* Set ADC state */
+      SET_BIT(hadc->State, HAL_ADC_STATE_REG_EOC); 
+    }
+    
+    /* Get relevant register CFGR in ADC instance of ADC master or slave    */
+    /* in function of multimode state (for devices with multimode           */
+    /* available).                                                          */
+    if (ADC_NONMULTIMODE_REG_OR_MULTIMODEMASTER(hadc))
+    {
+      tmp_cfgr = READ_REG(hadc->Instance->CFGR); 
+    }
+    else
+    {
+      tmp_cfgr = READ_REG(ADC_MASTER_INSTANCE(hadc)->CFGR);
+    }
+    
+    /* Disable interruption if no further conversion upcoming by regular      */
+    /* external trigger or by continuous mode,                                */
+    /* and if scan sequence if completed.                                     */
+    if(ADC_IS_SOFTWARE_START_REGULAR(hadc)         && 
+       (READ_BIT(tmp_cfgr, ADC_CFGR_CONT) == RESET)  )
+    {
+      /* If End of Sequence is reached, disable interrupts */
+      if( __HAL_ADC_GET_FLAG(hadc, ADC_FLAG_EOS) )
+      {
+        /* Allowed to modify bits ADC_IT_EOC/ADC_IT_EOS only if bit           */
+        /* ADSTART==0 (no conversion on going)                                */
+        if (ADC_IS_CONVERSION_ONGOING_REGULAR(hadc) == RESET)
+        {
+          /* Disable ADC end of sequence conversion interrupt */
+          /* Note: Overrun interrupt was enabled with EOC interrupt in        */
+          /* HAL_Start_IT(), but is not disabled here because can be used     */
+          /* by overrun IRQ process below.                                    */
+          __HAL_ADC_DISABLE_IT(hadc, ADC_IT_EOC | ADC_IT_EOS);
+          
+          /* Set ADC state */
+          CLEAR_BIT(hadc->State, HAL_ADC_STATE_REG_BUSY);   
+          
+          if (HAL_IS_BIT_CLR(hadc->State, HAL_ADC_STATE_INJ_BUSY))
+          {
+            SET_BIT(hadc->State, HAL_ADC_STATE_READY);
+          }
+        }
+        else
+        {
+          /* Update ADC state machine to error */
+          SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL);
+        
+          /* Set ADC error code to ADC IP internal error */
+          SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_INTERNAL);
+        }
+      }
+    }
+    
+    /* Conversion complete callback */
+    /* Note: into callback, to determine if conversion has been triggered     */
+    /*       from EOC or EOS, possibility to use:                             */
+    /*        " if( __HAL_ADC_GET_FLAG(&hadc, ADC_FLAG_EOS)) "                */
+#if (USE_HAL_ADC_REGISTER_CALLBACKS == 1)
+      hadc->ConvCpltCallback(hadc);
+#else
+      HAL_ADC_ConvCpltCallback(hadc);
+#endif /* USE_HAL_ADC_REGISTER_CALLBACKS */
+
+    
+    /* Clear regular group conversion flag */
+    /* Note: in case of overrun set to ADC_OVR_DATA_PRESERVED, end of         */
+    /*       conversion flags clear induces the release of the preserved      */
+    /*       data.                                                            */
+    /*       Therefore, if the preserved data value is needed, it must be     */
+    /*       read preliminarily into HAL_ADC_ConvCpltCallback().              */
+    __HAL_ADC_CLEAR_FLAG(hadc, (ADC_FLAG_EOC | ADC_FLAG_EOS) );
+  }
+  
+  
+  /* ========== Check End of Conversion flag for injected group ========== */
+  if( (__HAL_ADC_GET_FLAG(hadc, ADC_FLAG_JEOC) && __HAL_ADC_GET_IT_SOURCE(hadc, ADC_IT_JEOC)) ||   
+      (__HAL_ADC_GET_FLAG(hadc, ADC_FLAG_JEOS) && __HAL_ADC_GET_IT_SOURCE(hadc, ADC_IT_JEOS))   )
+  {
+    /* Set ADC state */
+    SET_BIT(hadc->State, HAL_ADC_STATE_INJ_EOC);
+        
+    /* Get relevant register CFGR in ADC instance of ADC master or slave      */
+    /* in function of multimode state (for devices with multimode             */
+    /* available).                                                            */
+    if (ADC_NONMULTIMODE_REG_OR_MULTIMODEMASTER(hadc))
+    {
+      tmp_cfgr = READ_REG(hadc->Instance->CFGR); 
+    }
+    else
+    {
+      tmp_cfgr = READ_REG(ADC_MASTER_INSTANCE(hadc)->CFGR);
+    }
+    
+    /* Disable interruption if no further conversion upcoming by injected     */
+    /* external trigger or by automatic injected conversion with regular      */
+    /* group having no further conversion upcoming (same conditions as        */
+    /* regular group interruption disabling above),                           */
+    /* and if injected scan sequence is completed.                            */
+    if(ADC_IS_SOFTWARE_START_INJECTED(hadc))
+    {
+      if((READ_BIT (tmp_cfgr, ADC_CFGR_JAUTO) == RESET)    ||
+         (ADC_IS_SOFTWARE_START_REGULAR(hadc)          &&
+          (READ_BIT (tmp_cfgr, ADC_CFGR_CONT) == RESET)   )   )
+      {
+        /* If End of Sequence is reached, disable interrupts */
+        if( __HAL_ADC_GET_FLAG(hadc, ADC_FLAG_JEOS))
+        {
+          
+          /* Get relevant register CFGR in ADC instance of ADC master or slave  */
+          /* in function of multimode state (for devices with multimode         */
+          /* available).                                                        */
+          if (ADC_NONMULTIMODE_INJ_OR_MULTIMODEMASTER(hadc))
+          {
+            tmp_cfgr_jqm = READ_REG(hadc->Instance->CFGR); 
+          }
+          else
+          {
+            tmp_cfgr_jqm = READ_REG(ADC_MASTER_INSTANCE(hadc)->CFGR);
+          }
+          
+          /* Particular case if injected contexts queue is enabled:             */
+          /* when the last context has been fully processed, JSQR is reset      */
+          /* by the hardware. Even if no injected conversion is planned to come */
+          /* (queue empty, triggers are ignored), it can start again            */
+          /* immediately after setting a new context (JADSTART is still set).   */
+          /* Therefore, state of HAL ADC injected group is kept to busy.        */
+          if(READ_BIT(tmp_cfgr_jqm, ADC_CFGR_JQM) == RESET)
+          {
+            /* Allowed to modify bits ADC_IT_JEOC/ADC_IT_JEOS only if bit       */
+            /* JADSTART==0 (no conversion on going)                             */
+            if (ADC_IS_CONVERSION_ONGOING_INJECTED(hadc) == RESET)
+            {
+              /* Disable ADC end of sequence conversion interrupt  */
+              __HAL_ADC_DISABLE_IT(hadc, ADC_IT_JEOC | ADC_IT_JEOS);
+              
+              /* Set ADC state */
+              CLEAR_BIT(hadc->State, HAL_ADC_STATE_INJ_BUSY);
+              
+              if (HAL_IS_BIT_CLR(hadc->State, HAL_ADC_STATE_REG_BUSY))
+              { 
+                SET_BIT(hadc->State, HAL_ADC_STATE_READY);
+              }
+            }
+            else
+            {
+              /* Update ADC state machine to error */
+              SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL);
+              
+              /* Set ADC error code to ADC IP internal error */
+              SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_INTERNAL);
+            }
+          }
+        }
+      }
+    }
+    
+    /* Conversion complete callback */
+    /* Note: into callback, to determine if conversion has been triggered     */
+    /*       from JEOC or JEOS, possibility to use:                           */
+    /*        " if( __HAL_ADC_GET_FLAG(&hadc, ADC_FLAG_JEOS)) "               */
+#if (USE_HAL_ADC_REGISTER_CALLBACKS == 1)
+      hadc->InjectedConvCpltCallback(hadc);
+#else
+      HAL_ADCEx_InjectedConvCpltCallback(hadc);
+#endif /* USE_HAL_ADC_REGISTER_CALLBACKS */
+    
+    /* Clear injected group conversion flag */
+    __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_JEOC | ADC_FLAG_JEOS);
+  }
+  
+  /* ========== Check analog watchdog 1 flag ========== */
+  if (__HAL_ADC_GET_FLAG(hadc, ADC_FLAG_AWD1) && __HAL_ADC_GET_IT_SOURCE(hadc, ADC_IT_AWD1))
+  {
+    /* Set ADC state */
+    SET_BIT(hadc->State, HAL_ADC_STATE_AWD1);
+    
+    /* Level out of window 1 callback */
+#if (USE_HAL_ADC_REGISTER_CALLBACKS == 1)
+      hadc->LevelOutOfWindowCallback(hadc);
+#else
+      HAL_ADC_LevelOutOfWindowCallback(hadc);
+#endif /* USE_HAL_ADC_REGISTER_CALLBACKS */
+    /* Clear ADC analog watchdog flag */ 
+    __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_AWD1);
+  }
+  
+  /* ========== Check analog watchdog 2 flag ========== */
+  if (__HAL_ADC_GET_FLAG(hadc, ADC_FLAG_AWD2) && __HAL_ADC_GET_IT_SOURCE(hadc, ADC_IT_AWD2))
+  {
+    /* Set ADC state */
+    SET_BIT(hadc->State, HAL_ADC_STATE_AWD2);
+    
+    /* Level out of window 2 callback */
+    HAL_ADCEx_LevelOutOfWindow2Callback(hadc);
+    /* Clear ADC analog watchdog flag */ 
+    __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_AWD2);
+  } 
+  
+  /* ========== Check analog watchdog 3 flag ========== */
+  if (__HAL_ADC_GET_FLAG(hadc, ADC_FLAG_AWD3) && __HAL_ADC_GET_IT_SOURCE(hadc, ADC_IT_AWD3)) 
+  {
+    /* Set ADC state */
+    SET_BIT(hadc->State, HAL_ADC_STATE_AWD3);
+    
+    /* Level out of window 3 callback */
+    HAL_ADCEx_LevelOutOfWindow3Callback(hadc);
+    /* Clear ADC analog watchdog flag */ 
+    __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_AWD3);
+  }
+  
+  /* ========== Check Overrun flag ========== */
+  if(__HAL_ADC_GET_FLAG(hadc, ADC_FLAG_OVR) && __HAL_ADC_GET_IT_SOURCE(hadc, ADC_IT_OVR))
+  {
+    /* If overrun is set to overwrite previous data (default setting),        */
+    /* overrun event is not considered as an error.                           */
+    /* (cf ref manual "Managing conversions without using the DMA and         */
+    /* without overrun ")                                                     */
+    /* Exception for usage with DMA overrun event always considered as an     */
+    /* error.                                                                 */
+    if (hadc->Init.Overrun == ADC_OVR_DATA_PRESERVED)
+    {
+      overrun_error = 1U;
+    }
+    else
+    {
+      /* Pointer to the common control register to which is belonging hadc    */
+      /* (Depending on STM32F3 product, there may be up to 4 ADC and 2 common */
+      /* control registers)                                                   */
+      tmpADC_Common = ADC_COMMON_REGISTER(hadc);
+      
+      /* Check DMA configuration, depending on MultiMode set or not */
+      if (READ_BIT(tmpADC_Common->CCR, ADC_CCR_MULTI) == ADC_MODE_INDEPENDENT)
+      {
+        if (HAL_IS_BIT_SET(hadc->Instance->CFGR, ADC_CFGR_DMAEN))
+        {
+          overrun_error = 1U;  
+        }
+      }
+      else
+      {
+        /* MultiMode is enabled, Common Control Register MDMA bits must be checked */
+        if (READ_BIT(tmpADC_Common->CCR, ADC_CCR_MDMA) != RESET)
+        {
+          overrun_error = 1U;  
+        }
+      }
+    }
+    
+    if (overrun_error == 1U)
+    {
+      /* Update ADC state machine to error */
+      SET_BIT(hadc->State, HAL_ADC_STATE_REG_OVR);
+    
+      /* Set ADC error code to ADC IP internal error */
+      SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_OVR);
+      
+      /* Error callback */ 
+#if (USE_HAL_ADC_REGISTER_CALLBACKS == 1)
+      hadc->ErrorCallback(hadc);
+#else
+      HAL_ADC_ErrorCallback(hadc);
+#endif /* USE_HAL_ADC_REGISTER_CALLBACKS */
+    }
+    
+    /* Clear the Overrun flag */
+    __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_OVR);
+
+  }
+  
+  
+  /* ========== Check Injected context queue overflow flag ========== */
+  if(__HAL_ADC_GET_FLAG(hadc, ADC_FLAG_JQOVF) && __HAL_ADC_GET_IT_SOURCE(hadc, ADC_IT_JQOVF))
+  {
+      /* Update ADC state machine to error */
+      SET_BIT(hadc->State, HAL_ADC_STATE_INJ_JQOVF);
+    
+      /* Set ADC error code to ADC IP internal error */
+      SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_JQOVF);
+    
+    /* Clear the Injected context queue overflow flag */
+    __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_JQOVF);
+    
+    /* Error callback */ 
+    HAL_ADCEx_InjectedQueueOverflowCallback(hadc);
+  }
+  
+}
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+
+#if defined(STM32F373xC) || defined(STM32F378xx)
+/**
+  * @brief  Handles ADC interrupt request  
+  * @param  hadc ADC handle
+  * @retval None
+  */
+void HAL_ADC_IRQHandler(ADC_HandleTypeDef* hadc)
+{
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  assert_param(IS_FUNCTIONAL_STATE(hadc->Init.ContinuousConvMode));
+  assert_param(IS_ADC_REGULAR_NB_CONV(hadc->Init.NbrOfConversion));
+  
+  
+  /* ========== Check End of Conversion flag for regular group ========== */
+  if(__HAL_ADC_GET_IT_SOURCE(hadc, ADC_IT_EOC))
+  {
+    if(__HAL_ADC_GET_FLAG(hadc, ADC_FLAG_EOC) )
+    {
+      /* Update state machine on conversion status if not in error state */
+      if (HAL_IS_BIT_CLR(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL))
+      {
+        /* Set ADC state */
+        SET_BIT(hadc->State, HAL_ADC_STATE_REG_EOC); 
+      }
+      
+      /* Determine whether any further conversion upcoming on group regular   */
+      /* by external trigger, continuous mode or scan sequence on going.      */
+      /* Note: On STM32F37x devices, in case of sequencer enabled             */
+      /*       (several ranks selected), end of conversion flag is raised     */
+      /*       at the end of the sequence.                                    */
+      if(ADC_IS_SOFTWARE_START_REGULAR(hadc)       && 
+         (hadc->Init.ContinuousConvMode == DISABLE)  )
+      {
+        /* Disable ADC end of single conversion interrupt  */
+        __HAL_ADC_DISABLE_IT(hadc, ADC_IT_EOC);
+        
+        /* Set ADC state */
+        CLEAR_BIT(hadc->State, HAL_ADC_STATE_REG_BUSY);   
+        
+        if (HAL_IS_BIT_CLR(hadc->State, HAL_ADC_STATE_INJ_BUSY))
+        {
+          SET_BIT(hadc->State, HAL_ADC_STATE_READY);
+        }
+      }
+
+      /* Conversion complete callback */
+#if (USE_HAL_ADC_REGISTER_CALLBACKS == 1)
+      hadc->ConvCpltCallback(hadc);
+#else
+      HAL_ADC_ConvCpltCallback(hadc);
+#endif /* USE_HAL_ADC_REGISTER_CALLBACKS */
+      
+      /* Clear regular group conversion flag */
+      __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_STRT | ADC_FLAG_EOC);
+    }
+  }
+  
+  /* ========== Check End of Conversion flag for injected group ========== */
+  if(__HAL_ADC_GET_IT_SOURCE(hadc, ADC_IT_JEOC))
+  {
+    if(__HAL_ADC_GET_FLAG(hadc, ADC_FLAG_JEOC))
+    {
+      /* Update state machine on conversion status if not in error state */
+      if (HAL_IS_BIT_CLR(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL))
+      {
+        /* Set ADC state */
+        SET_BIT(hadc->State, HAL_ADC_STATE_INJ_EOC);
+      }
+
+      /* Determine whether any further conversion upcoming on group injected  */
+      /* by external trigger, scan sequence on going or by automatic injected */
+      /* conversion from group regular (same conditions as group regular      */
+      /* interruption disabling above).                                       */
+      /* Note: On STM32F37x devices, in case of sequencer enabled             */
+      /*       (several ranks selected), end of conversion flag is raised     */
+      /*       at the end of the sequence.                                    */
+      if(ADC_IS_SOFTWARE_START_INJECTED(hadc)                     || 
+         (HAL_IS_BIT_CLR(hadc->Instance->CR1, ADC_CR1_JAUTO) &&     
+         (ADC_IS_SOFTWARE_START_REGULAR(hadc)       &&
+          (hadc->Init.ContinuousConvMode == DISABLE)  )         )   )
+      {
+        /* Disable ADC end of single conversion interrupt  */
+        __HAL_ADC_DISABLE_IT(hadc, ADC_IT_JEOC);
+        
+        /* Set ADC state */
+        CLEAR_BIT(hadc->State, HAL_ADC_STATE_INJ_BUSY);   
+
+        if (HAL_IS_BIT_CLR(hadc->State, HAL_ADC_STATE_REG_BUSY))
+        { 
+          SET_BIT(hadc->State, HAL_ADC_STATE_READY);
+        }
+      }
+
+      /* Conversion complete callback */ 
+#if (USE_HAL_ADC_REGISTER_CALLBACKS == 1)
+      hadc->InjectedConvCpltCallback(hadc);
+#else
+      HAL_ADCEx_InjectedConvCpltCallback(hadc);
+#endif /* USE_HAL_ADC_REGISTER_CALLBACKS */
+      
+      /* Clear injected group conversion flag */
+      __HAL_ADC_CLEAR_FLAG(hadc, (ADC_FLAG_JSTRT | ADC_FLAG_JEOC));
+    }
+  }
+   
+  /* ========== Check Analog watchdog flags ========== */
+  if(__HAL_ADC_GET_IT_SOURCE(hadc, ADC_IT_AWD))
+  {
+    if(__HAL_ADC_GET_FLAG(hadc, ADC_FLAG_AWD))
+    {
+      /* Set ADC state */
+      SET_BIT(hadc->State, HAL_ADC_STATE_AWD1);
+      
+      /* Level out of window callback */ 
+#if (USE_HAL_ADC_REGISTER_CALLBACKS == 1)
+      hadc->LevelOutOfWindowCallback(hadc);
+#else
+      HAL_ADC_LevelOutOfWindowCallback(hadc);
+#endif /* USE_HAL_ADC_REGISTER_CALLBACKS */
+      
+      /* Clear the ADC analog watchdog flag */
+      __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_AWD);
+    }
+  }
+  
+}
+#endif /* STM32F373xC || STM32F378xx */
+
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+/**
+  * @brief  Perform an ADC automatic self-calibration
+  *         Calibration prerequisite: ADC must be disabled (execute this
+  *         function before HAL_ADC_Start() or after HAL_ADC_Stop() ).
+  * @param  hadc ADC handle
+  * @param  SingleDiff Selection of single-ended or differential input
+  *          This parameter can be one of the following values:
+  *            @arg ADC_SINGLE_ENDED: Channel in mode input single ended
+  *            @arg ADC_DIFFERENTIAL_ENDED: Channel in mode input differential ended
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADCEx_Calibration_Start(ADC_HandleTypeDef* hadc, uint32_t SingleDiff)
+{
+  HAL_StatusTypeDef tmp_hal_status = HAL_OK;
+  uint32_t tickstart;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  assert_param(IS_ADC_SINGLE_DIFFERENTIAL(SingleDiff));
+
+  /* Process locked */
+  __HAL_LOCK(hadc);
+   
+  /* Calibration prerequisite: ADC must be disabled. */
+   
+  /* Disable the ADC (if not already disabled) */
+  tmp_hal_status = ADC_Disable(hadc);
+  
+  /* Check if ADC is effectively disabled */
+  if (tmp_hal_status == HAL_OK)
+  {
+    /* Change ADC state */
+    hadc->State = HAL_ADC_STATE_READY;
+    
+    /* Select calibration mode single ended or differential ended */
+    hadc->Instance->CR &= (~ADC_CR_ADCALDIF);
+    if (SingleDiff == ADC_DIFFERENTIAL_ENDED)
+    {
+      hadc->Instance->CR |= ADC_CR_ADCALDIF;
+    }
+
+    /* Start ADC calibration */
+    hadc->Instance->CR |= ADC_CR_ADCAL;
+
+    tickstart = HAL_GetTick();  
+
+    /* Wait for calibration completion */
+    while(HAL_IS_BIT_SET(hadc->Instance->CR, ADC_CR_ADCAL))
+    {
+      if((HAL_GetTick() - tickstart) > ADC_CALIBRATION_TIMEOUT)
+      {
+        /* Update ADC state machine to error */
+        ADC_STATE_CLR_SET(hadc->State,
+                          HAL_ADC_STATE_BUSY_INTERNAL,
+                          HAL_ADC_STATE_ERROR_INTERNAL);
+        
+        /* Process unlocked */
+        __HAL_UNLOCK(hadc);
+        
+        return HAL_ERROR;
+      }
+    }
+    
+    /* Set ADC state */
+    ADC_STATE_CLR_SET(hadc->State,
+                      HAL_ADC_STATE_BUSY_INTERNAL,
+                      HAL_ADC_STATE_READY);
+  }
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+  
+  /* Return function status */
+  return tmp_hal_status;
+}
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+
+#if defined(STM32F373xC) || defined(STM32F378xx)
+/**
+  * @brief  Perform an ADC automatic self-calibration
+  *         Calibration prerequisite: ADC must be disabled (execute this
+  *         function before HAL_ADC_Start() or after HAL_ADC_Stop() ).
+  *         During calibration process, ADC is enabled. ADC is let enabled at
+  *         the completion of this function.
+  * @param  hadc ADC handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADCEx_Calibration_Start(ADC_HandleTypeDef* hadc)
+{
+  HAL_StatusTypeDef tmp_hal_status = HAL_OK;
+  uint32_t tickstart;
+  __IO uint32_t wait_loop_index = 0U;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+
+  /* Process locked */
+  __HAL_LOCK(hadc);
+    
+  /* 1. Calibration prerequisite:                                             */
+  /*    - ADC must be disabled for at least two ADC clock cycles in disable   */
+  /*      mode before ADC enable                                              */
+  /* Stop potential conversion on going, on regular and injected groups       */
+  /* Disable ADC peripheral */
+  tmp_hal_status = ADC_ConversionStop_Disable(hadc);
+  
+  /* Check if ADC is effectively disabled */
+  if (tmp_hal_status == HAL_OK)
+  {
+    /* Set ADC state */
+    ADC_STATE_CLR_SET(hadc->State,
+                      HAL_ADC_STATE_REG_BUSY | HAL_ADC_STATE_INJ_BUSY,
+                      HAL_ADC_STATE_BUSY_INTERNAL);
+    
+    /* Wait two ADC clock cycles */
+    while(wait_loop_index < ADC_CYCLE_WORST_CASE_CPU_CYCLES *2U)
+    {
+      wait_loop_index++;
+    }
+    
+    /* 2. Enable the ADC peripheral */
+    ADC_Enable(hadc);
+    
+
+    /* 3. Resets ADC calibration registers */  
+    SET_BIT(hadc->Instance->CR2, ADC_CR2_RSTCAL);
+    
+    tickstart = HAL_GetTick();  
+
+    /* Wait for calibration reset completion */
+    while(HAL_IS_BIT_SET(hadc->Instance->CR2, ADC_CR2_RSTCAL))
+    {
+      if((HAL_GetTick() - tickstart) > ADC_CALIBRATION_TIMEOUT)
+      {
+        /* Update ADC state machine to error */
+        ADC_STATE_CLR_SET(hadc->State,
+                          HAL_ADC_STATE_BUSY_INTERNAL,
+                          HAL_ADC_STATE_ERROR_INTERNAL);
+        
+        /* Process unlocked */
+        __HAL_UNLOCK(hadc);
+        
+        return HAL_ERROR;
+      }
+    }
+    
+    
+    /* 4. Start ADC calibration */
+    SET_BIT(hadc->Instance->CR2, ADC_CR2_CAL);
+
+    tickstart = HAL_GetTick();  
+
+    /* Wait for calibration completion */
+    while(HAL_IS_BIT_SET(hadc->Instance->CR2, ADC_CR2_CAL))
+    {
+      if((HAL_GetTick() - tickstart) > ADC_CALIBRATION_TIMEOUT)
+      {
+        /* Update ADC state machine to error */
+        ADC_STATE_CLR_SET(hadc->State,
+                          HAL_ADC_STATE_BUSY_INTERNAL,
+                          HAL_ADC_STATE_ERROR_INTERNAL);
+        
+        /* Process unlocked */
+        __HAL_UNLOCK(hadc);
+        
+        return HAL_ERROR;
+      }
+    }
+    
+    /* Set ADC state */
+    ADC_STATE_CLR_SET(hadc->State,
+                      HAL_ADC_STATE_BUSY_INTERNAL,
+                      HAL_ADC_STATE_READY);
+  }
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+  
+  /* Return function status */
+  return tmp_hal_status;
+}
+
+#endif /* STM32F373xC || STM32F378xx */
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+/**
+  * @brief  Get the calibration factor from automatic conversion result
+  * @param  hadc ADC handle
+  * @param  SingleDiff Selection of single-ended or differential input
+  *          This parameter can be one of the following values:
+  *            @arg ADC_SINGLE_ENDED: Channel in mode input single ended
+  *            @arg ADC_DIFFERENTIAL_ENDED: Channel in mode input differential ended
+  * @retval Converted value
+  */
+uint32_t HAL_ADCEx_Calibration_GetValue(ADC_HandleTypeDef* hadc, uint32_t SingleDiff)
+{
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  assert_param(IS_ADC_SINGLE_DIFFERENTIAL(SingleDiff)); 
+  
+  /* Return the selected ADC calibration value */ 
+  if (SingleDiff == ADC_DIFFERENTIAL_ENDED)
+  {
+    return ADC_CALFACT_DIFF_GET(hadc->Instance->CALFACT);
+  }
+  else
+  {
+    return ((hadc->Instance->CALFACT) & ADC_CALFACT_CALFACT_S);
+  }
+}
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+/**
+  * @brief  Set the calibration factor to overwrite automatic conversion result. ADC must be enabled and no conversion on going.
+  * @param  hadc ADC handle
+  * @param  SingleDiff Selection of single-ended or differential input
+  *          This parameter can be one of the following values:
+  *            @arg ADC_SINGLE_ENDED: Channel in mode input single ended
+  *            @arg ADC_DIFFERENTIAL_ENDED: Channel in mode input differential ended
+  * @param  CalibrationFactor Calibration factor (coded on 7 bits maximum)
+  * @retval HAL state
+  */
+HAL_StatusTypeDef HAL_ADCEx_Calibration_SetValue(ADC_HandleTypeDef* hadc, uint32_t SingleDiff, uint32_t CalibrationFactor)
+{
+  HAL_StatusTypeDef tmp_hal_status = HAL_OK;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  assert_param(IS_ADC_SINGLE_DIFFERENTIAL(SingleDiff)); 
+  assert_param(IS_ADC_CALFACT(CalibrationFactor)); 
+  
+  /* Process locked */
+  __HAL_LOCK(hadc);
+  
+  /* Verification of hardware constraints before modifying the calibration    */
+  /* factors register: ADC must be enabled, no conversion on going.           */
+  if ( (ADC_IS_ENABLE(hadc) != RESET)                              &&
+       (ADC_IS_CONVERSION_ONGOING_REGULAR_INJECTED(hadc) == RESET)   )
+  {
+    /* Set the selected ADC calibration value */ 
+    if (SingleDiff == ADC_DIFFERENTIAL_ENDED)
+    {
+      MODIFY_REG(hadc->Instance->CALFACT                ,
+                 ADC_CALFACT_CALFACT_D                  ,
+                 ADC_CALFACT_DIFF_SET(CalibrationFactor) );
+    }
+    else
+    {
+      MODIFY_REG(hadc->Instance->CALFACT,
+                 ADC_CALFACT_CALFACT_S  ,
+                 CalibrationFactor       );
+    }
+  }
+  else
+  {
+    /* Update ADC state machine to error */
+    SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_CONFIG);
+    
+    /* Set ADC error code to ADC IP internal error */
+    SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_INTERNAL);
+  }
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+  
+  /* Return function status */
+  return tmp_hal_status;
+}
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+/**
+  * @brief  Enables ADC, starts conversion of injected group.
+  *         Interruptions enabled in this function: None.
+  * @note   Case of multimode enabled (for devices with several ADCs): This 
+  *         function must be called for ADC slave first, then ADC master. 
+  *         For ADC slave, ADC is enabled only (conversion is not started).  
+  *         For ADC master, ADC is enabled and multimode conversion is started.
+  * @param  hadc ADC handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADCEx_InjectedStart(ADC_HandleTypeDef* hadc)
+{
+  HAL_StatusTypeDef tmp_hal_status = HAL_OK;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  
+  /* Perform ADC enable and conversion start if no conversion is on going */
+  if (ADC_IS_CONVERSION_ONGOING_INJECTED(hadc) == RESET)
+  {
+    /* Process locked */
+    __HAL_LOCK(hadc);
+    
+    /* Enable the ADC peripheral */
+    tmp_hal_status = ADC_Enable(hadc);
+    
+      /* Start conversion if ADC is effectively enabled */
+    if (tmp_hal_status == HAL_OK)
+    {
+      /* Set ADC state                                                        */
+      /* - Clear state bitfield related to injected group conversion results  */
+      /* - Set state bitfield related to injected operation                   */
+      ADC_STATE_CLR_SET(hadc->State,
+                        HAL_ADC_STATE_READY | HAL_ADC_STATE_INJ_EOC,
+                        HAL_ADC_STATE_INJ_BUSY);
+      
+      /* Case of independent mode or multimode(for devices with several ADCs):*/
+      /* Set multimode state.                                                 */
+      if (ADC_NONMULTIMODE_OR_MULTIMODEMASTER(hadc))
+      {
+        CLEAR_BIT(hadc->State, HAL_ADC_STATE_MULTIMODE_SLAVE);
+      }
+      else
+      {
+        SET_BIT(hadc->State, HAL_ADC_STATE_MULTIMODE_SLAVE);
+      }
+      
+      /* Check if a regular conversion is ongoing */
+      /* Note: On this device, there is no ADC error code fields related to   */
+      /*       conversions on group injected only. In case of conversion on   */
+      /*       going on group regular, no error code is reset.                */
+      if (HAL_IS_BIT_CLR(hadc->State, HAL_ADC_STATE_REG_BUSY))
+      {
+        /* Reset ADC all error code fields */
+        ADC_CLEAR_ERRORCODE(hadc);
+      }
+      
+      /* Process unlocked */
+      /* Unlock before starting ADC conversions: in case of potential         */
+      /* interruption, to let the process to ADC IRQ Handler.                 */
+      __HAL_UNLOCK(hadc);
+      
+      /* Clear injected group conversion flag */
+      /* (To ensure of no unknown state from potential previous ADC           */
+      /* operations)                                                          */
+      __HAL_ADC_CLEAR_FLAG(hadc, (ADC_FLAG_JEOC | ADC_FLAG_JEOS));
+      
+      /* Enable conversion of injected group, if automatic injected           */
+      /* conversion is disabled.                                              */
+      /* If software start has been selected, conversion starts immediately.  */
+      /* If external trigger has been selected, conversion will start at next */
+      /* trigger event.                                                       */
+      /* Case of multimode enabled (for devices with several ADCs):           */
+      /*  - if ADC is slave, ADC is enabled only (conversion is not started). */
+      /*  - if ADC is master, ADC is enabled and conversion is started.       */
+      if (HAL_IS_BIT_CLR(hadc->Instance->CFGR, ADC_CFGR_JAUTO) && 
+          ADC_NONMULTIMODE_INJ_OR_MULTIMODEMASTER(hadc)          )
+      {
+        SET_BIT(hadc->Instance->CR, ADC_CR_JADSTART);
+      }
+    }
+    else
+    {
+      /* Process unlocked */
+      __HAL_UNLOCK(hadc);
+    }
+  }
+  else
+  {
+    tmp_hal_status = HAL_BUSY;
+  }
+  
+  /* Return function status */
+  return tmp_hal_status;
+}
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+
+#if defined(STM32F373xC) || defined(STM32F378xx)
+/**
+  * @brief  Enables ADC, starts conversion of injected group.
+  *         Interruptions enabled in this function: None.
+  * @param  hadc ADC handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADCEx_InjectedStart(ADC_HandleTypeDef* hadc)
+{
+  HAL_StatusTypeDef tmp_hal_status = HAL_OK;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  
+  /* Process locked */
+  __HAL_LOCK(hadc);
+    
+  /* Enable the ADC peripheral */
+  tmp_hal_status = ADC_Enable(hadc);
+  
+  /* Start conversion if ADC is effectively enabled */
+  if (tmp_hal_status == HAL_OK)
+  {
+    /* Set ADC state                                                          */
+    /* - Clear state bitfield related to injected group conversion results    */
+    /* - Set state bitfield related to injected operation                     */
+    ADC_STATE_CLR_SET(hadc->State,
+                      HAL_ADC_STATE_READY | HAL_ADC_STATE_INJ_EOC,
+                      HAL_ADC_STATE_INJ_BUSY);
+    
+    /* Check if a regular conversion is ongoing */
+    /* Note: On this device, there is no ADC error code fields related to     */
+    /*       conversions on group injected only. In case of conversion on     */
+    /*       going on group regular, no error code is reset.                  */
+    if (HAL_IS_BIT_CLR(hadc->State, HAL_ADC_STATE_REG_BUSY))
+    {
+      /* Reset ADC all error code fields */
+      ADC_CLEAR_ERRORCODE(hadc);
+    }
+    
+    /* Process unlocked */
+    /* Unlock before starting ADC conversions: in case of potential           */
+    /* interruption, to let the process to ADC IRQ Handler.                   */
+    __HAL_UNLOCK(hadc);
+    
+    /* Clear injected group conversion flag */
+    /* (To ensure of no unknown state from potential previous ADC operations) */
+    __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_JEOC);
+    
+    /* Enable conversion of injected group.                                   */
+    /* If software start has been selected, conversion starts immediately.    */
+    /* If external trigger has been selected, conversion will start at next   */
+    /* trigger event.                                                         */
+    /* If external trigger has been selected, conversion will start at next   */
+    /* trigger event.                                                         */
+    /* If automatic injected conversion is enabled, conversion will start     */
+    /* after next regular group conversion.                                   */
+    if (ADC_IS_SOFTWARE_START_INJECTED(hadc)               && 
+        HAL_IS_BIT_CLR(hadc->Instance->CR1, ADC_CR1_JAUTO)   )
+    {
+      /* Start ADC conversion on injected group with SW start */
+      SET_BIT(hadc->Instance->CR2, (ADC_CR2_JSWSTART | ADC_CR2_JEXTTRIG));
+    }
+    else
+    {
+      /* Start ADC conversion on injected group with external trigger */
+      SET_BIT(hadc->Instance->CR2, ADC_CR2_JEXTTRIG);
+    }
+  }
+
+  /* Return function status */
+  return tmp_hal_status;
+}
+#endif /* STM32F373xC || STM32F378xx */
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+/**
+  * @brief  Stop ADC group injected conversion (potential conversion on going
+  *         on ADC group regular is not impacted), disable ADC peripheral
+  *         if no conversion is on going on group regular.
+  * @note   To stop ADC conversion of both groups regular and injected and to
+  *         to disable ADC peripheral, instead of using 2 functions
+  *         @ref HAL_ADCEx_RegularStop() and @ref HAL_ADCEx_InjectedStop(),
+  *         use function @ref HAL_ADC_Stop().
+  * @note   If injected group mode auto-injection is enabled,
+  *         function HAL_ADC_Stop must be used.
+  * @note   Case of multimode enabled (for devices with several ADCs): This 
+  *         function must be called for ADC master first, then ADC slave.
+  *         For ADC master, conversion is stopped and ADC is disabled. 
+  *         For ADC slave, ADC is disabled only (conversion stop of ADC master
+  *         has already stopped conversion of ADC slave).
+  * @note   In case of auto-injection mode, HAL_ADC_Stop must be used.
+  * @param  hadc ADC handle
+  * @retval None
+  */
+HAL_StatusTypeDef HAL_ADCEx_InjectedStop(ADC_HandleTypeDef* hadc)
+{
+  HAL_StatusTypeDef tmp_hal_status = HAL_OK;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  
+  /* Process locked */
+  __HAL_LOCK(hadc);
+  
+  /* Stop potential ADC conversion on going and disable ADC peripheral        */
+  /* conditioned to:                                                          */
+  /* - In case of auto-injection mode, HAL_ADC_Stop must be used.             */
+  /* - For ADC injected group conversion stop:                                */
+  /*   On this STM32 family, conversion on the other group                    */
+  /*   (group regular) can continue (groups regular and injected              */
+  /*   conversion stop commands are independent)                              */
+  /* - For ADC disable:                                                       */
+  /*   No conversion on the other group (group regular) must be intended to   */
+  /*   continue (groups regular and injected are both impacted by             */
+  /*   ADC disable)                                                           */
+  if(HAL_IS_BIT_CLR(hadc->Instance->CFGR, ADC_CFGR_JAUTO))
+  {
+    /* 1. Stop potential conversion on going on injected group only. */
+    tmp_hal_status = ADC_ConversionStop(hadc, ADC_INJECTED_GROUP);
+    
+    /* Disable ADC peripheral if conversion on ADC group injected is          */
+    /* effectively stopped and if no conversion on the other group            */
+    /* (ADC group regular) is intended to continue.                           */
+    if (tmp_hal_status == HAL_OK)
+    {      
+      if((ADC_IS_CONVERSION_ONGOING_REGULAR(hadc) == RESET) &&
+         ((hadc->State & HAL_ADC_STATE_REG_BUSY) == RESET)    )
+      {
+        /* 2. Disable the ADC peripheral */
+        tmp_hal_status = ADC_Disable(hadc);
+        
+        /* Check if ADC is effectively disabled */
+        if (tmp_hal_status == HAL_OK)
+        {
+          /* Set ADC state */
+          ADC_STATE_CLR_SET(hadc->State,
+                            HAL_ADC_STATE_REG_BUSY | HAL_ADC_STATE_INJ_BUSY,
+                            HAL_ADC_STATE_READY);
+        }
+      }
+      /* Conversion on ADC group injected group is stopped, but ADC is not    */
+      /* disabled since conversion on ADC group regular is still on going.    */
+      else
+      {
+        /* Set ADC state */
+        CLEAR_BIT(hadc->State, HAL_ADC_STATE_INJ_BUSY);
+      }
+    }
+  }
+  else
+  {
+    /* Update ADC state machine to error */
+    SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_CONFIG);
+      
+    tmp_hal_status = HAL_ERROR;
+  }
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+  
+  /* Return function status */
+  return tmp_hal_status;
+}
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+
+#if defined(STM32F373xC) || defined(STM32F378xx)
+/**
+  * @brief  Stop conversion of injected channels. Disable ADC peripheral if
+  *         no regular conversion is on going.
+  * @note   If ADC must be disabled and if conversion is on going on 
+  *         regular group, function HAL_ADC_Stop must be used to stop both
+  *         injected and regular groups, and disable the ADC.
+  * @note   In case of auto-injection mode, HAL_ADC_Stop must be used.
+  * @param  hadc ADC handle
+  * @retval None
+  */
+HAL_StatusTypeDef HAL_ADCEx_InjectedStop(ADC_HandleTypeDef* hadc)
+{
+  HAL_StatusTypeDef tmp_hal_status = HAL_OK;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+
+  /* Process locked */
+  __HAL_LOCK(hadc);
+    
+  /* Stop potential conversion and disable ADC peripheral                     */
+  /* Conditioned to:                                                          */
+  /* - No conversion on the other group (regular group) is intended to        */
+  /*   continue (injected and regular groups stop conversion and ADC disable  */
+  /*   are common)                                                            */
+  /* - In case of auto-injection mode, HAL_ADC_Stop must be used.             */
+  if(((hadc->State & HAL_ADC_STATE_REG_BUSY) == RESET)  &&
+     HAL_IS_BIT_CLR(hadc->Instance->CR1, ADC_CR1_JAUTO)   )
+  {
+    /* Stop potential conversion on going, on regular and injected groups */
+    /* Disable ADC peripheral */
+    tmp_hal_status = ADC_ConversionStop_Disable(hadc);
+    
+    /* Check if ADC is effectively disabled */
+    if (tmp_hal_status == HAL_OK)
+    {
+      /* Set ADC state */
+      ADC_STATE_CLR_SET(hadc->State,
+                        HAL_ADC_STATE_REG_BUSY | HAL_ADC_STATE_INJ_BUSY,
+                        HAL_ADC_STATE_READY);
+    }
+  }
+  else
+  {
+    /* Update ADC state machine to error */
+    SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_CONFIG);
+      
+    tmp_hal_status = HAL_ERROR;
+  }
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+  
+  /* Return function status */
+  return tmp_hal_status;
+}
+#endif /* STM32F373xC || STM32F378xx */
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+/**
+  * @brief  Wait for injected group conversion to be completed.
+  * @param  hadc ADC handle
+  * @param  Timeout Timeout value in millisecond.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADCEx_InjectedPollForConversion(ADC_HandleTypeDef* hadc, uint32_t Timeout)
+{
+  uint32_t tickstart;
+  uint32_t tmp_Flag_EOC;
+  uint32_t tmp_cfgr = 0x00000000U;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+
+  /* If end of conversion selected to end of sequence */
+  if (hadc->Init.EOCSelection == ADC_EOC_SEQ_CONV)
+  {
+    tmp_Flag_EOC = ADC_FLAG_JEOS;
+  }
+  /* If end of conversion selected to end of each conversion */
+  else /* ADC_EOC_SINGLE_CONV */
+  {
+    tmp_Flag_EOC = (ADC_FLAG_JEOC | ADC_FLAG_JEOS);
+  }
+  
+  /* Get relevant register CFGR in ADC instance of ADC master or slave      */
+  /* in function of multimode state (for devices with multimode             */
+  /* available).                                                            */
+  if (ADC_NONMULTIMODE_OR_MULTIMODEMASTER(hadc))
+  {
+    tmp_cfgr = READ_REG(hadc->Instance->CFGR); 
+  }
+  else
+  {
+    tmp_cfgr = READ_REG(ADC_MASTER_INSTANCE(hadc)->CFGR);
+  }
+  
+  /* Get tick count */
+  tickstart = HAL_GetTick();  
+     
+  /* Wait until End of Conversion flag is raised */
+  while(HAL_IS_BIT_CLR(hadc->Instance->ISR, tmp_Flag_EOC))
+  {
+    /* Check if timeout is disabled (set to infinite wait) */
+    if(Timeout != HAL_MAX_DELAY)
+    {
+      if((Timeout == 0U) || ((HAL_GetTick() - tickstart) > Timeout))
+      {
+        /* Update ADC state machine to timeout */
+        SET_BIT(hadc->State, HAL_ADC_STATE_TIMEOUT);
+        
+        /* Process unlocked */
+        __HAL_UNLOCK(hadc);
+        
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+  
+  /* Update ADC state machine */
+  SET_BIT(hadc->State, HAL_ADC_STATE_INJ_EOC);
+  
+  /* Determine whether any further conversion upcoming on group injected      */
+  /* by external trigger or by automatic injected conversion                  */
+  /* from group regular.                                                      */
+  if(ADC_IS_SOFTWARE_START_INJECTED(hadc)                   ||
+     ((READ_BIT (tmp_cfgr, ADC_CFGR_JAUTO) == RESET)    &&
+      (ADC_IS_SOFTWARE_START_REGULAR(hadc)          &&
+      (READ_BIT (tmp_cfgr, ADC_CFGR_CONT) == RESET)   )   )   )
+  {
+    /* Set ADC state */
+    CLEAR_BIT(hadc->State, HAL_ADC_STATE_INJ_BUSY);   
+    
+    if (HAL_IS_BIT_CLR(hadc->State, HAL_ADC_STATE_REG_BUSY))
+    {
+      SET_BIT(hadc->State, HAL_ADC_STATE_READY);
+    }
+  }
+  
+  /* Clear end of conversion flag of injected group if low power feature      */
+  /* "Auto Wait" is disabled, to not interfere with this feature until data   */
+  /* register is read using function HAL_ADC_GetValue().                      */
+  if (READ_BIT (tmp_cfgr, ADC_CFGR_AUTDLY) == RESET)
+  {
+    /* Clear injected group conversion flag */
+    /* (JEOC or JEOS depending on HAL ADC initialization parameter) */
+    __HAL_ADC_CLEAR_FLAG(hadc, tmp_Flag_EOC);
+  }
+  
+  /* Return ADC state */
+  return HAL_OK;
+}
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+
+#if defined(STM32F373xC) || defined(STM32F378xx)
+/**
+  * @brief  Wait for injected group conversion to be completed.
+  * @param  hadc ADC handle
+  * @param  Timeout Timeout value in millisecond.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADCEx_InjectedPollForConversion(ADC_HandleTypeDef* hadc, uint32_t Timeout)
+{
+  uint32_t tickstart = 0U;
+  
+  /* Variables for polling in case of scan mode enabled */
+  uint32_t Conversion_Timeout_CPU_cycles_max =0U;
+  uint32_t Conversion_Timeout_CPU_cycles =0U;
+ 
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+
+  /* Get tick count */
+  tickstart = HAL_GetTick();  
+     
+  /* Polling for end of conversion: differentiation if single/sequence        */
+  /* conversion.                                                              */
+  /* For injected group, flag JEOC is set only at the end of the sequence,    */
+  /* not for each conversion within the sequence.                             */
+  /*  - If single conversion for injected group (scan mode disabled or        */
+  /*    InjectedNbrOfConversion ==1U), flag JEOC is used to determine the      */
+  /*    conversion completion.                                                */
+  /*  - If sequence conversion for injected group (scan mode enabled and      */
+  /*    InjectedNbrOfConversion >=2U), flag JEOC is set only at the end of the */
+  /*    sequence.                                                             */
+  /*    To poll for each conversion, the maximum conversion time is computed  */
+  /*    from ADC conversion time (selected sampling time + conversion time of */
+  /*    12.5 ADC clock cycles) and APB2/ADC clock prescalers (depending on    */
+  /*    settings, conversion time range can be from 28 to 32256 CPU cycles).  */
+  /*    As flag JEOC is not set after each conversion, no timeout status can  */
+  /*    be set.                                                               */
+  if ((hadc->Instance->JSQR & ADC_JSQR_JL) == RESET)
+  {
+    /* Wait until End of Conversion flag is raised */
+    while(HAL_IS_BIT_CLR(hadc->Instance->SR, ADC_FLAG_JEOC))
+    {
+      /* Check if timeout is disabled (set to infinite wait) */
+      if(Timeout != HAL_MAX_DELAY)
+      {
+        if((Timeout == 0U) || ((HAL_GetTick() - tickstart) > Timeout))
+        {
+          /* Update ADC state machine to timeout */
+          SET_BIT(hadc->State, HAL_ADC_STATE_TIMEOUT);
+          
+          /* Process unlocked */
+          __HAL_UNLOCK(hadc);
+          
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+  }
+  else
+  {
+    /* Replace polling by wait for maximum conversion time */
+    /* Calculation of CPU cycles corresponding to ADC conversion cycles.      */
+    /* Retrieve ADC clock prescaler and ADC maximum conversion cycles on all  */
+    /* channels.                                                              */
+    Conversion_Timeout_CPU_cycles_max = ADC_CLOCK_PRESCALER_RANGE();
+    Conversion_Timeout_CPU_cycles_max *= ADC_CONVCYCLES_MAX_RANGE(hadc);
+    
+    /* Poll with maximum conversion time */
+    while(Conversion_Timeout_CPU_cycles < Conversion_Timeout_CPU_cycles_max)
+    {
+      /* Check if timeout is disabled (set to infinite wait) */
+      if(Timeout != HAL_MAX_DELAY)
+      {
+        if((Timeout == 0U) || ((HAL_GetTick() - tickstart) > Timeout))
+        {
+          /* Update ADC state machine to timeout */
+          SET_BIT(hadc->State, HAL_ADC_STATE_TIMEOUT);
+          
+          /* Process unlocked */
+          __HAL_UNLOCK(hadc);
+          
+          return HAL_TIMEOUT;
+        }
+      }
+      Conversion_Timeout_CPU_cycles ++;
+    }
+  }
+  
+      
+  /* Clear injected group conversion flag (and regular conversion flag raised simultaneously) */
+  __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_JSTRT | ADC_FLAG_JEOC | ADC_FLAG_EOC);
+  
+  /* Update ADC state machine */
+  SET_BIT(hadc->State, HAL_ADC_STATE_INJ_EOC);
+  
+  /* Determine whether any further conversion upcoming on group injected      */
+  /* by external trigger or by automatic injected conversion                  */
+  /* from group regular.                                                      */
+  if(ADC_IS_SOFTWARE_START_INJECTED(hadc)                     || 
+     (HAL_IS_BIT_CLR(hadc->Instance->CR1, ADC_CR1_JAUTO) &&     
+     (ADC_IS_SOFTWARE_START_REGULAR(hadc)        &&
+      (hadc->Init.ContinuousConvMode == DISABLE)   )        )   )
+  {
+    /* Set ADC state */
+    CLEAR_BIT(hadc->State, HAL_ADC_STATE_INJ_BUSY);   
+    
+    if (HAL_IS_BIT_CLR(hadc->State, HAL_ADC_STATE_REG_BUSY))
+    {
+      SET_BIT(hadc->State, HAL_ADC_STATE_READY);
+    }
+  }
+  
+  /* Return ADC state */
+  return HAL_OK;
+}
+#endif /* STM32F373xC || STM32F378xx */
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+/**
+  * @brief  Enables ADC, starts conversion of injected group with interruption.
+  *         Interruptions enabled in this function:
+  *          - JEOC (end of conversion of injected group) or JEOS (end of 
+  *            sequence of injected group) depending on ADC initialization 
+  *            parameter "EOCSelection"
+  *         Each of these interruptions has its dedicated callback function.
+  * @note   Case of multimode enabled (for devices with several ADCs): This 
+  *         function must be called for ADC slave first, then ADC master. 
+  *         For ADC slave, ADC is enabled only (conversion is not started).  
+  *         For ADC master, ADC is enabled and multimode conversion is started.
+  * @param  hadc ADC handle
+  * @retval HAL status.
+  */
+HAL_StatusTypeDef HAL_ADCEx_InjectedStart_IT(ADC_HandleTypeDef* hadc)
+{
+  HAL_StatusTypeDef tmp_hal_status = HAL_OK;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+
+  /* Perform ADC enable and conversion start if no conversion is on going */
+  if (ADC_IS_CONVERSION_ONGOING_INJECTED(hadc) == RESET)
+  {
+    /* Process locked */
+    __HAL_LOCK(hadc);
+    
+    /* Enable the ADC peripheral */
+    tmp_hal_status = ADC_Enable(hadc);
+    
+    /* Start conversion if ADC is effectively enabled */
+      /* Start conversion if ADC is effectively enabled */
+    if (tmp_hal_status == HAL_OK)
+    {
+      /* Set ADC state                                                        */
+      /* - Clear state bitfield related to injected group conversion results  */
+      /* - Set state bitfield related to injected operation                   */
+      ADC_STATE_CLR_SET(hadc->State,
+                        HAL_ADC_STATE_READY | HAL_ADC_STATE_INJ_EOC,
+                        HAL_ADC_STATE_INJ_BUSY);
+      
+      /* Case of independent mode or multimode(for devices with several ADCs):*/
+      /* Set multimode state.                                                 */
+      if (ADC_NONMULTIMODE_OR_MULTIMODEMASTER(hadc))
+      {
+        CLEAR_BIT(hadc->State, HAL_ADC_STATE_MULTIMODE_SLAVE);
+      }
+      else
+      {
+        SET_BIT(hadc->State, HAL_ADC_STATE_MULTIMODE_SLAVE);
+      }
+      
+      /* Check if a regular conversion is ongoing */
+      /* Note: On this device, there is no ADC error code fields related to   */
+      /*       conversions on group injected only. In case of conversion on   */
+      /*       going on group regular, no error code is reset.                */
+      if (HAL_IS_BIT_CLR(hadc->State, HAL_ADC_STATE_REG_BUSY))
+      {
+        /* Reset ADC all error code fields */
+        ADC_CLEAR_ERRORCODE(hadc);
+      }
+      
+      /* Process unlocked */
+      /* Unlock before starting ADC conversions: in case of potential         */
+      /* interruption, to let the process to ADC IRQ Handler.                 */
+      __HAL_UNLOCK(hadc);
+      
+      /* Clear injected group conversion flag */
+      /* (To ensure of no unknown state from potential previous ADC           */
+      /* operations)                                                          */
+      __HAL_ADC_CLEAR_FLAG(hadc, (ADC_FLAG_JEOC | ADC_FLAG_JEOS));
+      
+      /* Enable ADC Injected context queue overflow interrupt if this feature */
+      /* is enabled.                                                          */
+      if ((hadc->Instance->CFGR & ADC_CFGR_JQM) != RESET)
+      {
+        __HAL_ADC_ENABLE_IT(hadc, ADC_FLAG_JQOVF);
+      }
+      
+      /* Enable ADC end of conversion interrupt */
+      switch(hadc->Init.EOCSelection)
+      {
+        case ADC_EOC_SEQ_CONV: 
+          __HAL_ADC_DISABLE_IT(hadc, ADC_IT_JEOC);
+          __HAL_ADC_ENABLE_IT(hadc, ADC_IT_JEOS);
+          break;
+        /* case ADC_EOC_SINGLE_CONV */
+        default:
+          __HAL_ADC_ENABLE_IT(hadc, ADC_IT_JEOC | ADC_IT_JEOS);
+          break;
+      }
+      
+      /* Enable conversion of injected group, if automatic injected           */
+      /* conversion is disabled.                                              */
+      /* If software start has been selected, conversion starts immediately.  */
+      /* If external trigger has been selected, conversion will start at next */
+      /* trigger event.                                                       */
+      /* Case of multimode enabled (for devices with several ADCs):           */
+      /*  - if ADC is slave, ADC is enabled only (conversion is not started). */
+      /*  - if ADC is master, ADC is enabled and conversion is started.       */
+      if (HAL_IS_BIT_CLR(hadc->Instance->CFGR, ADC_CFGR_JAUTO) && 
+          ADC_NONMULTIMODE_INJ_OR_MULTIMODEMASTER(hadc)          )
+      {
+        SET_BIT(hadc->Instance->CR, ADC_CR_JADSTART);
+      }
+    }
+    else
+    {
+      /* Process unlocked */
+      __HAL_UNLOCK(hadc);
+    }
+  }
+  else
+  {
+    tmp_hal_status = HAL_BUSY;
+  }
+  
+  /* Return function status */
+  return tmp_hal_status;
+}
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+
+#if defined(STM32F373xC) || defined(STM32F378xx)
+/**
+  * @brief  Enables ADC, starts conversion of injected group with interruption.
+  *         Interruptions enabled in this function:
+  *          - JEOC (end of conversion of injected group)
+  *         Each of these interruptions has its dedicated callback function.
+  * @param  hadc ADC handle
+  * @retval HAL status.
+  */
+HAL_StatusTypeDef HAL_ADCEx_InjectedStart_IT(ADC_HandleTypeDef* hadc)
+{
+  HAL_StatusTypeDef tmp_hal_status = HAL_OK;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  
+  /* Process locked */
+  __HAL_LOCK(hadc);
+    
+  /* Enable the ADC peripheral */
+  tmp_hal_status = ADC_Enable(hadc);
+  
+  /* Start conversion if ADC is effectively enabled */
+  if (tmp_hal_status == HAL_OK)
+  {
+    /* Set ADC state                                                          */
+    /* - Clear state bitfield related to injected group conversion results    */
+    /* - Set state bitfield related to injected operation                     */
+    ADC_STATE_CLR_SET(hadc->State,
+                      HAL_ADC_STATE_READY | HAL_ADC_STATE_INJ_EOC,
+                      HAL_ADC_STATE_INJ_BUSY);
+    
+    /* Check if a regular conversion is ongoing */
+    /* Note: On this device, there is no ADC error code fields related to     */
+    /*       conversions on group injected only. In case of conversion on     */
+    /*       going on group regular, no error code is reset.                  */
+    if (HAL_IS_BIT_CLR(hadc->State, HAL_ADC_STATE_REG_BUSY))
+    {
+      /* Reset ADC all error code fields */
+      ADC_CLEAR_ERRORCODE(hadc);
+    }
+    
+    /* Process unlocked */
+    /* Unlock before starting ADC conversions: in case of potential           */
+    /* interruption, to let the process to ADC IRQ Handler.                   */
+    __HAL_UNLOCK(hadc);
+    
+    /* Set ADC error code to none */
+    ADC_CLEAR_ERRORCODE(hadc);
+    
+    /* Clear injected group conversion flag */
+    /* (To ensure of no unknown state from potential previous ADC operations) */
+    __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_JEOC);
+    
+    /* Enable end of conversion interrupt for injected channels */
+    __HAL_ADC_ENABLE_IT(hadc, ADC_IT_JEOC);
+
+    /* Enable conversion of injected group.                                   */
+    /* If software start has been selected, conversion starts immediately.    */
+    /* If external trigger has been selected, conversion will start at next   */
+    /* trigger event.                                                         */
+    /* If external trigger has been selected, conversion will start at next   */
+    /* trigger event.                                                         */
+    /* If automatic injected conversion is enabled, conversion will start     */
+    /* after next regular group conversion.                                   */
+    if (ADC_IS_SOFTWARE_START_INJECTED(hadc)              && 
+        HAL_IS_BIT_CLR(hadc->Instance->CR1, ADC_CR1_JAUTO)  )
+    {
+      /* Start ADC conversion on injected group with SW start */
+      SET_BIT(hadc->Instance->CR2, (ADC_CR2_JSWSTART | ADC_CR2_JEXTTRIG));
+    }
+    else
+    {
+      /* Start ADC conversion on injected group with external trigger */
+      SET_BIT(hadc->Instance->CR2, ADC_CR2_JEXTTRIG);
+    }
+  }
+  
+  /* Return function status */
+  return tmp_hal_status;
+}
+#endif /* STM32F373xC || STM32F378xx */
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+/**
+  * @brief  Stop ADC group injected conversion (potential conversion on going
+  *         on ADC group regular is not impacted), disable ADC peripheral
+  *         if no conversion is on going on group regular.
+  *         Interruptions disabled in this function:
+  *          - JEOC (end of conversion of injected group) and JEOS (end of 
+  *            sequence of injected group)
+  * @note   To stop ADC conversion of both groups regular and injected and to
+  *         to disable ADC peripheral, instead of using 2 functions
+  *         @ref HAL_ADCEx_RegularStop() and @ref HAL_ADCEx_InjectedStop(),
+  *         use function @ref HAL_ADC_Stop().
+  * @note   If injected group mode auto-injection is enabled,
+  *         function HAL_ADC_Stop must be used.
+  * @note   Case of multimode enabled (for devices with several ADCs): This 
+  *         function must be called for ADC master first, then ADC slave.
+  *         For ADC master, conversion is stopped and ADC is disabled. 
+  *         For ADC slave, ADC is disabled only (conversion stop of ADC master
+  *         has already stopped conversion of ADC slave).
+  * @note   In case of auto-injection mode, HAL_ADC_Stop must be used.
+  * @param  hadc ADC handle
+  * @retval None
+  */
+HAL_StatusTypeDef HAL_ADCEx_InjectedStop_IT(ADC_HandleTypeDef* hadc)
+{ 
+  HAL_StatusTypeDef tmp_hal_status = HAL_OK;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  
+  /* Process locked */
+  __HAL_LOCK(hadc);
+  
+  /* Stop potential ADC conversion on going and disable ADC peripheral        */
+  /* conditioned to:                                                          */
+  /* - In case of auto-injection mode, HAL_ADC_Stop must be used.             */
+  /* - For ADC injected group conversion stop:                                */
+  /*   On this STM32 family, conversion on the other group                    */
+  /*   (group regular) can continue (groups regular and injected              */
+  /*   conversion stop commands are independent)                              */
+  /* - For ADC disable:                                                       */
+  /*   No conversion on the other group (group regular) must be intended to   */
+  /*   continue (groups regular and injected are both impacted by             */
+  /*   ADC disable)                                                           */
+  if(HAL_IS_BIT_CLR(hadc->Instance->CFGR, ADC_CFGR_JAUTO))
+  {
+    /* 1. Stop potential conversion on going on injected group only. */
+    tmp_hal_status = ADC_ConversionStop(hadc, ADC_INJECTED_GROUP);
+    
+    /* Disable ADC peripheral if conversion on ADC group injected is          */
+    /* effectively stopped and if no conversion on the other group            */
+    /* (ADC group regular) is intended to continue.                           */
+    if (tmp_hal_status == HAL_OK)
+    {
+      /* Disable ADC end of conversion interrupt for injected channels */
+      __HAL_ADC_DISABLE_IT(hadc, (ADC_IT_JEOC | ADC_IT_JEOS | ADC_IT_JQOVF));
+      
+      if((ADC_IS_CONVERSION_ONGOING_REGULAR(hadc) == RESET) &&
+         ((hadc->State & HAL_ADC_STATE_REG_BUSY) == RESET)    )
+      {
+        /* 2. Disable the ADC peripheral */
+        tmp_hal_status = ADC_Disable(hadc);
+        
+        /* Check if ADC is effectively disabled */
+        if (tmp_hal_status == HAL_OK)
+        {
+          /* Set ADC state */
+          ADC_STATE_CLR_SET(hadc->State,
+                            HAL_ADC_STATE_REG_BUSY | HAL_ADC_STATE_INJ_BUSY,
+                            HAL_ADC_STATE_READY);
+        }
+      }
+      /* Conversion on ADC group injected group is stopped, but ADC is not    */
+      /* disabled since conversion on ADC group regular is still on going.    */
+      else
+      {
+        /* Set ADC state */
+        CLEAR_BIT(hadc->State, HAL_ADC_STATE_INJ_BUSY);
+      }
+    }
+  }
+  else
+  {
+    /* Update ADC state machine to error */
+    SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_CONFIG);
+      
+    tmp_hal_status = HAL_ERROR;
+  }
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+  
+  /* Return function status */
+  return tmp_hal_status;
+}
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+
+#if defined(STM32F373xC) || defined(STM32F378xx)
+/**
+  * @brief  Stop conversion of injected channels, disable interruption of 
+  *         end-of-conversion. Disable ADC peripheral if no regular conversion
+  *         is on going.
+  * @note   If ADC must be disabled and if conversion is on going on 
+  *         regular group, function HAL_ADC_Stop must be used to stop both
+  *         injected and regular groups, and disable the ADC.
+  * @param  hadc ADC handle
+  * @retval None
+  */
+HAL_StatusTypeDef HAL_ADCEx_InjectedStop_IT(ADC_HandleTypeDef* hadc)
+{
+  HAL_StatusTypeDef tmp_hal_status = HAL_OK;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+
+  /* Process locked */
+  __HAL_LOCK(hadc);
+    
+  /* Stop potential conversion and disable ADC peripheral                     */
+  /* Conditioned to:                                                          */
+  /* - No conversion on the other group (regular group) is intended to        */
+  /*   continue (injected and regular groups stop conversion and ADC disable  */
+  /*   are common)                                                            */
+  /* - In case of auto-injection mode, HAL_ADC_Stop must be used.             */ 
+  if(((hadc->State & HAL_ADC_STATE_REG_BUSY) == RESET)  &&
+     HAL_IS_BIT_CLR(hadc->Instance->CR1, ADC_CR1_JAUTO)   )
+  {
+    /* Stop potential conversion on going, on regular and injected groups */
+    /* Disable ADC peripheral */
+    tmp_hal_status = ADC_ConversionStop_Disable(hadc);
+    
+    /* Check if ADC is effectively disabled */
+    if (tmp_hal_status == HAL_OK)
+    {
+      /* Disable ADC end of conversion interrupt for injected channels */
+      __HAL_ADC_DISABLE_IT(hadc, ADC_IT_JEOC);
+      
+      /* Set ADC state */
+      ADC_STATE_CLR_SET(hadc->State,
+                        HAL_ADC_STATE_REG_BUSY | HAL_ADC_STATE_INJ_BUSY,
+                        HAL_ADC_STATE_READY);
+    }
+  }
+  else
+  {
+    /* Update ADC state machine to error */
+    SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_CONFIG);
+      
+    tmp_hal_status = HAL_ERROR;
+  }
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+  
+  /* Return function status */
+  return tmp_hal_status;
+}
+#endif /* STM32F373xC || STM32F378xx */
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
+/**
+  * @brief  With ADC configured in multimode, for ADC master:
+  *         Enables ADC, starts conversion of regular group and transfers result
+  *         through DMA.
+  *         Multimode must have been previously configured using 
+  *         HAL_ADCEx_MultiModeConfigChannel() function.
+  *         Interruptions enabled in this function:
+  *          - DMA transfer complete
+  *          - DMA half transfer
+  *          - overrun
+  *         Each of these interruptions has its dedicated callback function.
+  * @note   ADC slave must be preliminarily enabled using single-mode  
+  *         HAL_ADC_Start() function.
+  * @param  hadc ADC handle of ADC master (handle of ADC slave must not be used)
+  * @param  pData The destination Buffer address.
+  * @param  Length The length of data to be transferred from ADC peripheral to memory.
+  * @retval None
+  */
+HAL_StatusTypeDef HAL_ADCEx_MultiModeStart_DMA(ADC_HandleTypeDef* hadc, uint32_t* pData, uint32_t Length)
+{
+  HAL_StatusTypeDef tmp_hal_status = HAL_OK;
+  ADC_HandleTypeDef tmphadcSlave = {0};
+  ADC_Common_TypeDef *tmpADC_Common;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_MULTIMODE_MASTER_INSTANCE(hadc->Instance));
+  assert_param(IS_FUNCTIONAL_STATE(hadc->Init.ContinuousConvMode));
+  assert_param(IS_ADC_EXTTRIG_EDGE(hadc->Init.ExternalTrigConvEdge));
+  assert_param(IS_FUNCTIONAL_STATE(hadc->Init.DMAContinuousRequests));
+  
+  /* Process locked */
+  __HAL_LOCK(hadc);
+
+  /* Perform ADC enable and conversion start if no conversion is on going */
+  /* (check on ADC master only) */
+  if (ADC_IS_CONVERSION_ONGOING_REGULAR(hadc) == RESET)
+  {
+    /* Set a temporary handle of the ADC slave associated to the ADC master   */
+    /* (Depending on STM32F3 product, there may be up to 2 ADC slaves)        */
+    ADC_MULTI_SLAVE(hadc, &tmphadcSlave);
+    
+    if (tmphadcSlave.Instance == NULL)
+    {
+      /* Update ADC state machine to error */
+      SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_CONFIG);
+      
+      /* Process unlocked */
+      __HAL_UNLOCK(hadc);
+      
+      return HAL_ERROR;
+    }
+    
+    
+    /* Enable the ADC peripherals: master and slave (in case if not already   */
+    /* enabled previously)                                                    */
+    tmp_hal_status = ADC_Enable(hadc);
+    if (tmp_hal_status == HAL_OK)
+    {
+      tmp_hal_status = ADC_Enable(&tmphadcSlave);
+    }
+    
+    /* Start conversion all ADCs of multimode are effectively enabled */
+    if (tmp_hal_status == HAL_OK)
+    {
+      /* Set ADC state (ADC master)                                           */
+      /* - Clear state bitfield related to regular group conversion results   */
+      /* - Set state bitfield related to regular operation                    */
+      ADC_STATE_CLR_SET(hadc->State,
+                        HAL_ADC_STATE_READY | HAL_ADC_STATE_REG_EOC | HAL_ADC_STATE_REG_OVR | HAL_ADC_STATE_REG_EOSMP | HAL_ADC_STATE_MULTIMODE_SLAVE,
+                        HAL_ADC_STATE_REG_BUSY);
+        
+      /* If conversions on group regular are also triggering group injected,  */
+      /* update ADC state.                                                    */
+      if (READ_BIT(hadc->Instance->CFGR, ADC_CFGR_JAUTO) != RESET)
+      {
+        ADC_STATE_CLR_SET(hadc->State, HAL_ADC_STATE_INJ_EOC, HAL_ADC_STATE_INJ_BUSY);  
+      }
+      
+      /* Process unlocked */
+      /* Unlock before starting ADC conversions: in case of potential         */
+      /* interruption, to let the process to ADC IRQ Handler.                 */
+      __HAL_UNLOCK(hadc);
+      
+      /* Set ADC error code to none */
+      ADC_CLEAR_ERRORCODE(hadc);
+      
+      
+      /* Set the DMA transfer complete callback */
+      hadc->DMA_Handle->XferCpltCallback = ADC_DMAConvCplt;
+         
+      /* Set the DMA half transfer complete callback */
+      hadc->DMA_Handle->XferHalfCpltCallback = ADC_DMAHalfConvCplt;
+      
+      /* Set the DMA error callback */
+      hadc->DMA_Handle->XferErrorCallback = ADC_DMAError ;
+      
+      /* Pointer to the common control register to which is belonging hadc    */
+      /* (Depending on STM32F3 product, there may be up to 4 ADC and 2 common */
+      /* control registers)                                                   */
+      tmpADC_Common = ADC_COMMON_REGISTER(hadc);
+      
+      
+      /* Manage ADC and DMA start: ADC overrun interruption, DMA start, ADC   */
+      /* start (in case of SW start):                                         */
+
+      /* Clear regular group conversion flag and overrun flag */
+      /* (To ensure of no unknown state from potential previous ADC operations) */
+      __HAL_ADC_CLEAR_FLAG(hadc, (ADC_FLAG_EOC | ADC_FLAG_EOS | ADC_FLAG_OVR));
+      
+      /* Enable ADC overrun interrupt */
+      __HAL_ADC_ENABLE_IT(hadc, ADC_IT_OVR);
+
+      /* Start the DMA channel */
+      HAL_DMA_Start_IT(hadc->DMA_Handle, (uint32_t)&tmpADC_Common->CDR, (uint32_t)pData, Length);
+          
+      /* Enable conversion of regular group.                                  */
+      /* If software start has been selected, conversion starts immediately.  */
+      /* If external trigger has been selected, conversion will start at next */
+      /* trigger event.                                                       */
+      SET_BIT(hadc->Instance->CR, ADC_CR_ADSTART);
+
+    }
+    else
+    {
+      /* Process unlocked */
+      __HAL_UNLOCK(hadc);
+    }
+  }
+  else
+  {
+    tmp_hal_status = HAL_BUSY;
+  }
+  
+  /* Return function status */
+  return tmp_hal_status;
+}
+
+/**
+  * @brief  With ADC configured in multimode, for ADC master:
+  *         Stop ADC group regular conversion (potential conversion on going
+  *         on ADC group injected is not impacted),
+  *         disable ADC DMA transfer, disable ADC peripheral
+  *         if no conversion is on going on group injected.
+  *         Interruptions disabled in this function:
+  *          - DMA transfer complete
+  *          - DMA half transfer
+  *          - overrun
+  * @note   In case of auto-injection mode, this function also stop conversion
+  *         on ADC group injected.
+  * @note   Multimode is kept enabled after this function. To disable multimode
+  *         (set with HAL_ADCEx_MultiModeConfigChannel() ), ADC must be 
+  *         reinitialized using HAL_ADC_Init() or HAL_ADC_ReInit().
+  * @note   In case of DMA configured in circular mode, function 
+  *         HAL_ADC_Stop_DMA must be called after this function with handle of
+  *         ADC slave, to properly disable the DMA channel of ADC slave.
+  * @param  hadc ADC handle of ADC master (handle of ADC slave must not be used)
+  * @retval None
+  */
+HAL_StatusTypeDef HAL_ADCEx_MultiModeStop_DMA(ADC_HandleTypeDef* hadc)
+{
+  HAL_StatusTypeDef tmp_hal_status = HAL_OK;
+  uint32_t tickstart;
+  ADC_HandleTypeDef tmphadcSlave = {0};
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_MULTIMODE_MASTER_INSTANCE(hadc->Instance));
+  
+  /* Process locked */
+  __HAL_LOCK(hadc);
+  
+  /* 1. Stop potential multimode conversion on going, on regular and          */
+  /*    injected groups.                                                      */
+  tmp_hal_status = ADC_ConversionStop(hadc, ADC_REGULAR_INJECTED_GROUP);
+
+  /* Disable ADC peripheral if conversions are effectively stopped */
+  if (tmp_hal_status == HAL_OK)
+  {
+    /* Set a temporary handle of the ADC slave associated to the ADC master   */
+    /* (Depending on STM32F3 product, there may be up to 2 ADC slaves)        */
+    ADC_MULTI_SLAVE(hadc, &tmphadcSlave);
+    
+    if (tmphadcSlave.Instance == NULL)
+    {
+      /* Update ADC state machine (ADC master) to error */
+      SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_DMA);
+      
+      /* Process unlocked */
+      __HAL_UNLOCK(hadc);
+      
+      return HAL_ERROR;
+    }
+    
+    /* Procedure to disable the ADC peripheral: wait for conversions          */
+    /* effectively stopped (ADC master and ADC slave), then disable ADC       */
+    
+    /* 1. Wait until ADSTP=0 for ADC master and ADC slave */
+    tickstart = HAL_GetTick();  
+
+    while(ADC_IS_CONVERSION_ONGOING_REGULAR(hadc)          || 
+          ADC_IS_CONVERSION_ONGOING_REGULAR(&tmphadcSlave)   )
+    {
+      if((HAL_GetTick() - tickstart) > ADC_STOP_CONVERSION_TIMEOUT)
+      {
+        /* Update ADC state machine (ADC master) to error */
+        SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL);
+        
+        /* Process unlocked */
+        __HAL_UNLOCK(hadc);
+        
+        return HAL_ERROR;
+      }
+    }
+    
+    /* Disable the DMA channel (in case of DMA in circular mode or stop while */
+    /* while DMA transfer is on going)                                        */
+    /* Note: In case of ADC slave using its own DMA channel (multimode        */
+    /*       parameter "DMAAccessMode" set to disabled):                      */
+    /*       DMA channel of ADC slave should stopped after this function with */
+    /*       function HAL_ADC_Stop_DMA.                                       */
+    tmp_hal_status = HAL_DMA_Abort(hadc->DMA_Handle);
+    
+    /* Check if DMA channel effectively disabled */
+    if (tmp_hal_status != HAL_OK)
+    {
+      /* Update ADC state machine to error */
+      SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_DMA);
+    }
+    
+    /* Disable ADC overrun interrupt */
+    __HAL_ADC_DISABLE_IT(hadc, ADC_IT_OVR);
+    
+    
+    
+    /* 2. Disable the ADC peripherals: master and slave */
+    /* Update "tmp_hal_status" only if DMA channel disabling passed,          */
+    /* to retain a potential failing status.                                  */
+    if (tmp_hal_status == HAL_OK)
+    {
+      /* Check if ADC are effectively disabled */
+      if ((ADC_Disable(hadc) != HAL_ERROR)          &&
+          (ADC_Disable(&tmphadcSlave) != HAL_ERROR)   )
+      {
+        tmp_hal_status = HAL_OK;
+        
+        /* Change ADC state (ADC master) */
+        ADC_STATE_CLR_SET(hadc->State,
+                          HAL_ADC_STATE_REG_BUSY | HAL_ADC_STATE_INJ_BUSY,
+                          HAL_ADC_STATE_READY);
+      }
+    }
+    else
+    {
+      /* In case of error, attempt to disable ADC instances anyway */
+      ADC_Disable(hadc);
+      ADC_Disable(&tmphadcSlave);
+      
+      /* Update ADC state machine (ADC master) to error */
+      SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL);
+    }
+    
+  }
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+  
+  /* Return function status */
+  return tmp_hal_status;
+}
+
+/**
+  * @brief  Returns the last ADC Master&Slave regular conversions results data
+  *         in the selected multi mode.
+  * @note   Reading register CDR does not clear flag ADC flag EOC
+  *         (ADC group regular end of unitary conversion),
+  *         as it is the case for independent mode data register.
+  * @param  hadc ADC handle of ADC master (handle of ADC slave must not be used)
+  * @retval The converted data value.
+  */
+uint32_t HAL_ADCEx_MultiModeGetValue(ADC_HandleTypeDef* hadc)
+{
+  ADC_Common_TypeDef *tmpADC_Common;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_MULTIMODE_MASTER_INSTANCE(hadc->Instance));
+  
+  /* Pointer to the common control register to which is belonging hadc        */
+  /* (Depending on STM32F3 product, there may be up to 4 ADC and 2 common     */
+  /* control registers)                                                       */
+  tmpADC_Common = ADC_COMMON_REGISTER(hadc);
+  
+  /* Return the multi mode conversion value */
+  return tmpADC_Common->CDR;
+}
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx    */
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+/**
+  * @brief  Get ADC injected group conversion result.
+  * @note   Reading register JDRx automatically clears ADC flag JEOC
+  *         (ADC group injected end of unitary conversion).
+  * @note   This function does not clear ADC flag JEOS 
+  *         (ADC group injected end of sequence conversion)
+  *         Occurrence of flag JEOS rising:
+  *          - If sequencer is composed of 1 rank, flag JEOS is equivalent
+  *            to flag JEOC.
+  *          - If sequencer is composed of several ranks, during the scan
+  *            sequence flag JEOC only is raised, at the end of the scan sequence
+  *            both flags JEOC and EOS are raised.
+  *         Flag JEOS must not be cleared by this function because
+  *         it would not be compliant with low power features
+  *         (feature low power auto-wait, not available on all STM32 families).
+  *         To clear this flag, either use function: 
+  *         in programming model IT: @ref HAL_ADC_IRQHandler(), in programming
+  *         model polling: @ref HAL_ADCEx_InjectedPollForConversion() 
+  *         or @ref __HAL_ADC_CLEAR_FLAG(&hadc, ADC_FLAG_JEOS).
+  * @param  hadc ADC handle
+  * @param  InjectedRank the converted ADC injected rank.
+  *          This parameter can be one of the following values:
+  *            @arg ADC_INJECTED_RANK_1: Injected Channel1 selected
+  *            @arg ADC_INJECTED_RANK_2: Injected Channel2 selected
+  *            @arg ADC_INJECTED_RANK_3: Injected Channel3 selected
+  *            @arg ADC_INJECTED_RANK_4: Injected Channel4 selected
+  * @retval ADC group injected conversion data
+  */
+uint32_t HAL_ADCEx_InjectedGetValue(ADC_HandleTypeDef* hadc, uint32_t InjectedRank)
+{
+  uint32_t tmp_jdr = 0U;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  assert_param(IS_ADC_INJECTED_RANK(InjectedRank));
+  
+  /* Note: ADC flag JEOC is not cleared here by software because              */
+  /*       automatically cleared by hardware when reading register JDRx.      */
+  
+  /* Get ADC converted value */ 
+  switch(InjectedRank)
+  {  
+    case ADC_INJECTED_RANK_4: 
+      tmp_jdr = hadc->Instance->JDR4;
+      break;
+    case ADC_INJECTED_RANK_3: 
+      tmp_jdr = hadc->Instance->JDR3;
+      break;
+    case ADC_INJECTED_RANK_2: 
+      tmp_jdr = hadc->Instance->JDR2;
+      break;
+    case ADC_INJECTED_RANK_1:
+    default:
+      tmp_jdr = hadc->Instance->JDR1;
+      break;
+  }
+  
+  /* Return ADC converted value */ 
+  return tmp_jdr;
+}
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+
+#if defined(STM32F373xC) || defined(STM32F378xx)
+/**
+  * @brief  Get ADC injected group conversion result.
+  * @note   Reading register JDRx automatically clears ADC flag JEOC
+  *         (ADC group injected end of unitary conversion).
+  * @note   This function does not clear ADC flag JEOS 
+  *         (ADC group injected end of sequence conversion)
+  *         Occurrence of flag JEOS rising:
+  *          - If sequencer is composed of 1 rank, flag JEOS is equivalent
+  *            to flag JEOC.
+  *          - If sequencer is composed of several ranks, during the scan
+  *            sequence flag JEOC only is raised, at the end of the scan sequence
+  *            both flags JEOC and EOS are raised.
+  *         Flag JEOS must not be cleared by this function because
+  *         it would not be compliant with low power features
+  *         (feature low power auto-wait, not available on all STM32 families).
+  *         To clear this flag, either use function: 
+  *         in programming model IT: @ref HAL_ADC_IRQHandler(), in programming
+  *         model polling: @ref HAL_ADCEx_InjectedPollForConversion() 
+  *         or @ref __HAL_ADC_CLEAR_FLAG(&hadc, ADC_FLAG_JEOS).
+  * @param  hadc ADC handle
+  * @param  InjectedRank the converted ADC injected rank.
+  *          This parameter can be one of the following values:
+  *            @arg ADC_INJECTED_RANK_1: Injected Channel1 selected
+  *            @arg ADC_INJECTED_RANK_2: Injected Channel2 selected
+  *            @arg ADC_INJECTED_RANK_3: Injected Channel3 selected
+  *            @arg ADC_INJECTED_RANK_4: Injected Channel4 selected
+  * @retval ADC group injected conversion data
+  */
+uint32_t HAL_ADCEx_InjectedGetValue(ADC_HandleTypeDef* hadc, uint32_t InjectedRank)
+{
+  uint32_t tmp_jdr = 0U;
+
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  assert_param(IS_ADC_INJECTED_RANK(InjectedRank));
+  
+  /* Get ADC converted value */ 
+  switch(InjectedRank)
+  {  
+    case ADC_INJECTED_RANK_4: 
+      tmp_jdr = hadc->Instance->JDR4;
+      break;
+    case ADC_INJECTED_RANK_3: 
+      tmp_jdr = hadc->Instance->JDR3;
+      break;
+    case ADC_INJECTED_RANK_2: 
+      tmp_jdr = hadc->Instance->JDR2;
+      break;
+    case ADC_INJECTED_RANK_1:
+    default:
+      tmp_jdr = hadc->Instance->JDR1;
+      break;
+  }
+  
+  /* Return ADC converted value */ 
+  return tmp_jdr;
+}
+#endif /* STM32F373xC || STM32F378xx */
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+/**
+  * @brief  Stop ADC group regular conversion (potential conversion on going
+  *         on ADC group injected is not impacted), disable ADC peripheral
+  *         if no conversion is on going on group injected.
+  * @note   To stop ADC conversion of both groups regular and injected and to
+  *         to disable ADC peripheral, instead of using 2 functions
+  *         @ref HAL_ADCEx_RegularStop() and @ref HAL_ADCEx_InjectedStop(),
+  *         use function @ref HAL_ADC_Stop().
+  * @note   In case of auto-injection mode, this function also stop conversion
+  *         on ADC group injected.
+  * @param  hadc ADC handle
+  * @retval HAL status.
+  */
+HAL_StatusTypeDef HAL_ADCEx_RegularStop(ADC_HandleTypeDef* hadc)
+{
+  HAL_StatusTypeDef tmp_hal_status = HAL_OK;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  
+  /* Process locked */
+  __HAL_LOCK(hadc);
+  
+  /* Stop potential ADC conversion on going and disable ADC peripheral        */
+  /* conditioned to:                                                          */
+  /* - For ADC regular group conversion stop:                                 */
+  /*   On this STM32 family, conversion on the other group                    */
+  /*   (group injected) can continue (groups regular and injected             */
+  /*   conversion stop commands are independent)                              */
+  /* - For ADC disable:                                                       */
+  /*   No conversion on the other group (group injected) must be intended to  */
+  /*   continue (groups regular and injected are both impacted by             */
+  /*   ADC disable)                                                           */
+  
+  /* 1. Stop potential conversion on going, on regular group only */
+  tmp_hal_status = ADC_ConversionStop(hadc, ADC_REGULAR_GROUP);
+  
+  /* Disable ADC peripheral if conversion on ADC group regular is             */
+  /* effectively stopped and if no conversion on the other group              */
+  /* (ADC group injected) is intended to continue.                            */
+  if((ADC_IS_CONVERSION_ONGOING_INJECTED(hadc) == RESET) &&
+     ((hadc->State & HAL_ADC_STATE_INJ_BUSY) == RESET)     )
+  {
+    /* 2. Disable the ADC peripheral */
+    tmp_hal_status = ADC_Disable(hadc);
+    
+    /* Check if ADC is effectively disabled */
+    if (tmp_hal_status == HAL_OK)
+    {
+      /* Set ADC state */
+      ADC_STATE_CLR_SET(hadc->State,
+                        HAL_ADC_STATE_REG_BUSY | HAL_ADC_STATE_INJ_BUSY,
+                        HAL_ADC_STATE_READY);
+    }
+  }
+  /* Conversion on ADC group regular group is stopped, but ADC is not         */
+  /* disabled since conversion on ADC group injected is still on going.       */
+  else
+  {
+    /* Set ADC state */
+    CLEAR_BIT(hadc->State, HAL_ADC_STATE_REG_BUSY);
+  }
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+  
+  /* Return function status */
+  return tmp_hal_status;
+}
+
+/**
+  * @brief  Stop ADC group regular conversion (potential conversion on going
+  *         on ADC group injected is not impacted), disable ADC peripheral
+  *         if no conversion is on going on group injected.
+  *         Interruptions disabled in this function:
+  *          - EOC (end of conversion of regular group) and EOS (end of 
+  *            sequence of regular group)
+  *          - overrun
+  * @note   To stop ADC conversion of both groups regular and injected and to
+  *         to disable ADC peripheral, instead of using 2 functions
+  *         @ref HAL_ADCEx_RegularStop() and @ref HAL_ADCEx_InjectedStop(),
+  *         use function @ref HAL_ADC_Stop().
+  * @note   In case of auto-injection mode, this function also stop conversion
+  *         on ADC group injected.
+  * @param  hadc ADC handle
+  * @retval HAL status.
+  */
+HAL_StatusTypeDef HAL_ADCEx_RegularStop_IT(ADC_HandleTypeDef* hadc)
+{
+  HAL_StatusTypeDef tmp_hal_status = HAL_OK;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  
+  /* Process locked */
+  __HAL_LOCK(hadc);
+  
+  /* Stop potential ADC conversion on going and disable ADC peripheral        */
+  /* conditioned to:                                                          */
+  /* - For ADC regular group conversion stop:                                 */
+  /*   On this STM32 family, conversion on the other group                    */
+  /*   (group injected) can continue (groups regular and injected             */
+  /*   conversion stop commands are independent)                              */
+  /* - For ADC disable:                                                       */
+  /*   No conversion on the other group (group injected) must be intended to  */
+  /*   continue (groups regular and injected are both impacted by             */
+  /*   ADC disable)                                                           */
+  
+  /* 1. Stop potential conversion on going, on regular group only */
+  tmp_hal_status = ADC_ConversionStop(hadc, ADC_REGULAR_GROUP);
+  
+  /* Disable ADC peripheral if conversion on ADC group regular is             */
+  /* effectively stopped and if no conversion on the other group              */
+  /* (ADC group injected) is intended to continue.                            */
+  if((ADC_IS_CONVERSION_ONGOING_INJECTED(hadc) == RESET) &&
+     ((hadc->State & HAL_ADC_STATE_INJ_BUSY) == RESET)     )
+  {
+    /* Disable ADC end of conversion interrupt for regular group */
+    /* Disable ADC overrun interrupt */
+    __HAL_ADC_DISABLE_IT(hadc, (ADC_IT_EOC | ADC_IT_EOS | ADC_IT_OVR));
+    
+    /* 2. Disable the ADC peripheral */
+    tmp_hal_status = ADC_Disable(hadc);
+    
+    /* Check if ADC is effectively disabled */
+    if (tmp_hal_status == HAL_OK)
+    {
+      /* Set ADC state */
+      ADC_STATE_CLR_SET(hadc->State,
+                        HAL_ADC_STATE_REG_BUSY | HAL_ADC_STATE_INJ_BUSY,
+                        HAL_ADC_STATE_READY);
+    }
+  }
+  /* Conversion on ADC group regular group is stopped, but ADC is not         */
+  /* disabled since conversion on ADC group injected is still on going.       */
+  else
+  {
+    /* Set ADC state */
+    CLEAR_BIT(hadc->State, HAL_ADC_STATE_REG_BUSY);
+  }
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+  
+  /* Return function status */
+  return tmp_hal_status;
+}
+
+/**
+  * @brief  Stop ADC group regular conversion (potential conversion on going
+  *         on ADC group injected is not impacted), 
+  *         disable ADC DMA transfer, disable ADC peripheral
+  *         if no conversion is on going on group injected.
+  *         Interruptions disabled in this function:
+  *          - DMA transfer complete
+  *          - DMA half transfer
+  *          - overrun
+  * @note   To stop ADC conversion of both groups regular and injected and to
+  *         to disable ADC peripheral, instead of using 2 functions
+  *         @ref HAL_ADCEx_RegularStop() and @ref HAL_ADCEx_InjectedStop(),
+  *         use function @ref HAL_ADC_Stop().
+  * @note   Case of multimode enabled (for devices with several ADCs): This 
+  *         function is for single-ADC mode only. For multimode, use the 
+  *         dedicated MultimodeStop function.
+  * @param  hadc ADC handle
+  * @retval HAL status.
+  */
+HAL_StatusTypeDef HAL_ADCEx_RegularStop_DMA(ADC_HandleTypeDef* hadc)
+{
+  HAL_StatusTypeDef tmp_hal_status = HAL_OK;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  
+  /* Process locked */
+  __HAL_LOCK(hadc);
+  
+  /* Stop potential ADC conversion on going and disable ADC peripheral        */
+  /* conditioned to:                                                          */
+  /* - For ADC regular group conversion stop:                                 */
+  /*   On this STM32 family, conversion on the other group                    */
+  /*   (group injected) can continue (groups regular and injected             */
+  /*   conversion stop commands are independent)                              */
+  /* - For ADC disable:                                                       */
+  /*   No conversion on the other group (group injected) must be intended to  */
+  /*   continue (groups regular and injected are both impacted by             */
+  /*   ADC disable)                                                           */
+  
+  /* 1. Stop potential conversion on going, on regular group only */
+  tmp_hal_status = ADC_ConversionStop(hadc, ADC_REGULAR_GROUP);
+  
+  /* Disable ADC peripheral if conversion on ADC group regular is             */
+  /* effectively stopped and if no conversion on the other group              */
+  /* (ADC group injected) is intended to continue.                            */
+  if((ADC_IS_CONVERSION_ONGOING_INJECTED(hadc) == RESET) &&
+     ((hadc->State & HAL_ADC_STATE_INJ_BUSY) == RESET)     )
+  {
+    /* Disable ADC DMA (ADC DMA configuration ADC_CFGR_DMACFG is kept) */
+    CLEAR_BIT(hadc->Instance->CFGR, ADC_CFGR_DMAEN);
+    
+    /* Disable the DMA channel (in case of DMA in circular mode or stop while */
+    /* while DMA transfer is on going)                                        */
+    tmp_hal_status = HAL_DMA_Abort(hadc->DMA_Handle);   
+    
+    /* Check if DMA channel effectively disabled */
+    if (tmp_hal_status != HAL_OK)
+    {
+      /* Update ADC state machine to error */
+      SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_DMA);     
+    }
+    
+    /* Disable ADC overrun interrupt */
+    __HAL_ADC_DISABLE_IT(hadc, ADC_IT_OVR);
+    
+    /* 2. Disable the ADC peripheral */
+    /* Update "tmp_hal_status" only if DMA channel disabling passed,          */
+    /* to retain a potential failing status.                                  */
+    if (tmp_hal_status == HAL_OK)
+    {
+      tmp_hal_status = ADC_Disable(hadc);
+    }
+    else
+    {
+      ADC_Disable(hadc);
+    }
+    
+    /* Check if ADC is effectively disabled */
+    if (tmp_hal_status == HAL_OK)
+    {
+      /* Set ADC state */
+      ADC_STATE_CLR_SET(hadc->State,
+                        HAL_ADC_STATE_REG_BUSY | HAL_ADC_STATE_INJ_BUSY,
+                        HAL_ADC_STATE_READY);
+    }
+  }
+  /* Conversion on ADC group regular group is stopped, but ADC is not         */
+  /* disabled since conversion on ADC group injected is still on going.       */
+  else
+  {
+    /* Set ADC state */
+    CLEAR_BIT(hadc->State, HAL_ADC_STATE_REG_BUSY);
+  }
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+  
+  /* Return function status */
+  return tmp_hal_status;
+}
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
+/**
+  * @brief  With ADC configured in multimode, for ADC master:
+  *         Stop ADC group regular conversion (potential conversion on going
+  *         on ADC group injected is not impacted),
+  *         disable ADC DMA transfer, disable ADC peripheral
+  *         if no conversion is on going on group injected.
+  *         Interruptions disabled in this function:
+  *          - DMA transfer complete
+  *          - DMA half transfer
+  *          - overrun
+  * @note   To stop ADC conversion of both groups regular and injected and to
+  *         to disable ADC peripheral, instead of using 2 functions
+  *         @ref HAL_ADCEx_RegularMultiModeStop_DMA() and
+  *         @ref HAL_ADCEx_InjectedStop(), use function
+  *         @ref HAL_ADCEx_MultiModeStop_DMA.
+  * @note   In case of auto-injection mode, this function also stop conversion
+  *         on ADC group injected.
+  * @note   Multimode is kept enabled after this function. To disable multimode
+  *         (set with HAL_ADCEx_MultiModeConfigChannel() ), ADC must be 
+  *         reinitialized using HAL_ADC_Init() or HAL_ADC_ReInit().
+  * @note   In case of DMA configured in circular mode, function 
+  *         HAL_ADC_Stop_DMA must be called after this function with handle of
+  *         ADC slave, to properly disable the DMA channel of ADC slave.
+  * @param  hadc ADC handle of ADC master (handle of ADC slave must not be used)
+  * @retval None
+  */
+HAL_StatusTypeDef HAL_ADCEx_RegularMultiModeStop_DMA(ADC_HandleTypeDef* hadc)
+{
+  HAL_StatusTypeDef tmp_hal_status = HAL_OK;
+  uint32_t tickstart;
+  ADC_HandleTypeDef tmphadcSlave = {0};
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_MULTIMODE_MASTER_INSTANCE(hadc->Instance));
+  
+  /* Process locked */
+  __HAL_LOCK(hadc);
+  
+  /* Stop potential ADC conversion on going and disable ADC peripheral        */
+  /* conditioned to:                                                          */
+  /* - For ADC regular group conversion stop:                                 */
+  /*   On this STM32 family, conversion on the other group                    */
+  /*   (group injected) can continue (groups regular and injected             */
+  /*   conversion stop commands are independent)                              */
+  /* - For ADC disable:                                                       */
+  /*   No conversion on the other group (group injected) must be intended to  */
+  /*   continue (groups regular and injected are both impacted by             */
+  /*   ADC disable)                                                           */
+  
+  /* 1. Stop potential conversion on going, on regular group only */
+  tmp_hal_status = ADC_ConversionStop(hadc, ADC_REGULAR_GROUP);
+
+  /* Disable ADC peripheral if conversion on ADC group regular is             */
+  /* effectively stopped and if no conversion on the other group              */
+  /* (ADC group injected) is intended to continue.                            */
+  if((ADC_IS_CONVERSION_ONGOING_INJECTED(hadc) == RESET) &&
+     ((hadc->State & HAL_ADC_STATE_INJ_BUSY) == RESET)     )
+  {
+    /* Set a temporary handle of the ADC slave associated to the ADC master   */
+    /* (Depending on STM32F3 product, there may be up to 2 ADC slaves)        */
+    ADC_MULTI_SLAVE(hadc, &tmphadcSlave);
+    
+    if (tmphadcSlave.Instance == NULL)
+    {
+      /* Update ADC state machine (ADC master) to error */
+      SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_DMA);
+      
+      /* Process unlocked */
+      __HAL_UNLOCK(hadc);
+      
+      return HAL_ERROR;
+    }
+    
+    /* Procedure to disable the ADC peripheral: wait for conversions          */
+    /* effectively stopped (ADC master and ADC slave), then disable ADC       */
+    
+    /* 1. Wait until ADSTP=0 for ADC master and ADC slave*/
+    tickstart = HAL_GetTick();  
+
+    while(ADC_IS_CONVERSION_ONGOING_REGULAR(hadc)          || 
+          ADC_IS_CONVERSION_ONGOING_REGULAR(&tmphadcSlave)   )
+    {
+      if((HAL_GetTick() - tickstart) > ADC_STOP_CONVERSION_TIMEOUT)
+      {
+        /* Update ADC state machine (ADC master) to error */
+        SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL);
+        
+        /* Process unlocked */
+        __HAL_UNLOCK(hadc);
+        
+        return HAL_ERROR;
+      }
+    }
+    
+    /* Disable the DMA channel (in case of DMA in circular mode or stop while */
+    /* while DMA transfer is on going)                                        */
+    /* Note: In case of ADC slave using its own DMA channel (multimode        */
+    /*       parameter "DMAAccessMode" set to disabled):                      */
+    /*       DMA channel of ADC slave should stopped after this function with */
+    /*       function HAL_ADC_Stop_DMA.                                       */
+    tmp_hal_status = HAL_DMA_Abort(hadc->DMA_Handle);
+    
+    /* Check if DMA channel effectively disabled */
+    if (tmp_hal_status != HAL_OK)
+    {
+      /* Update ADC state machine to error */
+      SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_DMA);
+    }
+    
+    /* Disable ADC overrun interrupt */
+    __HAL_ADC_DISABLE_IT(hadc, ADC_IT_OVR);
+    
+    
+    
+    /* 2. Disable the ADC peripherals: master and slave */
+    /* Update "tmp_hal_status" only if DMA channel disabling passed,          */
+    /* to retain a potential failing status.                                  */
+    if (tmp_hal_status == HAL_OK)
+    {
+      /* Check if ADC are effectively disabled */
+      if ((ADC_Disable(hadc) != HAL_ERROR)          &&
+          (ADC_Disable(&tmphadcSlave) != HAL_ERROR)   )
+      {
+        tmp_hal_status = HAL_OK;
+        
+        /* Change ADC state (ADC master) */
+        ADC_STATE_CLR_SET(hadc->State,
+                          HAL_ADC_STATE_REG_BUSY | HAL_ADC_STATE_INJ_BUSY,
+                          HAL_ADC_STATE_READY);
+      }
+    }
+    else
+    {
+      /* In case of error, attempt to disable ADC instances anyway */
+      ADC_Disable(hadc);
+      ADC_Disable(&tmphadcSlave);
+      
+      /* Update ADC state machine (ADC master) to error */
+      SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL);
+    }
+    
+  }
+  /* Conversion on ADC group regular group is stopped, but ADC is not         */
+  /* disabled since conversion on ADC group injected is still on going.       */
+  else
+  {
+    /* Set ADC state */
+    CLEAR_BIT(hadc->State, HAL_ADC_STATE_REG_BUSY);
+  }
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+  
+  /* Return function status */
+  return tmp_hal_status;
+}
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx    */
+
+
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+
+/**
+  * @brief  Injected conversion complete callback in non blocking mode 
+  * @param  hadc ADC handle
+  * @retval None
+  */
+__weak void HAL_ADCEx_InjectedConvCpltCallback(ADC_HandleTypeDef* hadc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hadc);
+
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_ADCEx_InjectedConvCpltCallback could be implemented in the user file
+  */
+}
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+/**
+  * @brief  Injected context queue overflow flag callback. 
+  * @note   This callback is called if injected context queue is enabled
+            (parameter "QueueInjectedContext" in injected channel configuration)
+            and if a new injected context is set when queue is full (maximum 2
+            contexts).
+  * @param  hadc ADC handle
+  * @retval None
+  */
+__weak void HAL_ADCEx_InjectedQueueOverflowCallback(ADC_HandleTypeDef* hadc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hadc);
+
+  /* NOTE : This function should not be modified. When the callback is needed,
+            function HAL_ADCEx_InjectedQueueOverflowCallback must be implemented 
+            in the user file.
+  */
+}
+                        
+/**
+  * @brief  Analog watchdog 2 callback in non blocking mode. 
+  * @param  hadc ADC handle
+  * @retval None
+  */
+__weak void HAL_ADCEx_LevelOutOfWindow2Callback(ADC_HandleTypeDef* hadc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hadc);
+
+  /* NOTE : This function should not be modified. When the callback is needed,
+            function HAL_ADC_LevelOoutOfWindow2Callback must be implemented in the user file.
+  */
+}
+
+/**
+  * @brief  Analog watchdog 3 callback in non blocking mode. 
+  * @param  hadc ADC handle
+  * @retval None
+  */
+__weak void HAL_ADCEx_LevelOutOfWindow3Callback(ADC_HandleTypeDef* hadc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hadc);
+
+  /* NOTE : This function should not be modified. When the callback is needed,
+            function HAL_ADC_LevelOoutOfWindow3Callback must be implemented in the user file.
+  */
+}
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_Exported_Functions_Group3 ADCEx Peripheral Control functions
+  * @brief    ADC Extended Peripheral Control functions
+  *
+@verbatim   
+ ===============================================================================
+             ##### Peripheral Control functions #####
+ ===============================================================================  
+    [..]  This section provides functions allowing to:
+      (+) Configure channels on regular group
+      (+) Configure channels on injected group
+      (+) Configure multimode
+      (+) Configure the analog watchdog
+      
+@endverbatim
+  * @{
+  */
+
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+/**
+  * @brief  Configures the the selected channel to be linked to the regular
+  *         group.
+  * @note   In case of usage of internal measurement channels:
+  *         Vbat/VrefInt/TempSensor.
+  *         The recommended sampling time is at least:
+  *          - For devices STM32F37x: 17.1us for temperature sensor
+  *          - For the other STM32F3 devices: 2.2us for each of channels 
+  *            Vbat/VrefInt/TempSensor.
+  *         These internal paths can be be disabled using function 
+  *         HAL_ADC_DeInit().
+  * @note   Possibility to update parameters on the fly:
+  *         This function initializes channel into regular group, following  
+  *         calls to this function can be used to reconfigure some parameters 
+  *         of structure "ADC_ChannelConfTypeDef" on the fly, without reseting 
+  *         the ADC.
+  *         The setting of these parameters is conditioned to ADC state.
+  *         For parameters constraints, see comments of structure 
+  *         "ADC_ChannelConfTypeDef".
+  * @param  hadc ADC handle
+  * @param  sConfig Structure ADC channel for regular group.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADC_ConfigChannel(ADC_HandleTypeDef* hadc, ADC_ChannelConfTypeDef* sConfig)
+{
+  HAL_StatusTypeDef tmp_hal_status = HAL_OK;
+  ADC_Common_TypeDef *tmpADC_Common;
+  ADC_HandleTypeDef tmphadcSharingSameCommonRegister;
+  uint32_t tmpOffsetShifted;
+  __IO uint32_t wait_loop_index = 0U;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  assert_param(IS_ADC_REGULAR_RANK(sConfig->Rank));
+  assert_param(IS_ADC_SAMPLE_TIME(sConfig->SamplingTime));
+  assert_param(IS_ADC_SINGLE_DIFFERENTIAL(sConfig->SingleDiff));
+  assert_param(IS_ADC_OFFSET_NUMBER(sConfig->OffsetNumber));
+  assert_param(IS_ADC_RANGE(ADC_GET_RESOLUTION(hadc), sConfig->Offset));
+  
+  
+  /* Verification of channel number: Channels 1 to 14 are available in        */  
+  /* differential mode. Channels 15U, 16U, 17U, 18 can be used only in           */
+  /* single-ended mode.                                                       */
+  if (sConfig->SingleDiff != ADC_DIFFERENTIAL_ENDED)
+  {
+    assert_param(IS_ADC_CHANNEL(sConfig->Channel));
+  }
+  else
+  {
+    assert_param(IS_ADC_DIFF_CHANNEL(sConfig->Channel));
+  }
+  
+  /* Process locked */
+  __HAL_LOCK(hadc);
+  
+  
+  /* Parameters update conditioned to ADC state:                              */
+  /* Parameters that can be updated when ADC is disabled or enabled without   */
+  /* conversion on going on regular group:                                    */
+  /*  - Channel number                                                        */
+  /*  - Channel rank                                                          */
+  if (ADC_IS_CONVERSION_ONGOING_REGULAR(hadc) == RESET)
+  {
+    /* Regular sequence configuration */
+    /* For Rank 1 to 4U */
+    if (sConfig->Rank < 5U)
+    {
+      MODIFY_REG(hadc->Instance->SQR1,
+                 ADC_SQR1_RK(ADC_SQR2_SQ5, sConfig->Rank)    ,
+                 ADC_SQR1_RK(sConfig->Channel, sConfig->Rank) );
+    }
+    /* For Rank 5 to 9U */
+    else if (sConfig->Rank < 10U)
+    {
+      MODIFY_REG(hadc->Instance->SQR2,
+                 ADC_SQR2_RK(ADC_SQR2_SQ5, sConfig->Rank)    ,
+                 ADC_SQR2_RK(sConfig->Channel, sConfig->Rank) );
+    }
+    /* For Rank 10 to 14U */
+    else if (sConfig->Rank < 15U)
+    {
+      MODIFY_REG(hadc->Instance->SQR3                        ,
+                 ADC_SQR3_RK(ADC_SQR3_SQ10, sConfig->Rank)   ,
+                 ADC_SQR3_RK(sConfig->Channel, sConfig->Rank) );
+    }
+    /* For Rank 15 to 16U */
+    else
+    {   
+      MODIFY_REG(hadc->Instance->SQR4                        ,
+                 ADC_SQR4_RK(ADC_SQR4_SQ15, sConfig->Rank)   ,
+                 ADC_SQR4_RK(sConfig->Channel, sConfig->Rank) );
+    }
+    
+    
+  /* Parameters update conditioned to ADC state:                              */
+  /* Parameters that can be updated when ADC is disabled or enabled without   */
+  /* conversion on going on regular group:                                    */
+  /*  - Channel sampling time                                                 */
+  /*  - Channel offset                                                        */
+  if (ADC_IS_CONVERSION_ONGOING_REGULAR_INJECTED(hadc) == RESET)
+  {
+    /* Channel sampling time configuration */
+    /* For channels 10 to 18U */
+    if (sConfig->Channel >= ADC_CHANNEL_10)
+    {
+      MODIFY_REG(hadc->Instance->SMPR2                             ,
+                 ADC_SMPR2(ADC_SMPR2_SMP10, sConfig->Channel)      ,
+                 ADC_SMPR2(sConfig->SamplingTime, sConfig->Channel) );
+    }
+    else /* For channels 1 to 9U */
+    {
+      MODIFY_REG(hadc->Instance->SMPR1                             ,
+                 ADC_SMPR1(ADC_SMPR1_SMP0, sConfig->Channel)       ,
+                 ADC_SMPR1(sConfig->SamplingTime, sConfig->Channel) );
+    }
+    
+
+    /* Configure the offset: offset enable/disable, channel, offset value */
+
+    /* Shift the offset in function of the selected ADC resolution. */
+    /* Offset has to be left-aligned on bit 11U, the LSB (right bits) are set  */
+    /* to 0.                                                                  */
+    tmpOffsetShifted = ADC_OFFSET_SHIFT_RESOLUTION(hadc, sConfig->Offset);
+    
+    /* Configure the selected offset register:                                */
+    /* - Enable offset                                                        */
+    /* - Set channel number                                                   */
+    /* - Set offset value                                                     */
+    switch (sConfig->OffsetNumber)
+    {
+    case ADC_OFFSET_1:
+      /* Configure offset register 1U */
+      MODIFY_REG(hadc->Instance->OFR1               ,
+                 ADC_OFR1_OFFSET1_CH |
+                 ADC_OFR1_OFFSET1                   ,
+                 ADC_OFR1_OFFSET1_EN               |
+                 ADC_OFR_CHANNEL(sConfig->Channel) |
+                 tmpOffsetShifted                    );
+      break;
+    
+    case ADC_OFFSET_2:
+      /* Configure offset register 2U */
+      MODIFY_REG(hadc->Instance->OFR2               ,
+                 ADC_OFR2_OFFSET2_CH |
+                 ADC_OFR2_OFFSET2                   ,
+                 ADC_OFR2_OFFSET2_EN               |
+                 ADC_OFR_CHANNEL(sConfig->Channel) |
+                 tmpOffsetShifted                    );
+      break;
+        
+    case ADC_OFFSET_3:
+      /* Configure offset register 3U */
+      MODIFY_REG(hadc->Instance->OFR3               ,
+                 ADC_OFR3_OFFSET3_CH |
+                 ADC_OFR3_OFFSET3                   ,
+                 ADC_OFR3_OFFSET3_EN               |
+                 ADC_OFR_CHANNEL(sConfig->Channel) |
+                 tmpOffsetShifted                    );
+      break;
+    
+    case ADC_OFFSET_4:
+      /* Configure offset register 4U */
+      MODIFY_REG(hadc->Instance->OFR4               ,
+                 ADC_OFR4_OFFSET4_CH |
+                 ADC_OFR4_OFFSET4                   ,
+                 ADC_OFR4_OFFSET4_EN               |
+                 ADC_OFR_CHANNEL(sConfig->Channel) |
+                 tmpOffsetShifted                    );
+      break;
+    
+    /* Case ADC_OFFSET_NONE */
+    default :
+    /* Scan OFR1, OFR2, OFR3, OFR4 to check if the selected channel is        */
+    /* enabled. If this is the case, offset OFRx is disabled.                 */
+      if (((hadc->Instance->OFR1) & ADC_OFR1_OFFSET1_CH) == ADC_OFR_CHANNEL(sConfig->Channel))
+      {
+        /* Disable offset OFR1*/
+        CLEAR_BIT(hadc->Instance->OFR1, ADC_OFR1_OFFSET1_EN);
+      }
+      if (((hadc->Instance->OFR2) & ADC_OFR2_OFFSET2_CH) == ADC_OFR_CHANNEL(sConfig->Channel))
+      {
+        /* Disable offset OFR2*/
+        CLEAR_BIT(hadc->Instance->OFR2, ADC_OFR2_OFFSET2_EN); 
+      }
+      if (((hadc->Instance->OFR3) & ADC_OFR3_OFFSET3_CH) == ADC_OFR_CHANNEL(sConfig->Channel))
+      {
+        /* Disable offset OFR3*/
+        CLEAR_BIT(hadc->Instance->OFR3, ADC_OFR3_OFFSET3_EN);
+      }
+      if (((hadc->Instance->OFR4) & ADC_OFR4_OFFSET4_CH) == ADC_OFR_CHANNEL(sConfig->Channel))
+      {
+        /* Disable offset OFR4*/
+        CLEAR_BIT(hadc->Instance->OFR4, ADC_OFR4_OFFSET4_EN);
+      }
+      break;
+    }
+
+  }
+ 
+
+  /* Parameters update conditioned to ADC state:                              */
+  /* Parameters that can be updated only when ADC is disabled:                */
+  /*  - Single or differential mode                                           */
+  /*  - Internal measurement channels: Vbat/VrefInt/TempSensor                */
+  if (ADC_IS_ENABLE(hadc) == RESET)
+  {
+    /* Configuration of differential mode */
+    if (sConfig->SingleDiff != ADC_DIFFERENTIAL_ENDED)
+    {
+      /* Disable differential mode (default mode: single-ended) */
+      CLEAR_BIT(hadc->Instance->DIFSEL, ADC_DIFSEL_CHANNEL(sConfig->Channel));
+    }
+    else
+    {
+      /* Enable differential mode */
+      SET_BIT(hadc->Instance->DIFSEL, ADC_DIFSEL_CHANNEL(sConfig->Channel));
+      
+      /* Channel sampling time configuration (channel ADC_INx +1              */
+      /* corresponding to differential negative input).                       */
+      /* For channels 10 to 18U */
+      if (sConfig->Channel >= ADC_CHANNEL_10)
+      {
+        MODIFY_REG(hadc->Instance->SMPR2,
+                   ADC_SMPR2(ADC_SMPR2_SMP10, sConfig->Channel +1U)      ,
+                   ADC_SMPR2(sConfig->SamplingTime, sConfig->Channel +1U) );
+      }
+      else /* For channels 1 to 9U */
+      {
+        MODIFY_REG(hadc->Instance->SMPR1,
+                   ADC_SMPR1(ADC_SMPR1_SMP0, sConfig->Channel +1U)       ,
+                   ADC_SMPR1(sConfig->SamplingTime, sConfig->Channel +1U) );
+      }
+    }
+  
+    
+    /* Management of internal measurement channels: VrefInt/TempSensor/Vbat   */
+    /* internal measurement paths enable: If internal channel selected,       */
+    /* enable dedicated internal buffers and path.                            */
+    /* Note: these internal measurement paths can be disabled using           */
+    /* HAL_ADC_DeInit().                                                      */
+       
+    /* Configuration of common ADC parameters                                 */
+    /* Pointer to the common control register to which is belonging hadc      */
+    /* (Depending on STM32F3 product, there may be up to 4 ADC and 2 common   */
+    /* control registers)                                                     */
+    tmpADC_Common = ADC_COMMON_REGISTER(hadc);
+  
+    /* If the requested internal measurement path has already been enabled,   */
+    /* bypass the configuration processing.                                   */
+    if (( (sConfig->Channel == ADC_CHANNEL_TEMPSENSOR) &&
+          (HAL_IS_BIT_CLR(tmpADC_Common->CCR, ADC_CCR_TSEN))            ) ||
+        ( (sConfig->Channel == ADC_CHANNEL_VBAT)       &&
+          (HAL_IS_BIT_CLR(tmpADC_Common->CCR, ADC_CCR_VBATEN))          ) ||
+        ( (sConfig->Channel == ADC_CHANNEL_VREFINT)    &&
+          (HAL_IS_BIT_CLR(tmpADC_Common->CCR, ADC_CCR_VREFEN)))
+       )
+    {
+      /* Configuration of common ADC parameters (continuation)                */
+      /* Set handle of the other ADC sharing the same common register         */
+      ADC_COMMON_ADC_OTHER(hadc, &tmphadcSharingSameCommonRegister);
+      
+      /* Software is allowed to change common parameters only when all ADCs   */
+      /* of the common group are disabled.                                    */
+      if ((ADC_IS_ENABLE(hadc) == RESET)                                    &&
+          ( (tmphadcSharingSameCommonRegister.Instance == NULL)         ||
+            (ADC_IS_ENABLE(&tmphadcSharingSameCommonRegister) == RESET)   )   )
+      {
+        /* If Channel_16 is selected, enable Temp. sensor measurement path    */
+        /* Note: Temp. sensor internal channels available on ADC1 only        */
+        if ((sConfig->Channel == ADC_CHANNEL_TEMPSENSOR) && (hadc->Instance == ADC1))
+        {
+          SET_BIT(tmpADC_Common->CCR, ADC_CCR_TSEN);
+          
+          /* Delay for temperature sensor stabilization time */
+          /* Compute number of CPU cycles to wait for */
+          wait_loop_index = (ADC_TEMPSENSOR_DELAY_US * (SystemCoreClock / 1000000U));
+          while(wait_loop_index != 0U)
+          {
+            wait_loop_index--;
+          }
+        }
+        /* If Channel_17 is selected, enable VBAT measurement path            */
+        /* Note: VBAT internal channels available on ADC1 only                */
+        else if ((sConfig->Channel == ADC_CHANNEL_VBAT) && (hadc->Instance == ADC1))
+        {
+          SET_BIT(tmpADC_Common->CCR, ADC_CCR_VBATEN);
+        }
+        /* If Channel_18 is selected, enable VREFINT measurement path         */
+        /* Note: VrefInt internal channels available on all ADCs, but only    */
+        /*       one ADC is allowed to be connected to VrefInt at the same    */
+        /*       time.                                                        */
+        else if (sConfig->Channel == ADC_CHANNEL_VREFINT)
+        {
+          SET_BIT(tmpADC_Common->CCR, ADC_CCR_VREFEN);
+        }
+      }
+      /* If the requested internal measurement path has already been          */
+      /* enabled and other ADC of the common group are enabled, internal      */
+      /* measurement paths cannot be enabled.                                 */
+      else  
+      {
+        /* Update ADC state machine to error */
+        SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_CONFIG);
+        
+        tmp_hal_status = HAL_ERROR;
+      }
+    }
+    
+  }
+    
+  }
+  /* If a conversion is on going on regular group, no update on regular       */
+  /* channel could be done on neither of the channel configuration structure  */
+  /* parameters.                                                              */
+  else
+  {
+    /* Update ADC state machine to error */
+    SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_CONFIG);
+    
+    tmp_hal_status = HAL_ERROR;
+  }
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+  
+  /* Return function status */
+  return tmp_hal_status;
+}
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+
+#if defined(STM32F373xC) || defined(STM32F378xx)
+/**
+  * @brief  Configures the the selected channel to be linked to the regular
+  *         group.
+  * @note   In case of usage of internal measurement channels:
+  *         Vbat/VrefInt/TempSensor.
+  *         The recommended sampling time is at least:
+  *          - For devices STM32F37x: 17.1us for temperature sensor
+  *          - For the other STM32F3 devices: 2.2us for each of channels 
+  *            Vbat/VrefInt/TempSensor.
+  *         These internal paths can be be disabled using function 
+  *         HAL_ADC_DeInit().
+  * @note   Possibility to update parameters on the fly:
+  *         This function initializes channel into regular group, following  
+  *         calls to this function can be used to reconfigure some parameters 
+  *         of structure "ADC_ChannelConfTypeDef" on the fly, without reseting 
+  *         the ADC.
+  *         The setting of these parameters is conditioned to ADC state.
+  *         For parameters constraints, see comments of structure 
+  *         "ADC_ChannelConfTypeDef".
+  * @param  hadc ADC handle
+  * @param  sConfig Structure of ADC channel for regular group.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADC_ConfigChannel(ADC_HandleTypeDef* hadc, ADC_ChannelConfTypeDef* sConfig)
+{ 
+  HAL_StatusTypeDef tmp_hal_status = HAL_OK;
+  __IO uint32_t wait_loop_index = 0U;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  assert_param(IS_ADC_CHANNEL(sConfig->Channel));
+  assert_param(IS_ADC_REGULAR_RANK(sConfig->Rank));
+  assert_param(IS_ADC_SAMPLE_TIME(sConfig->SamplingTime));
+  
+  /* Process locked */
+  __HAL_LOCK(hadc);
+  
+  
+  /* Regular sequence configuration */
+  /* For Rank 1 to 6U */
+  if (sConfig->Rank < 7U)
+  {
+    MODIFY_REG(hadc->Instance->SQR3                        ,
+               ADC_SQR3_RK(ADC_SQR3_SQ1, sConfig->Rank)    ,
+               ADC_SQR3_RK(sConfig->Channel, sConfig->Rank) );
+  }
+  /* For Rank 7 to 12U */
+  else if (sConfig->Rank < 13U)
+  {
+    MODIFY_REG(hadc->Instance->SQR2                        ,
+               ADC_SQR2_RK(ADC_SQR2_SQ7, sConfig->Rank)    ,
+               ADC_SQR2_RK(sConfig->Channel, sConfig->Rank) );
+  }
+  /* For Rank 13 to 16U */
+  else
+  {
+    MODIFY_REG(hadc->Instance->SQR1                        ,
+               ADC_SQR1_RK(ADC_SQR1_SQ13, sConfig->Rank)   ,
+               ADC_SQR1_RK(sConfig->Channel, sConfig->Rank) );
+  }
+  
+  
+  /* Channel sampling time configuration */
+  /* For channels 10 to 18U */
+  if (sConfig->Channel > ADC_CHANNEL_10)
+  {
+    MODIFY_REG(hadc->Instance->SMPR1                             ,
+               ADC_SMPR1(ADC_SMPR1_SMP10, sConfig->Channel)      ,
+               ADC_SMPR1(sConfig->SamplingTime, sConfig->Channel) );
+  }
+  else   /* For channels 0 to 9U */
+  {
+    MODIFY_REG(hadc->Instance->SMPR2                             ,
+               ADC_SMPR2(ADC_SMPR2_SMP0, sConfig->Channel)       ,
+               ADC_SMPR2(sConfig->SamplingTime, sConfig->Channel) );
+  }
+  
+  /* If ADC1 Channel_16 or Channel_17 is selected, enable Temperature sensor  */
+  /* and VREFINT measurement path.                                            */
+  if ((sConfig->Channel == ADC_CHANNEL_TEMPSENSOR) ||
+      (sConfig->Channel == ADC_CHANNEL_VREFINT)      )
+  {
+    SET_BIT(hadc->Instance->CR2, ADC_CR2_TSVREFE);
+    
+    if ((sConfig->Channel == ADC_CHANNEL_TEMPSENSOR))
+    {
+      /* Delay for temperature sensor stabilization time */
+      /* Compute number of CPU cycles to wait for */
+      wait_loop_index = (ADC_TEMPSENSOR_DELAY_US * (SystemCoreClock / 1000000U));
+      while(wait_loop_index != 0U)
+      {
+        wait_loop_index--;
+      }
+    }
+  }
+  /* if ADC1 Channel_18 is selected, enable VBAT measurement path */
+  else if (sConfig->Channel == ADC_CHANNEL_VBAT)
+  {
+    SET_BIT(SYSCFG->CFGR1, SYSCFG_CFGR1_VBAT);
+  }
+
+   
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+  
+  /* Return function status */
+  return tmp_hal_status;
+}
+#endif /* STM32F373xC || STM32F378xx */
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+/**
+  * @brief  Configures the ADC injected group and the selected channel to be
+  *         linked to the injected group.
+  * @note   Possibility to update parameters on the fly:
+  *         This function initializes injected group, following calls to this 
+  *         function can be used to reconfigure some parameters of structure
+  *         "ADC_InjectionConfTypeDef" on the fly, without reseting the ADC.
+  *         The setting of these parameters is conditioned to ADC state.
+  *         For parameters constraints, see comments of structure 
+  *         "ADC_InjectionConfTypeDef".
+  * @note   In case of usage of internal measurement channels:
+  *         Vbat/VrefInt/TempSensor.
+  *         The recommended sampling time is at least:
+  *          - For devices STM32F37x: 17.1us for temperature sensor
+  *          - For the other STM32F3 devices: 2.2us for each of channels 
+  *            Vbat/VrefInt/TempSensor.
+  *         These internal paths can be be disabled using function 
+  *         HAL_ADC_DeInit().
+  * @note   To reset injected sequencer, function HAL_ADCEx_InjectedStop() can
+  *         be used.
+  * @note   Caution: For Injected Context Queue use: a context must be fully 
+  * defined before start of injected conversion: all channels configured 
+  * consecutively for the same ADC instance. Therefore, Number of calls of 
+  * HAL_ADCEx_InjectedConfigChannel() must correspond to value of parameter 
+  * InjectedNbrOfConversion for each context.
+  *  - Example 1: If 1 context intended to be used (or not use of this feature: 
+  *    QueueInjectedContext=DISABLE) and usage of the 3 first injected ranks 
+  *    (InjectedNbrOfConversion=3), HAL_ADCEx_InjectedConfigChannel() must be  
+  *    called once for each channel (3 times) before launching a conversion.   
+  *    This function must not be called to configure the 4th injected channel:   
+  *    it would start a new context into context queue.
+  *  - Example 2: If 2 contexts intended to be used and usage of the 3 first 
+  *    injected ranks (InjectedNbrOfConversion=3),  
+  *    HAL_ADCEx_InjectedConfigChannel() must be called once for each channel and  
+  *    for each context (3 channels x 2 contexts = 6 calls). Conversion can  
+  *    start once the 1st context is set. The 2nd context can be set on the fly.
+  * @param  hadc ADC handle
+  * @param  sConfigInjected Structure of ADC injected group and ADC channel for
+  *         injected group.
+  * @retval None
+  */
+HAL_StatusTypeDef HAL_ADCEx_InjectedConfigChannel(ADC_HandleTypeDef* hadc, ADC_InjectionConfTypeDef* sConfigInjected)
+{
+  HAL_StatusTypeDef tmp_hal_status = HAL_OK;
+  ADC_Common_TypeDef *tmpADC_Common;
+  ADC_HandleTypeDef tmphadcSharingSameCommonRegister;
+  uint32_t tmpOffsetShifted;
+  __IO uint32_t wait_loop_index = 0U;
+  
+  /* Injected context queue feature: temporary JSQR variables defined in      */
+  /* static to be passed over calls of this function                          */
+  uint32_t tmp_JSQR_ContextQueueBeingBuilt = 0U;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  assert_param(IS_ADC_SAMPLE_TIME(sConfigInjected->InjectedSamplingTime));
+  assert_param(IS_ADC_SINGLE_DIFFERENTIAL(sConfigInjected->InjectedSingleDiff));
+  assert_param(IS_FUNCTIONAL_STATE(sConfigInjected->AutoInjectedConv));
+  assert_param(IS_FUNCTIONAL_STATE(sConfigInjected->QueueInjectedContext));
+  assert_param(IS_ADC_EXTTRIGINJEC_EDGE(sConfigInjected->ExternalTrigInjecConvEdge));
+  assert_param(IS_ADC_EXTTRIGINJEC(sConfigInjected->ExternalTrigInjecConv));
+  assert_param(IS_ADC_OFFSET_NUMBER(sConfigInjected->InjectedOffsetNumber));
+  assert_param(IS_ADC_RANGE(ADC_GET_RESOLUTION(hadc), sConfigInjected->InjectedOffset));
+  
+  if(hadc->Init.ScanConvMode != ADC_SCAN_DISABLE)
+  {
+    assert_param(IS_ADC_INJECTED_RANK(sConfigInjected->InjectedRank));
+    assert_param(IS_ADC_INJECTED_NB_CONV(sConfigInjected->InjectedNbrOfConversion));
+    assert_param(IS_FUNCTIONAL_STATE(sConfigInjected->InjectedDiscontinuousConvMode));
+  }
+  
+  /* Verification of channel number: Channels 1 to 14 are available in        */  
+  /* differential mode. Channels 15U, 16U, 17U, 18 can be used only in           */
+  /* single-ended mode.                                                       */
+  if (sConfigInjected->InjectedSingleDiff != ADC_DIFFERENTIAL_ENDED)
+  {
+    assert_param(IS_ADC_CHANNEL(sConfigInjected->InjectedChannel));
+  }
+  else
+  {
+    assert_param(IS_ADC_DIFF_CHANNEL(sConfigInjected->InjectedChannel));
+  }
+  
+  /* Process locked */
+  __HAL_LOCK(hadc);
+  
+  /* Configuration of Injected group sequencer.                               */
+  /* Hardware constraint: Must fully define injected context register JSQR    */
+  /* before make it entering into injected sequencer queue.                   */
+  /*                                                                          */
+  /* - if scan mode is disabled:                                              */
+  /*    * Injected channels sequence length is set to 0x00: 1 channel         */
+  /*      converted (channel on injected rank 1U)                              */
+  /*      Parameter "InjectedNbrOfConversion" is discarded.                   */
+  /*    * Injected context register JSQR setting is simple: register is fully */
+  /*      defined on one call of this function (for injected rank 1U) and can  */
+  /*      be entered into queue directly.                                     */
+  /* - if scan mode is enabled:                                               */
+  /*    * Injected channels sequence length is set to parameter               */
+  /*      "InjectedNbrOfConversion".                                          */
+  /*    * Injected context register JSQR setting more complex: register is    */
+  /*      fully defined over successive calls of this function, for each      */
+  /*      injected channel rank. It is entered into queue only when all       */
+  /*      injected ranks have been set.                                       */
+  /*   Note: Scan mode is not present by hardware on this device, but used    */
+  /*   by software for alignment over all STM32 devices.                      */
+  
+  if ((hadc->Init.ScanConvMode == ADC_SCAN_DISABLE)  ||
+      (sConfigInjected->InjectedNbrOfConversion == 1U)  )
+  {
+    /* Configuration of context register JSQR:                                */
+    /*  - number of ranks in injected group sequencer: fixed to 1st rank      */
+    /*    (scan mode disabled, only rank 1 used)                              */
+    /*  - external trigger to start conversion                                */
+    /*  - external trigger polarity                                           */
+    /*  - channel set to rank 1 (scan mode disabled, only rank 1 used)        */
+    
+    if (sConfigInjected->InjectedRank == ADC_INJECTED_RANK_1)
+    {
+      /* Enable external trigger if trigger selection is different of         */
+      /* software start.                                                      */
+      /* Note: This configuration keeps the hardware feature of parameter     */
+      /*       ExternalTrigInjecConvEdge "trigger edge none" equivalent to    */
+      /*       software start.                                                */
+      if (sConfigInjected->ExternalTrigInjecConv != ADC_INJECTED_SOFTWARE_START)
+      {
+        SET_BIT(tmp_JSQR_ContextQueueBeingBuilt, ADC_JSQR_RK(sConfigInjected->InjectedChannel, ADC_INJECTED_RANK_1) |
+                                                 ADC_JSQR_JEXTSEL_SET(hadc, sConfigInjected->ExternalTrigInjecConv) |
+                                                 sConfigInjected->ExternalTrigInjecConvEdge                          );
+      }
+      else
+      {
+        SET_BIT(tmp_JSQR_ContextQueueBeingBuilt, ADC_JSQR_RK(sConfigInjected->InjectedChannel, ADC_INJECTED_RANK_1) );
+      }
+      
+      /* Update ADC register JSQR */
+      MODIFY_REG(hadc->Instance->JSQR           ,
+                 ADC_JSQR_JSQ4    |
+                 ADC_JSQR_JSQ3    |
+                 ADC_JSQR_JSQ2    |
+                 ADC_JSQR_JSQ1    |
+                 ADC_JSQR_JEXTEN  |
+                 ADC_JSQR_JEXTSEL |
+                 ADC_JSQR_JL                    ,
+                 tmp_JSQR_ContextQueueBeingBuilt );
+      
+      /* For debug and informative reasons, hadc handle saves JSQR setting */
+      hadc->InjectionConfig.ContextQueue = tmp_JSQR_ContextQueueBeingBuilt;
+    }
+    /* If another injected rank than rank1 was intended to be set, and could  */
+    /* not due to ScanConvMode disabled, error is reported.                   */
+    else
+    {
+      /* Update ADC state machine to error */
+      SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_CONFIG);
+      
+      tmp_hal_status = HAL_ERROR;
+    }
+  
+  }
+  else
+  {
+    /* Case of scan mode enabled, several channels to set into injected group */
+    /* sequencer.                                                             */
+    /* Procedure to define injected context register JSQR over successive     */
+    /* calls of this function, for each injected channel rank:                */
+    
+    /* 1. Start new context and set parameters related to all injected        */
+    /*    channels: injected sequence length and trigger                      */
+    if (hadc->InjectionConfig.ChannelCount == 0U)
+    {
+      /* Initialize number of channels that will be configured on the context */
+      /*  being built                                                         */
+      hadc->InjectionConfig.ChannelCount = sConfigInjected->InjectedNbrOfConversion;
+      /* Initialize value that will be set into register JSQR */
+      hadc->InjectionConfig.ContextQueue = 0x00000000U;
+      
+      /* Configuration of context register JSQR:                              */
+      /*  - number of ranks in injected group sequencer                       */
+      /*  - external trigger to start conversion                              */
+      /*  - external trigger polarity                                         */
+        
+      /* Enable external trigger if trigger selection is different of         */
+      /* software start.                                                      */
+      /* Note: This configuration keeps the hardware feature of parameter     */
+      /*       ExternalTrigInjecConvEdge "trigger edge none" equivalent to    */
+      /*       software start.                                                */
+      if (sConfigInjected->ExternalTrigInjecConv != ADC_INJECTED_SOFTWARE_START)
+      {
+        SET_BIT(hadc->InjectionConfig.ContextQueue, (sConfigInjected->InjectedNbrOfConversion - 1U)           |
+                                                    ADC_JSQR_JEXTSEL_SET(hadc, sConfigInjected->ExternalTrigInjecConv) |
+                                                    sConfigInjected->ExternalTrigInjecConvEdge                          );        
+      }
+      else
+      {
+        SET_BIT(hadc->InjectionConfig.ContextQueue, (sConfigInjected->InjectedNbrOfConversion - 1U) );        
+      }
+      
+    }
+
+      /* 2. Continue setting of context under definition with parameter       */
+      /*    related to each channel: channel rank sequence                    */
+      
+      /* Set the JSQx bits for the selected rank */
+      MODIFY_REG(hadc->InjectionConfig.ContextQueue                                          ,
+                 ADC_JSQR_RK(ADC_SQR3_SQ10, sConfigInjected->InjectedRank)                   ,
+                 ADC_JSQR_RK(sConfigInjected->InjectedChannel, sConfigInjected->InjectedRank) );
+      
+      /* Decrease channel count after setting into temporary JSQR variable */
+      hadc->InjectionConfig.ChannelCount --;
+      
+      /* 3. End of context setting: If last channel set, then write context   */
+      /*    into register JSQR and make it enter into queue                   */
+      if (hadc->InjectionConfig.ChannelCount == 0U)
+      {
+        /* Update ADC register JSQR */
+        MODIFY_REG(hadc->Instance->JSQR              ,
+                   ADC_JSQR_JSQ4    |
+                   ADC_JSQR_JSQ3    |
+                   ADC_JSQR_JSQ2    |
+                   ADC_JSQR_JSQ1    |
+                   ADC_JSQR_JEXTEN  |
+                   ADC_JSQR_JEXTSEL |
+                   ADC_JSQR_JL                       ,
+                   hadc->InjectionConfig.ContextQueue );
+      }
+
+  }
+
+  
+  /* Parameters update conditioned to ADC state:                              */
+  /* Parameters that can be updated when ADC is disabled or enabled without   */
+  /* conversion on going on injected group:                                   */
+  /*  - Injected context queue: Queue disable (active context is kept) or     */
+  /*    enable (context decremented, up to 2 contexts queued)                 */
+  /*  - Injected discontinuous mode: can be enabled only if auto-injected     */
+  /*    mode is disabled.                                                     */
+  if (ADC_IS_CONVERSION_ONGOING_INJECTED(hadc) == RESET)
+  {     
+    /* If auto-injected mode is disabled: no constraint                       */
+    if (sConfigInjected->AutoInjectedConv == DISABLE)
+    {
+      MODIFY_REG(hadc->Instance->CFGR                                                            ,
+                 ADC_CFGR_JQM    |
+                 ADC_CFGR_JDISCEN                                                                ,
+                 ADC_CFGR_INJECT_CONTEXT_QUEUE((uint32_t)sConfigInjected->QueueInjectedContext)           | 
+                 ADC_CFGR_INJECT_DISCCONTINUOUS((uint32_t)sConfigInjected->InjectedDiscontinuousConvMode)   );
+    }
+    /* If auto-injected mode is enabled: Injected discontinuous setting is    */
+    /* discarded.                                                             */
+    else
+    {
+      MODIFY_REG(hadc->Instance->CFGR                                                ,
+                 ADC_CFGR_JQM    |
+                 ADC_CFGR_JDISCEN                                                    ,
+                 ADC_CFGR_INJECT_CONTEXT_QUEUE((uint32_t)sConfigInjected->QueueInjectedContext) );
+      
+      /* If injected discontinuous mode was intended to be set and could not  */
+      /* due to auto-injected enabled, error is reported.                     */
+      if (sConfigInjected->InjectedDiscontinuousConvMode == ENABLE)
+      {
+        /* Update ADC state machine to error */
+        SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_CONFIG);
+        
+        tmp_hal_status = HAL_ERROR;
+      }
+    }
+
+  }
+  
+  
+  /* Parameters update conditioned to ADC state:                              */
+  /* Parameters that can be updated when ADC is disabled or enabled without   */
+  /* conversion on going on regular and injected groups:                      */
+  /*  - Automatic injected conversion: can be enabled if injected group       */
+  /*    external triggers are disabled.                                       */
+  /*  - Channel sampling time                                                 */
+  /*  - Channel offset                                                        */
+  if (ADC_IS_CONVERSION_ONGOING_REGULAR_INJECTED(hadc) == RESET)
+  {    
+    /* If injected group external triggers are disabled (set to injected      */
+    /* software start): no constraint                                         */
+    if (sConfigInjected->ExternalTrigInjecConv == ADC_INJECTED_SOFTWARE_START)
+    {
+      MODIFY_REG(hadc->Instance->CFGR                                              ,
+                 ADC_CFGR_JAUTO                                                    ,
+                 ADC_CFGR_INJECT_AUTO_CONVERSION((uint32_t)sConfigInjected->AutoInjectedConv) );
+    }
+    /* If Automatic injected conversion was intended to be set and could not  */
+    /* due to injected group external triggers enabled, error is reported.    */
+    else
+    {
+      /* Disable Automatic injected conversion */
+      CLEAR_BIT(hadc->Instance->CFGR, ADC_CFGR_JAUTO);
+      
+      if (sConfigInjected->AutoInjectedConv == ENABLE)
+      {
+        /* Update ADC state machine to error */
+        SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_CONFIG);
+        
+        tmp_hal_status = HAL_ERROR;
+      }
+    }
+      
+
+    /* Channel sampling time configuration */
+    /* For channels 10 to 18U */
+    if (sConfigInjected->InjectedChannel >= ADC_CHANNEL_10)
+    {
+      MODIFY_REG(hadc->Instance->SMPR2                                                             ,
+                 ADC_SMPR2(ADC_SMPR2_SMP10, sConfigInjected->InjectedChannel)                      ,
+                 ADC_SMPR2(sConfigInjected->InjectedSamplingTime, sConfigInjected->InjectedChannel) );
+    }
+    else /* For channels 1 to 9U */
+    {
+      MODIFY_REG(hadc->Instance->SMPR1                                                             ,
+                 ADC_SMPR1(ADC_SMPR1_SMP0, sConfigInjected->InjectedChannel)                       ,
+                 ADC_SMPR1(sConfigInjected->InjectedSamplingTime, sConfigInjected->InjectedChannel) );
+    }
+    
+    /* Configure the offset: offset enable/disable, channel, offset value */
+    
+    /* Shift the offset in function of the selected ADC resolution. */
+    /* Offset has to be left-aligned on bit 11U, the LSB (right bits) are set  */
+    /* to 0.                                                                  */
+    tmpOffsetShifted = ADC_OFFSET_SHIFT_RESOLUTION(hadc, sConfigInjected->InjectedOffset);
+    
+    /* Configure the selected offset register:                                */
+    /* - Enable offset                                                        */
+    /* - Set channel number                                                   */
+    /* - Set offset value                                                     */
+    switch (sConfigInjected->InjectedOffsetNumber)
+    {
+    case ADC_OFFSET_1:
+      /* Configure offset register 1U */
+      MODIFY_REG(hadc->Instance->OFR1                               ,
+                 ADC_OFR1_OFFSET1_CH |
+                 ADC_OFR1_OFFSET1                                   ,
+                 ADC_OFR1_OFFSET1_EN                               |
+                 ADC_OFR_CHANNEL(sConfigInjected->InjectedChannel) |
+                 tmpOffsetShifted                                    );
+      break;
+    
+    case ADC_OFFSET_2:
+      /* Configure offset register 2U */
+      MODIFY_REG(hadc->Instance->OFR2                               ,
+                 ADC_OFR2_OFFSET2_CH |
+                 ADC_OFR2_OFFSET2                                   ,
+                 ADC_OFR2_OFFSET2_EN                               |
+                 ADC_OFR_CHANNEL(sConfigInjected->InjectedChannel) |
+                 tmpOffsetShifted                                    );
+      break;
+        
+    case ADC_OFFSET_3:
+      /* Configure offset register 3U */
+      MODIFY_REG(hadc->Instance->OFR3                               ,
+                 ADC_OFR3_OFFSET3_CH |
+                 ADC_OFR3_OFFSET3                                   ,
+                 ADC_OFR3_OFFSET3_EN                               |
+                 ADC_OFR_CHANNEL(sConfigInjected->InjectedChannel) |
+                 tmpOffsetShifted                                    );
+      break;
+    
+    case ADC_OFFSET_4:
+      /* Configure offset register 4U */
+      MODIFY_REG(hadc->Instance->OFR4                               ,
+                 ADC_OFR4_OFFSET4_CH |
+                 ADC_OFR4_OFFSET4                                   ,
+                 ADC_OFR4_OFFSET4_EN                               |
+                 ADC_OFR_CHANNEL(sConfigInjected->InjectedChannel) |
+                 tmpOffsetShifted                                    );
+      break;
+    
+    /* Case ADC_OFFSET_NONE */
+    default :
+    /* Scan OFR1, OFR2, OFR3, OFR4 to check if the selected channel is        */
+    /* enabled. If this is the case, offset OFRx is disabled.                 */
+      if (((hadc->Instance->OFR1) & ADC_OFR1_OFFSET1_CH) == ADC_OFR_CHANNEL(sConfigInjected->InjectedChannel))
+      {
+        /* Disable offset OFR1*/
+        CLEAR_BIT(hadc->Instance->OFR1, ADC_OFR1_OFFSET1_EN);
+      }
+      if (((hadc->Instance->OFR2) & ADC_OFR2_OFFSET2_CH) == ADC_OFR_CHANNEL(sConfigInjected->InjectedChannel))
+      {
+        /* Disable offset OFR2*/
+        CLEAR_BIT(hadc->Instance->OFR2, ADC_OFR2_OFFSET2_EN); 
+      }
+      if (((hadc->Instance->OFR3) & ADC_OFR3_OFFSET3_CH) == ADC_OFR_CHANNEL(sConfigInjected->InjectedChannel))
+      {
+        /* Disable offset OFR3*/
+        CLEAR_BIT(hadc->Instance->OFR3, ADC_OFR3_OFFSET3_EN);
+      }
+      if (((hadc->Instance->OFR4) & ADC_OFR4_OFFSET4_CH) == ADC_OFR_CHANNEL(sConfigInjected->InjectedChannel))
+      {
+        /* Disable offset OFR4*/
+        CLEAR_BIT(hadc->Instance->OFR4, ADC_OFR4_OFFSET4_EN);
+      }
+      break;
+    }
+    
+  }
+  
+  
+  /* Parameters update conditioned to ADC state:                              */
+  /* Parameters that can be updated only when ADC is disabled:                */
+  /*  - Single or differential mode                                           */
+  /*  - Internal measurement channels: Vbat/VrefInt/TempSensor                */
+  if (ADC_IS_ENABLE(hadc) == RESET)
+  {
+    /* Configuration of differential mode */
+    if (sConfigInjected->InjectedSingleDiff != ADC_DIFFERENTIAL_ENDED)
+    {
+      /* Disable differential mode (default mode: single-ended) */
+      CLEAR_BIT(hadc->Instance->DIFSEL, ADC_DIFSEL_CHANNEL(sConfigInjected->InjectedChannel));
+    }
+    else
+    {
+      /* Enable differential mode */
+      SET_BIT(hadc->Instance->DIFSEL, ADC_DIFSEL_CHANNEL(sConfigInjected->InjectedChannel));
+      
+      /* Channel sampling time configuration (channel ADC_INx +1              */
+      /* corresponding to differential negative input).                       */
+      /* For channels 10 to 18U */
+      if (sConfigInjected->InjectedChannel >= ADC_CHANNEL_10)
+      {
+        MODIFY_REG(hadc->Instance->SMPR2,
+                   ADC_SMPR2(ADC_SMPR2_SMP10, sConfigInjected->InjectedChannel +1U),
+                   ADC_SMPR2(sConfigInjected->InjectedSamplingTime, sConfigInjected->InjectedChannel +1U) );
+      }
+      else /* For channels 1 to 9U */
+      {
+        MODIFY_REG(hadc->Instance->SMPR1,
+                   ADC_SMPR1(ADC_SMPR1_SMP0, sConfigInjected->InjectedChannel +1U),
+                   ADC_SMPR1(sConfigInjected->InjectedSamplingTime, sConfigInjected->InjectedChannel +1U) );
+      }
+    }
+    
+
+    /* Management of internal measurement channels: VrefInt/TempSensor/Vbat   */
+    /* internal measurement paths enable: If internal channel selected,       */
+    /* enable dedicated internal buffers and path.                            */
+    /* Note: these internal measurement paths can be disabled using           */
+    /* HAL_ADC_deInit().                                                      */
+       
+    /* Configuration of common ADC parameters                                 */
+    /* Pointer to the common control register to which is belonging hadc      */
+    /* (Depending on STM32F3 product, there may be up to 4 ADC and 2 common   */
+    /* control registers)                                                     */
+    tmpADC_Common = ADC_COMMON_REGISTER(hadc);
+  
+    /* If the requested internal measurement path has already been enabled,   */
+    /* bypass the configuration processing.                                   */
+    if (( (sConfigInjected->InjectedChannel == ADC_CHANNEL_TEMPSENSOR) &&
+          (HAL_IS_BIT_CLR(tmpADC_Common->CCR, ADC_CCR_TSEN))            ) ||
+        ( (sConfigInjected->InjectedChannel == ADC_CHANNEL_VBAT)       &&
+          (HAL_IS_BIT_CLR(tmpADC_Common->CCR, ADC_CCR_VBATEN))          ) ||
+        ( (sConfigInjected->InjectedChannel == ADC_CHANNEL_VREFINT)    &&
+          (HAL_IS_BIT_CLR(tmpADC_Common->CCR, ADC_CCR_VREFEN)))
+       )
+    {
+      /* Configuration of common ADC parameters (continuation)                */
+      /* Set handle of the other ADC sharing the same common register         */
+      ADC_COMMON_ADC_OTHER(hadc, &tmphadcSharingSameCommonRegister);
+      
+      /* Software is allowed to change common parameters only when all ADCs   */
+      /* of the common group are disabled.                                    */
+      if ((ADC_IS_ENABLE(hadc) == RESET)                                    &&
+          ( (tmphadcSharingSameCommonRegister.Instance == NULL)         ||
+            (ADC_IS_ENABLE(&tmphadcSharingSameCommonRegister) == RESET)   )   )
+      {
+        /* If Channel_16 is selected, enable Temp. sensor measurement path    */
+        /* Note: Temp. sensor internal channels available on ADC1 only        */
+        if ((sConfigInjected->InjectedChannel == ADC_CHANNEL_TEMPSENSOR) && (hadc->Instance == ADC1))
+        {
+          SET_BIT(tmpADC_Common->CCR, ADC_CCR_TSEN);
+          
+          /* Delay for temperature sensor stabilization time */
+          /* Compute number of CPU cycles to wait for */
+          wait_loop_index = (ADC_TEMPSENSOR_DELAY_US * (SystemCoreClock / 1000000U));
+          while(wait_loop_index != 0U)
+          {
+            wait_loop_index--;
+          }
+        }
+        /* If Channel_17 is selected, enable VBAT measurement path            */
+        /* Note: VBAT internal channels available on ADC1 only                */
+        else if ((sConfigInjected->InjectedChannel == ADC_CHANNEL_VBAT) && (hadc->Instance == ADC1))
+        {
+          SET_BIT(tmpADC_Common->CCR, ADC_CCR_VBATEN);
+        }
+        /* If Channel_18 is selected, enable VREFINT measurement path         */
+        /* Note: VrefInt internal channels available on all ADCs, but only    */
+        /*       one ADC is allowed to be connected to VrefInt at the same    */
+        /*       time.                                                        */
+        else if (sConfigInjected->InjectedChannel == ADC_CHANNEL_VREFINT)
+        {
+          SET_BIT(tmpADC_Common->CCR, ADC_CCR_VREFEN);
+        }
+      }
+      /* If the requested internal measurement path has already been enabled  */
+      /* and other ADC of the common group are enabled, internal              */
+      /* measurement paths cannot be enabled.                                 */
+      else  
+      {
+        /* Update ADC state machine to error */
+        SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_CONFIG);
+        
+        tmp_hal_status = HAL_ERROR;
+      }
+    }
+    
+  }
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+  
+  /* Return function status */
+  return tmp_hal_status;
+}
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+
+#if defined(STM32F373xC) || defined(STM32F378xx)
+/**
+  * @brief  Configures the ADC injected group and the selected channel to be
+  *         linked to the injected group.
+  * @note   Possibility to update parameters on the fly:
+  *         This function initializes injected group, following calls to this 
+  *         function can be used to reconfigure some parameters of structure
+  *         "ADC_InjectionConfTypeDef" on the fly, without reseting the ADC.
+  *         The setting of these parameters is conditioned to ADC state: 
+  *         this function must be called when ADC is not under conversion.
+  * @note   In case of usage of internal measurement channels:
+  *         Vbat/VrefInt/TempSensor.
+  *         The recommended sampling time is at least:
+  *          - For devices STM32F37x: 17.1us for temperature sensor
+  *          - For the other STM32F3 devices: 2.2us for each of channels 
+  *            Vbat/VrefInt/TempSensor.
+  *         These internal paths can be be disabled using function 
+  *         HAL_ADC_DeInit().
+  * @param  hadc ADC handle
+  * @param  sConfigInjected Structure of ADC injected group and ADC channel for
+  *         injected group.
+  * @retval None
+  */
+HAL_StatusTypeDef HAL_ADCEx_InjectedConfigChannel(ADC_HandleTypeDef* hadc, ADC_InjectionConfTypeDef* sConfigInjected)
+{
+  HAL_StatusTypeDef tmp_hal_status = HAL_OK;
+  __IO uint32_t wait_loop_index = 0U;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  assert_param(IS_ADC_CHANNEL(sConfigInjected->InjectedChannel));
+  assert_param(IS_ADC_SAMPLE_TIME(sConfigInjected->InjectedSamplingTime));
+  assert_param(IS_FUNCTIONAL_STATE(sConfigInjected->AutoInjectedConv));
+  assert_param(IS_ADC_EXTTRIGINJEC(sConfigInjected->ExternalTrigInjecConv));
+  assert_param(IS_ADC_RANGE(sConfigInjected->InjectedOffset));
+  
+  if(hadc->Init.ScanConvMode != ADC_SCAN_DISABLE)
+  {
+    assert_param(IS_ADC_INJECTED_RANK(sConfigInjected->InjectedRank));
+    assert_param(IS_ADC_INJECTED_NB_CONV(sConfigInjected->InjectedNbrOfConversion));
+    assert_param(IS_FUNCTIONAL_STATE(sConfigInjected->InjectedDiscontinuousConvMode));
+  }
+  
+  /* Process locked */
+  __HAL_LOCK(hadc);
+  
+  /* Configuration of injected group sequencer:                               */
+  /* - if scan mode is disabled, injected channels sequence length is set to  */
+  /*   0x00: 1 channel converted (channel on regular rank 1U)                  */
+  /*   Parameter "InjectedNbrOfConversion" is discarded.                      */
+  /*   Note: Scan mode is present by hardware on this device and, if          */
+  /*   disabled, discards automatically nb of conversions. Anyway, nb of      */
+  /*   conversions is forced to 0x00 for alignment over all STM32 devices.    */
+  /* - if scan mode is enabled, injected channels sequence length is set to   */
+  /*   parameter "InjectedNbrOfConversion".                                   */
+  if (hadc->Init.ScanConvMode == ADC_SCAN_DISABLE)
+  {
+    if (sConfigInjected->InjectedRank == ADC_INJECTED_RANK_1)
+    {
+      /* Clear the old SQx bits for all injected ranks */
+      MODIFY_REG(hadc->Instance->JSQR                           ,
+                 ADC_JSQR_JL   |
+                 ADC_JSQR_JSQ4 |
+                 ADC_JSQR_JSQ3 |
+                 ADC_JSQR_JSQ2 |
+                 ADC_JSQR_JSQ1                                  ,
+                 ADC_JSQR_RK_JL(sConfigInjected->InjectedChannel,
+                                      ADC_INJECTED_RANK_1,
+                                      0x01U)                      );
+    }
+    /* If another injected rank than rank1 was intended to be set, and could  */
+    /* not due to ScanConvMode disabled, error is reported.                   */
+    else
+    {
+      /* Update ADC state machine to error */
+      SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_CONFIG);
+      
+      tmp_hal_status = HAL_ERROR;
+    }
+  }
+  else
+  {
+    /* Since injected channels rank conv. order depends on total number of   */
+    /* injected conversions, selected rank must be below or equal to total   */
+    /* number of injected conversions to be updated.                         */
+    if (sConfigInjected->InjectedRank <= sConfigInjected->InjectedNbrOfConversion)
+    {
+      /* Clear the old SQx bits for the selected rank */
+      /* Set the SQx bits for the selected rank */
+      MODIFY_REG(hadc->Instance->JSQR                                         ,
+                 
+                 ADC_JSQR_JL                                                 |
+                 ADC_JSQR_RK_JL(ADC_JSQR_JSQ1,                         
+                                sConfigInjected->InjectedRank,         
+                                sConfigInjected->InjectedNbrOfConversion)     ,
+                 
+                 ADC_JSQR_JL_SHIFT(sConfigInjected->InjectedNbrOfConversion) |
+                 ADC_JSQR_RK_JL(sConfigInjected->InjectedChannel,      
+                                sConfigInjected->InjectedRank,         
+                                sConfigInjected->InjectedNbrOfConversion)      );
+    }
+    else
+    {
+      /* Clear the old SQx bits for the selected rank */
+      MODIFY_REG(hadc->Instance->JSQR                                     ,
+                 
+                 ADC_JSQR_JL                                             |
+                 ADC_JSQR_RK_JL(ADC_JSQR_JSQ1,                         
+                                sConfigInjected->InjectedRank,         
+                                sConfigInjected->InjectedNbrOfConversion) ,
+                 
+                 0x00000000                                                );
+    }
+  }
+  
+  /* Configuration of injected group                                          */
+  /* Parameters update conditioned to ADC state:                              */
+  /* Parameters that can be updated only when ADC is disabled:                */
+  /*  - external trigger to start conversion                                  */
+  /* Parameters update not conditioned to ADC state:                          */
+  /*  - Automatic injected conversion                                         */
+  /*  - Injected discontinuous mode                                           */
+  /* Note: In case of ADC already enabled, caution to not launch an unwanted  */
+  /*       conversion while modifying register CR2 by writing 1 to bit ADON.  */
+  if (ADC_IS_ENABLE(hadc) == RESET)
+  {    
+    MODIFY_REG(hadc->Instance->CR2                   ,
+               ADC_CR2_JEXTSEL |
+               ADC_CR2_ADON                          ,
+               sConfigInjected->ExternalTrigInjecConv );
+  }
+  
+  /* Configuration of injected group                                          */
+  /*  - Automatic injected conversion                                         */
+  /*  - Injected discontinuous mode                                           */
+  
+    /* Automatic injected conversion can be enabled if injected group         */
+    /* external triggers are disabled.                                        */
+    if (sConfigInjected->AutoInjectedConv == ENABLE)
+    {
+      if (sConfigInjected->ExternalTrigInjecConv == ADC_INJECTED_SOFTWARE_START)
+      {
+        SET_BIT(hadc->Instance->CR1, ADC_CR1_JAUTO);
+      }
+      else
+      {
+        /* Update ADC state machine to error */
+        SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_CONFIG);
+        
+        tmp_hal_status = HAL_ERROR;
+      }
+    }
+    
+    /* Injected discontinuous can be enabled only if auto-injected mode is    */
+    /* disabled.                                                              */  
+    if (sConfigInjected->InjectedDiscontinuousConvMode == ENABLE)
+    {
+      if (sConfigInjected->AutoInjectedConv == DISABLE)
+      {
+        SET_BIT(hadc->Instance->CR1, ADC_CR1_JDISCEN);
+      } 
+      else
+      {
+        /* Update ADC state machine to error */
+        SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_CONFIG);
+        
+        tmp_hal_status = HAL_ERROR;
+      }
+    }
+
+
+  /* InjectedChannel sampling time configuration */
+  /* For channels 10 to 18 */
+  if (sConfigInjected->InjectedChannel > ADC_CHANNEL_10)
+  {
+    MODIFY_REG(hadc->Instance->SMPR1,
+               ADC_SMPR1(ADC_SMPR1_SMP10, sConfigInjected->InjectedChannel),
+               ADC_SMPR1(sConfigInjected->InjectedSamplingTime, sConfigInjected->InjectedChannel) );
+  }
+  else /* For channels 1 to 9 */
+  {
+    MODIFY_REG(hadc->Instance->SMPR2,
+               ADC_SMPR2(ADC_SMPR2_SMP0, sConfigInjected->InjectedChannel),
+               ADC_SMPR2(sConfigInjected->InjectedSamplingTime, sConfigInjected->InjectedChannel) );
+  }
+  
+  
+  /* Configure the offset: offset enable/disable, InjectedChannel, offset value */
+  switch(sConfigInjected->InjectedRank)
+  {
+    case 1:
+      /* Set injected channel 1 offset */
+      MODIFY_REG(hadc->Instance->JOFR1,
+                 ADC_JOFR1_JOFFSET1,
+                 sConfigInjected->InjectedOffset);
+      break;
+    case 2:
+      /* Set injected channel 2 offset */
+      MODIFY_REG(hadc->Instance->JOFR2,
+                 ADC_JOFR2_JOFFSET2,
+                 sConfigInjected->InjectedOffset);
+      break;
+    case 3:
+      /* Set injected channel 3 offset */
+      MODIFY_REG(hadc->Instance->JOFR3,
+                 ADC_JOFR3_JOFFSET3,
+                 sConfigInjected->InjectedOffset);
+      break;
+    case 4:
+    default:
+      MODIFY_REG(hadc->Instance->JOFR4,
+                 ADC_JOFR4_JOFFSET4,
+                 sConfigInjected->InjectedOffset);
+      break;
+  }
+  
+  /* If ADC1 Channel_16 or Channel_17 is selected, enable Temperature sensor  */
+  /* and VREFINT measurement path.                                            */
+  if ((sConfigInjected->InjectedChannel == ADC_CHANNEL_TEMPSENSOR) ||
+      (sConfigInjected->InjectedChannel == ADC_CHANNEL_VREFINT)      )
+  {
+    if (READ_BIT(hadc->Instance->CR2, ADC_CR2_TSVREFE) == RESET)
+    {
+      SET_BIT(hadc->Instance->CR2, ADC_CR2_TSVREFE);
+      
+      if ((sConfigInjected->InjectedChannel == ADC_CHANNEL_TEMPSENSOR))
+      {
+        /* Delay for temperature sensor stabilization time */
+        /* Compute number of CPU cycles to wait for */
+        wait_loop_index = (ADC_TEMPSENSOR_DELAY_US * (SystemCoreClock / 1000000U));
+        while(wait_loop_index != 0U)
+        {
+          wait_loop_index--;
+        }
+      }
+    }
+  }
+  /* if ADC1 Channel_18 is selected, enable VBAT measurement path */
+  else if (sConfigInjected->InjectedChannel == ADC_CHANNEL_VBAT)
+  {
+    SET_BIT(SYSCFG->CFGR1, SYSCFG_CFGR1_VBAT);
+  }
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+  
+  /* Return function status */
+  return tmp_hal_status;
+}
+#endif /* STM32F373xC || STM32F378xx */
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+/**
+  * @brief  Configures the analog watchdog.
+  * @note   Possibility to update parameters on the fly:
+  *         This function initializes the selected analog watchdog, following  
+  *         calls to this function can be used to reconfigure some parameters 
+  *         of structure "ADC_AnalogWDGConfTypeDef" on the fly, without reseting 
+  *         the ADC.
+  *         The setting of these parameters is conditioned to ADC state.
+  *         For parameters constraints, see comments of structure 
+  *         "ADC_AnalogWDGConfTypeDef".
+  * @param  hadc ADC handle
+  * @param  AnalogWDGConfig Structure of ADC analog watchdog configuration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADC_AnalogWDGConfig(ADC_HandleTypeDef* hadc, ADC_AnalogWDGConfTypeDef* AnalogWDGConfig)
+{
+  HAL_StatusTypeDef tmp_hal_status = HAL_OK;
+  
+  uint32_t tmpAWDHighThresholdShifted;
+  uint32_t tmpAWDLowThresholdShifted;
+  
+  uint32_t tmpADCFlagAWD2orAWD3;
+  uint32_t tmpADCITAWD2orAWD3;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  assert_param(IS_ADC_ANALOG_WATCHDOG_NUMBER(AnalogWDGConfig->WatchdogNumber));
+  assert_param(IS_ADC_ANALOG_WATCHDOG_MODE(AnalogWDGConfig->WatchdogMode));
+  assert_param(IS_FUNCTIONAL_STATE(AnalogWDGConfig->ITMode));
+
+  /* Verify if threshold is within the selected ADC resolution */
+  assert_param(IS_ADC_RANGE(ADC_GET_RESOLUTION(hadc), AnalogWDGConfig->HighThreshold));
+  assert_param(IS_ADC_RANGE(ADC_GET_RESOLUTION(hadc), AnalogWDGConfig->LowThreshold));
+
+  if((AnalogWDGConfig->WatchdogMode == ADC_ANALOGWATCHDOG_SINGLE_REG)     ||
+     (AnalogWDGConfig->WatchdogMode == ADC_ANALOGWATCHDOG_SINGLE_INJEC)   ||
+     (AnalogWDGConfig->WatchdogMode == ADC_ANALOGWATCHDOG_SINGLE_REGINJEC)  )
+  {
+    assert_param(IS_ADC_CHANNEL(AnalogWDGConfig->Channel));
+  }
+  
+  /* Process locked */
+  __HAL_LOCK(hadc);
+  
+  /* Parameters update conditioned to ADC state:                              */
+  /* Parameters that can be updated when ADC is disabled or enabled without   */
+  /* conversion on going on regular and injected groups:                      */
+  /*  - Analog watchdog channels                                              */
+  /*  - Analog watchdog thresholds                                            */
+  if (ADC_IS_CONVERSION_ONGOING_REGULAR_INJECTED(hadc) == RESET)
+  {
+  
+    /* Analog watchdogs configuration */
+    if(AnalogWDGConfig->WatchdogNumber == ADC_ANALOGWATCHDOG_1)
+    {
+      /* Configuration of analog watchdog:                                    */
+      /*  - Set the analog watchdog enable mode: regular and/or injected      */
+      /*    groups, one or overall group of channels.                         */
+      /*  - Set the Analog watchdog channel (is not used if watchdog          */
+      /*    mode "all channels": ADC_CFGR_AWD1SGL=0U).                         */
+      MODIFY_REG(hadc->Instance->CFGR                             ,
+                 ADC_CFGR_AWD1SGL |
+                 ADC_CFGR_JAWD1EN |
+                 ADC_CFGR_AWD1EN  |
+                 ADC_CFGR_AWD1CH                                  ,
+                 AnalogWDGConfig->WatchdogMode                   |
+                 ADC_CFGR_AWD1CH_SHIFT(AnalogWDGConfig->Channel)   );
+
+      /* Shift the offset in function of the selected ADC resolution:         */
+      /* Thresholds have to be left-aligned on bit 11U, the LSB (right bits)   */
+      /* are set to 0                                                         */ 
+      tmpAWDHighThresholdShifted = ADC_AWD1THRESHOLD_SHIFT_RESOLUTION(hadc, AnalogWDGConfig->HighThreshold);
+      tmpAWDLowThresholdShifted  = ADC_AWD1THRESHOLD_SHIFT_RESOLUTION(hadc, AnalogWDGConfig->LowThreshold);
+      
+      /* Set the high and low thresholds */
+      MODIFY_REG(hadc->Instance->TR1                                ,
+                 ADC_TR1_HT1 |
+                 ADC_TR1_LT1                                        ,
+                 ADC_TRX_HIGHTHRESHOLD(tmpAWDHighThresholdShifted) |
+                 tmpAWDLowThresholdShifted                           );
+      
+      /* Clear the ADC Analog watchdog flag (in case of left enabled by       */
+      /* previous ADC operations) to be ready to use for HAL_ADC_IRQHandler() */
+      /* or HAL_ADC_PollForEvent().                                           */
+      __HAL_ADC_CLEAR_FLAG(hadc, ADC_IT_AWD1);
+      
+      /* Configure ADC Analog watchdog interrupt */
+      if(AnalogWDGConfig->ITMode == ENABLE)
+      {
+        /* Enable the ADC Analog watchdog interrupt */
+        __HAL_ADC_ENABLE_IT(hadc, ADC_IT_AWD1);
+      }
+      else
+      {
+        /* Disable the ADC Analog watchdog interrupt */
+        __HAL_ADC_DISABLE_IT(hadc, ADC_IT_AWD1);
+      }
+      
+    }
+    /* Case of ADC_ANALOGWATCHDOG_2 and ADC_ANALOGWATCHDOG_3 */
+    else
+    {
+    /* Shift the threshold in function of the selected ADC resolution */
+    /* have to be left-aligned on bit 7U, the LSB (right bits) are set to 0    */
+      tmpAWDHighThresholdShifted = ADC_AWD23THRESHOLD_SHIFT_RESOLUTION(hadc, AnalogWDGConfig->HighThreshold);
+      tmpAWDLowThresholdShifted  = ADC_AWD23THRESHOLD_SHIFT_RESOLUTION(hadc, AnalogWDGConfig->LowThreshold);
+
+      if (AnalogWDGConfig->WatchdogNumber == ADC_ANALOGWATCHDOG_2)
+      {
+        /* Set the Analog watchdog channel or group of channels. This also    */
+        /* enables the watchdog.                                              */
+        /* Note: Conditional register reset, because several channels can be  */
+        /*       set by successive calls of this function.                    */
+        if (AnalogWDGConfig->WatchdogMode != ADC_ANALOGWATCHDOG_NONE) 
+        {
+          /* Set the high and low thresholds */
+          MODIFY_REG(hadc->Instance->TR2                                ,
+                     ADC_TR2_HT2 |
+                     ADC_TR2_LT2                                        ,
+                     ADC_TRX_HIGHTHRESHOLD(tmpAWDHighThresholdShifted) |
+                     tmpAWDLowThresholdShifted                           );
+          
+          SET_BIT(hadc->Instance->AWD2CR, ADC_CFGR_AWD23CR(AnalogWDGConfig->Channel));
+        }
+        else
+        {
+          CLEAR_BIT(hadc->Instance->TR2, ADC_TR2_HT2 | ADC_TR2_LT2);
+          CLEAR_BIT(hadc->Instance->AWD2CR, ADC_AWD2CR_AWD2CH);
+        }
+                
+        /* Set temporary variable to flag and IT of AWD2 or AWD3 for further  */
+        /* settings.                                                          */
+        tmpADCFlagAWD2orAWD3 = ADC_FLAG_AWD2;
+        tmpADCITAWD2orAWD3 = ADC_IT_AWD2;
+      }
+      /* (AnalogWDGConfig->WatchdogNumber == ADC_ANALOGWATCHDOG_3) */
+      else
+      {
+        /* Set the Analog watchdog channel or group of channels. This also    */
+        /* enables the watchdog.                                              */
+        /* Note: Conditionnal register reset, because several channels can be */
+        /*       set by successive calls of this function.                    */
+        if (AnalogWDGConfig->WatchdogMode != ADC_ANALOGWATCHDOG_NONE) 
+        {
+          /* Set the high and low thresholds */
+          MODIFY_REG(hadc->Instance->TR3                                ,
+                     ADC_TR3_HT3 |
+                     ADC_TR3_LT3                                        ,
+                     ADC_TRX_HIGHTHRESHOLD(tmpAWDHighThresholdShifted) |
+                     tmpAWDLowThresholdShifted                           );
+          
+          SET_BIT(hadc->Instance->AWD3CR, ADC_CFGR_AWD23CR(AnalogWDGConfig->Channel));
+        }
+        else
+        {
+          CLEAR_BIT(hadc->Instance->TR3, ADC_TR3_HT3 | ADC_TR3_LT3);
+          CLEAR_BIT(hadc->Instance->AWD3CR, ADC_AWD3CR_AWD3CH);
+        }
+        
+        /* Set temporary variable to flag and IT of AWD2 or AWD3 for further  */
+        /* settings.                                                          */
+        tmpADCFlagAWD2orAWD3 = ADC_FLAG_AWD3;
+        tmpADCITAWD2orAWD3 = ADC_IT_AWD3;
+      }
+
+      /* Clear the ADC Analog watchdog flag (in case of left enabled by       */
+      /* previous ADC operations) to be ready to use for HAL_ADC_IRQHandler() */
+      /* or HAL_ADC_PollForEvent().                                           */
+      __HAL_ADC_CLEAR_FLAG(hadc, tmpADCFlagAWD2orAWD3);
+
+      /* Configure ADC Analog watchdog interrupt */
+      if(AnalogWDGConfig->ITMode == ENABLE)
+      {
+        __HAL_ADC_ENABLE_IT(hadc, tmpADCITAWD2orAWD3);
+      }
+      else
+      {
+        __HAL_ADC_DISABLE_IT(hadc, tmpADCITAWD2orAWD3);
+      }
+    }
+  
+  }
+  /* If a conversion is on going on regular or injected groups, no update     */
+  /* could be done on neither of the AWD configuration structure parameters.  */
+  else
+  {
+    /* Update ADC state machine to error */
+    SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_CONFIG);
+    
+    tmp_hal_status = HAL_ERROR;
+  }
+  
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+  
+  /* Return function status */
+  return tmp_hal_status;
+}
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+
+#if defined(STM32F373xC) || defined(STM32F378xx)
+/**
+  * @brief  Configures the analog watchdog.
+  * @note   Analog watchdog thresholds can be modified while ADC conversion
+  *         is on going.
+  *         In this case, some constraints must be taken into account:
+  *         the programmed threshold values are effective from the next
+  *         ADC EOC (end of unitary conversion).
+  *         Considering that registers write delay may happen due to
+  *         bus activity, this might cause an uncertainty on the
+  *         effective timing of the new programmed threshold values.
+  * @param  hadc ADC handle
+  * @param  AnalogWDGConfig Structure of ADC analog watchdog configuration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADC_AnalogWDGConfig(ADC_HandleTypeDef* hadc, ADC_AnalogWDGConfTypeDef* AnalogWDGConfig)
+{
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  assert_param(IS_ADC_ANALOG_WATCHDOG_MODE(AnalogWDGConfig->WatchdogMode));
+  assert_param(IS_FUNCTIONAL_STATE(AnalogWDGConfig->ITMode));
+  assert_param(IS_ADC_RANGE(AnalogWDGConfig->HighThreshold));
+  assert_param(IS_ADC_RANGE(AnalogWDGConfig->LowThreshold));
+  
+  if((AnalogWDGConfig->WatchdogMode == ADC_ANALOGWATCHDOG_SINGLE_REG)     ||
+     (AnalogWDGConfig->WatchdogMode == ADC_ANALOGWATCHDOG_SINGLE_INJEC)   ||
+     (AnalogWDGConfig->WatchdogMode == ADC_ANALOGWATCHDOG_SINGLE_REGINJEC)  )
+  {
+    assert_param(IS_ADC_CHANNEL(AnalogWDGConfig->Channel));
+  }
+  
+  /* Process locked */
+  __HAL_LOCK(hadc);
+  
+  /* Analog watchdog configuration */
+
+  /* Configure ADC Analog watchdog interrupt */
+  if(AnalogWDGConfig->ITMode == ENABLE)
+  {
+    /* Enable the ADC Analog watchdog interrupt */
+    __HAL_ADC_ENABLE_IT(hadc, ADC_IT_AWD);
+  }
+  else
+  {
+    /* Disable the ADC Analog watchdog interrupt */
+    __HAL_ADC_DISABLE_IT(hadc, ADC_IT_AWD);
+  }
+  
+  /* Configuration of analog watchdog:                                        */
+  /*  - Set the analog watchdog enable mode: regular and/or injected groups,  */
+  /*    one or all channels.                                                  */
+  /*  - Set the Analog watchdog channel (is not used if watchdog              */
+  /*    mode "all channels": ADC_CFGR_AWD1SGL=0U).                             */
+  MODIFY_REG(hadc->Instance->CR1            ,
+             ADC_CR1_AWDSGL |
+             ADC_CR1_JAWDEN |
+             ADC_CR1_AWDEN  |
+             ADC_CR1_AWDCH                  ,
+             AnalogWDGConfig->WatchdogMode |
+             AnalogWDGConfig->Channel       );
+  
+  /* Set the high threshold */
+  WRITE_REG(hadc->Instance->HTR, AnalogWDGConfig->HighThreshold);
+  
+  /* Set the low threshold */
+  WRITE_REG(hadc->Instance->LTR, AnalogWDGConfig->LowThreshold);
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+  
+  /* Return function status */
+  return HAL_OK;
+}
+#endif /* STM32F373xC || STM32F378xx */
+
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
+/**
+  * @brief  Enable ADC multimode and configure multimode parameters
+  * @note   Possibility to update parameters on the fly:
+  *         This function initializes multimode parameters, following  
+  *         calls to this function can be used to reconfigure some parameters 
+  *         of structure "ADC_MultiModeTypeDef" on the fly, without reseting 
+  *         the ADCs (both ADCs of the common group).
+  *         The setting of these parameters is conditioned to ADC state.
+  *         For parameters constraints, see comments of structure 
+  *         "ADC_MultiModeTypeDef".
+  * @note   To change back configuration from multimode to single mode, ADC must
+  *         be reset (using function HAL_ADC_Init() ).
+  * @param  hadc ADC handle
+  * @param  multimode Structure of ADC multimode configuration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADCEx_MultiModeConfigChannel(ADC_HandleTypeDef* hadc, ADC_MultiModeTypeDef* multimode)
+{
+  HAL_StatusTypeDef tmp_hal_status = HAL_OK;
+  ADC_Common_TypeDef *tmpADC_Common;
+  ADC_HandleTypeDef tmphadcSharingSameCommonRegister;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_MULTIMODE_MASTER_INSTANCE(hadc->Instance));
+  assert_param(IS_ADC_MODE(multimode->Mode));
+  if(multimode->Mode != ADC_MODE_INDEPENDENT)
+  {
+    assert_param(IS_ADC_DMA_ACCESS_MODE(multimode->DMAAccessMode));
+    assert_param(IS_ADC_SAMPLING_DELAY(multimode->TwoSamplingDelay));
+  }
+  
+  /* Set handle of the other ADC sharing the same common register             */
+  ADC_COMMON_ADC_OTHER(hadc, &tmphadcSharingSameCommonRegister);
+  if (tmphadcSharingSameCommonRegister.Instance == NULL)
+  {
+    /* Return function status */
+    return HAL_ERROR;
+  }
+
+  /* Process locked */
+  __HAL_LOCK(hadc);
+  
+  /* Parameters update conditioned to ADC state:                              */
+  /* Parameters that can be updated when ADC is disabled or enabled without   */
+  /* conversion on going on regular group:                                    */
+  /*  - Multimode DMA configuration                                           */
+  /*  - Multimode DMA mode                                                    */
+  if ( (ADC_IS_CONVERSION_ONGOING_REGULAR(hadc) == RESET) 
+    && (ADC_IS_CONVERSION_ONGOING_REGULAR(&tmphadcSharingSameCommonRegister) == RESET) )
+  {
+    /* Pointer to the common control register to which is belonging hadc      */
+    /* (Depending on STM32F3 product, there may have up to 4 ADC and 2 common */
+    /* control registers)                                                     */
+    tmpADC_Common = ADC_COMMON_REGISTER(hadc);
+    
+    /* If multimode is selected, configure all multimode paramaters.          */
+    /* Otherwise, reset multimode parameters (can be used in case of          */
+    /* transition from multimode to independent mode).                        */
+    if(multimode->Mode != ADC_MODE_INDEPENDENT)
+    {
+      /* Configuration of ADC common group ADC1&ADC2, ADC3&ADC4 if available    */
+      /* (ADC2, ADC3, ADC4 availability depends on STM32 product)               */
+      /*  - DMA access mode                                                     */
+      MODIFY_REG(tmpADC_Common->CCR                                          ,
+                 ADC_CCR_MDMA  |
+                 ADC_CCR_DMACFG                                              ,
+                 multimode->DMAAccessMode                                   |
+                 ADC_CCR_MULTI_DMACONTREQ((uint32_t)hadc->Init.DMAContinuousRequests)   );
+      
+      /* Parameters that can be updated only when ADC is disabled:              */
+      /*  - Multimode mode selection                                            */
+      /*  - Set delay between two sampling phases                               */
+      /*    Note: Delay range depends on selected resolution:                   */
+      /*      from 1 to 12 clock cycles for 12 bits                             */
+      /*      from 1 to 10 clock cycles for 10 bits,                            */
+      /*      from 1 to 8 clock cycles for 8 bits                               */
+      /*      from 1 to 6 clock cycles for 6 bits                               */
+      /*    If a higher delay is selected, it will be clamped to maximum delay  */
+      /*    range                                                               */
+      /* Note: If ADC is not in the appropriate state to modify these           */
+      /*       parameters, their setting is bypassed without error reporting    */
+      /*       (as it can be the expected behaviour in case of intended action  */
+      /*       to update parameter above (which fulfills the ADC state          */
+      /*       condition: no conversion on going on group regular)              */
+      /*       on the fly).                                                     */
+      if ((ADC_IS_ENABLE(hadc) == RESET)                              &&
+          (ADC_IS_ENABLE(&tmphadcSharingSameCommonRegister) == RESET)   )
+      {
+        MODIFY_REG(tmpADC_Common->CCR                                          ,
+                   ADC_CCR_MULTI |
+                   ADC_CCR_DELAY                                               ,
+                   multimode->Mode                                            |
+                   multimode->TwoSamplingDelay                                  );
+      }
+    }
+    else /* ADC_MODE_INDEPENDENT */
+    {
+      CLEAR_BIT(tmpADC_Common->CCR, ADC_CCR_MDMA | ADC_CCR_DMACFG);
+      
+      /* Parameters that can be updated only when ADC is disabled:                */
+      /*  - Multimode mode selection                                              */
+      /*  - Multimode delay                                                       */
+      if ((ADC_IS_ENABLE(hadc) == RESET)                              &&
+          (ADC_IS_ENABLE(&tmphadcSharingSameCommonRegister) == RESET)   )
+      {
+        CLEAR_BIT(tmpADC_Common->CCR, ADC_CCR_MULTI | ADC_CCR_DELAY);
+      }
+    }
+  }
+  /* If one of the ADC sharing the same common group is enabled, no update    */
+  /* could be done on neither of the multimode structure parameters.          */
+  else
+  {
+    /* Update ADC state machine to error */
+    SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_CONFIG);
+    
+    tmp_hal_status = HAL_ERROR;
+  }
+    
+    
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+  
+  /* Return function status */
+  return tmp_hal_status;
+} 
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F328xx || STM32F334x8    */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+  
+/** @defgroup ADCEx_Private_Functions ADCEx Private Functions
+  * @{
+  */
+/**
+  * @brief  DMA transfer complete callback. 
+  * @param  hdma pointer to DMA handle.
+  * @retval None
+  */
+static void ADC_DMAConvCplt(DMA_HandleTypeDef *hdma)
+{
+  /* Retrieve ADC handle corresponding to current DMA handle */
+  ADC_HandleTypeDef* hadc = ( ADC_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+ 
+  /* Update state machine on conversion status if not in error state */
+  if (HAL_IS_BIT_CLR(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL | HAL_ADC_STATE_ERROR_DMA))
+  {
+    /* Update ADC state machine */
+    SET_BIT(hadc->State, HAL_ADC_STATE_REG_EOC);
+    
+    /* Determine whether any further conversion upcoming on group regular     */
+    /* by external trigger, continuous mode or scan sequence on going.        */
+    /* Note: On STM32F3 devices, in case of sequencer enabled                 */
+    /*       (several ranks selected), end of conversion flag is raised       */
+    /*       at the end of the sequence.                                      */
+    if(ADC_IS_SOFTWARE_START_REGULAR(hadc)        && 
+       (hadc->Init.ContinuousConvMode == DISABLE)   )
+    {
+      /* Set ADC state */
+      CLEAR_BIT(hadc->State, HAL_ADC_STATE_REG_BUSY);   
+      
+      if (HAL_IS_BIT_CLR(hadc->State, HAL_ADC_STATE_INJ_BUSY))
+      {
+        SET_BIT(hadc->State, HAL_ADC_STATE_READY);
+      }
+    }
+    
+    /* Conversion complete callback */
+#if (USE_HAL_ADC_REGISTER_CALLBACKS == 1)
+      hadc->ConvCpltCallback(hadc);
+#else
+      HAL_ADC_ConvCpltCallback(hadc);
+#endif /* USE_HAL_ADC_REGISTER_CALLBACKS */
+  }
+  else
+  {
+    /* Call DMA error callback */
+    hadc->DMA_Handle->XferErrorCallback(hdma);
+  }
+}
+
+/**
+  * @brief  DMA half transfer complete callback. 
+  * @param  hdma pointer to DMA handle.
+  * @retval None
+  */
+static void ADC_DMAHalfConvCplt(DMA_HandleTypeDef *hdma)   
+{
+  /* Retrieve ADC handle corresponding to current DMA handle */
+  ADC_HandleTypeDef* hadc = ( ADC_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+  
+  /* Half conversion callback */
+#if (USE_HAL_ADC_REGISTER_CALLBACKS == 1)
+    hadc->ConvHalfCpltCallback(hadc);
+#else
+  HAL_ADC_ConvHalfCpltCallback(hadc);
+#endif /* USE_HAL_ADC_REGISTER_CALLBACKS */ 
+}
+
+/**
+  * @brief  DMA error callback 
+  * @param  hdma pointer to DMA handle.
+  * @retval None
+  */
+static void ADC_DMAError(DMA_HandleTypeDef *hdma)   
+{
+  /* Retrieve ADC handle corresponding to current DMA handle */
+  ADC_HandleTypeDef* hadc = ( ADC_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+  
+  /* Set ADC state */
+  SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_DMA);
+  
+  /* Set ADC error code to DMA error */
+  SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_DMA);
+  
+  /* Error callback */
+#if (USE_HAL_ADC_REGISTER_CALLBACKS == 1)
+      hadc->ErrorCallback(hadc);
+#else
+      HAL_ADC_ErrorCallback(hadc);
+#endif /* USE_HAL_ADC_REGISTER_CALLBACKS */
+}
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+/**
+  * @brief  Enable the selected ADC.
+  * @note   Prerequisite condition to use this function: ADC must be disabled
+  *         and voltage regulator must be enabled (done into HAL_ADC_Init()).
+  * @param  hadc ADC handle
+  * @retval HAL status.
+  */
+static HAL_StatusTypeDef ADC_Enable(ADC_HandleTypeDef* hadc)
+{
+  uint32_t tickstart = 0U;
+  
+  /* ADC enable and wait for ADC ready (in case of ADC is disabled or         */
+  /* enabling phase not yet completed: flag ADC ready not yet set).           */
+  /* Timeout implemented to not be stuck if ADC cannot be enabled (possible   */
+  /* causes: ADC clock not running, ...).                                     */
+  if (ADC_IS_ENABLE(hadc) == RESET)
+  {
+    /* Check if conditions to enable the ADC are fulfilled */
+    if (ADC_ENABLING_CONDITIONS(hadc) == RESET)
+    {
+      /* Update ADC state machine to error */
+      SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL);
+      
+      /* Set ADC error code to ADC IP internal error */
+      SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_INTERNAL);
+      
+      return HAL_ERROR;
+    }
+    
+    /* Enable the ADC peripheral */
+    __HAL_ADC_ENABLE(hadc);
+    
+    /* Wait for ADC effectively enabled */
+    tickstart = HAL_GetTick();  
+    
+    while(__HAL_ADC_GET_FLAG(hadc, ADC_FLAG_RDY) == RESET)
+    {
+      if((HAL_GetTick() - tickstart) > ADC_ENABLE_TIMEOUT)
+      {
+        /* Update ADC state machine to error */
+        SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL);
+        
+        /* Set ADC error code to ADC IP internal error */
+        SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_INTERNAL);
+      
+        return HAL_ERROR;
+      }
+    }
+  }
+  
+  /* Return HAL status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Disable the selected ADC.
+  * @note   Prerequisite condition to use this function: ADC conversions must be
+  *         stopped.
+  * @param  hadc ADC handle
+  * @retval HAL status.
+  */
+static HAL_StatusTypeDef ADC_Disable(ADC_HandleTypeDef* hadc)
+{
+  uint32_t tickstart = 0U;
+  
+  /* Verification if ADC is not already disabled:                             */
+  /* Note: forbidden to disable ADC (set bit ADC_CR_ADDIS) if ADC is already  */
+  /* disabled.                                                                */
+  if (ADC_IS_ENABLE(hadc) != RESET )
+  {
+    /* Check if conditions to disable the ADC are fulfilled */
+    if (ADC_DISABLING_CONDITIONS(hadc) != RESET)
+    {
+      /* Disable the ADC peripheral */
+      __HAL_ADC_DISABLE(hadc);
+    }
+    else
+    {
+      /* Update ADC state machine to error */
+      SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL);
+      
+      /* Set ADC error code to ADC IP internal error */
+      SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_INTERNAL);
+      
+      return HAL_ERROR;
+    }
+     
+    /* Wait for ADC effectively disabled */
+    tickstart = HAL_GetTick();
+    
+    while(HAL_IS_BIT_SET(hadc->Instance->CR, ADC_CR_ADEN))
+    {
+      if((HAL_GetTick() - tickstart) > ADC_DISABLE_TIMEOUT)
+      {
+        /* Update ADC state machine to error */
+        SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL);
+        
+        /* Set ADC error code to ADC IP internal error */
+        SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_INTERNAL);
+        
+        return HAL_ERROR;
+      }
+    }
+  }
+  
+  /* Return HAL status */
+  return HAL_OK;
+}
+
+
+/**
+  * @brief  Stop ADC conversion.
+  * @param  hadc ADC handle
+  * @param  ConversionGroup ADC group regular and/or injected.
+  *          This parameter can be one of the following values:
+  *            @arg ADC_REGULAR_GROUP: ADC regular conversion type.
+  *            @arg ADC_INJECTED_GROUP: ADC injected conversion type.
+  *            @arg ADC_REGULAR_INJECTED_GROUP: ADC regular and injected conversion type.
+  * @retval HAL status.
+  */
+static HAL_StatusTypeDef ADC_ConversionStop(ADC_HandleTypeDef* hadc, uint32_t ConversionGroup)
+{
+  uint32_t tmp_ADC_CR_ADSTART_JADSTART = 0U;
+  uint32_t tickstart = 0U;
+  uint32_t Conversion_Timeout_CPU_cycles = 0U;
+
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  assert_param(IS_ADC_CONVERSION_GROUP(ConversionGroup));
+    
+  /* Verification if ADC is not already stopped (on regular and injected      */
+  /* groups) to bypass this function if not needed.                           */
+  if (ADC_IS_CONVERSION_ONGOING_REGULAR_INJECTED(hadc))
+  {
+    /* Particular case of continuous auto-injection mode combined with        */
+    /* auto-delay mode.                                                       */
+    /* In auto-injection mode, regular group stop ADC_CR_ADSTP is used (not   */
+    /* injected group stop ADC_CR_JADSTP).                                    */
+    /* Procedure to be followed: Wait until JEOS=1U, clear JEOS, set ADSTP=1   */
+    /* (see reference manual).                                                */
+    if ((HAL_IS_BIT_SET(hadc->Instance->CFGR, ADC_CFGR_JAUTO)) &&
+         (hadc->Init.ContinuousConvMode==ENABLE)               &&
+         (hadc->Init.LowPowerAutoWait==ENABLE)                   )
+    {
+      /* Use stop of regular group */
+      ConversionGroup = ADC_REGULAR_GROUP;
+      
+      /* Wait until JEOS=1 (maximum Timeout: 4 injected conversions) */
+      while(__HAL_ADC_GET_FLAG(hadc, ADC_FLAG_JEOS) == RESET)
+      {
+        if (Conversion_Timeout_CPU_cycles >= (ADC_CONVERSION_TIME_MAX_CPU_CYCLES *4U))
+        {
+          /* Update ADC state machine to error */
+          SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL);
+          
+          /* Set ADC error code to ADC IP internal error */
+          SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_INTERNAL);
+          
+          return HAL_ERROR;
+        }
+        Conversion_Timeout_CPU_cycles ++;
+      }
+
+      /* Clear JEOS */
+      __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_JEOS);
+    }
+    
+    /* Stop potential conversion on going on regular group */
+    if (ConversionGroup != ADC_INJECTED_GROUP)
+    {
+      /* Software is allowed to set ADSTP only when ADSTART=1 and ADDIS=0U */
+      if (HAL_IS_BIT_SET(hadc->Instance->CR, ADC_CR_ADSTART) && 
+          HAL_IS_BIT_CLR(hadc->Instance->CR, ADC_CR_ADDIS)     )
+      {
+        /* Stop conversions on regular group */
+        hadc->Instance->CR |= ADC_CR_ADSTP;
+      }
+    }
+
+    /* Stop potential conversion on going on injected group */
+    if (ConversionGroup != ADC_REGULAR_GROUP)
+    {
+      /* Software is allowed to set JADSTP only when JADSTART=1 and ADDIS=0U */
+      if (HAL_IS_BIT_SET(hadc->Instance->CR, ADC_CR_JADSTART) && 
+          HAL_IS_BIT_CLR(hadc->Instance->CR, ADC_CR_ADDIS)      )
+      {
+        /* Stop conversions on injected group */
+        hadc->Instance->CR |= ADC_CR_JADSTP;
+      }
+    }
+
+    /* Selection of start and stop bits in function of regular or injected group */
+    switch(ConversionGroup)
+    {
+    case ADC_REGULAR_INJECTED_GROUP:
+        tmp_ADC_CR_ADSTART_JADSTART = (ADC_CR_ADSTART | ADC_CR_JADSTART);
+        break;
+    case ADC_INJECTED_GROUP:
+        tmp_ADC_CR_ADSTART_JADSTART = ADC_CR_JADSTART;
+        break;
+    /* Case ADC_REGULAR_GROUP */
+    default:
+        tmp_ADC_CR_ADSTART_JADSTART = ADC_CR_ADSTART;
+        break;
+    }
+    
+    /* Wait for conversion effectively stopped */
+    tickstart = HAL_GetTick();
+      
+    while((hadc->Instance->CR & tmp_ADC_CR_ADSTART_JADSTART) != RESET)
+    {
+      if((HAL_GetTick() - tickstart) > ADC_STOP_CONVERSION_TIMEOUT)
+      {
+        /* Update ADC state machine to error */
+        SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL);
+        
+        /* Set ADC error code to ADC IP internal error */
+        SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_INTERNAL);
+        
+        return HAL_ERROR;
+      }
+    }
+    
+  }
+   
+  /* Return HAL status */
+  return HAL_OK;
+}
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+
+#if defined(STM32F373xC) || defined(STM32F378xx)
+/**
+  * @brief  Enable the selected ADC.
+  * @note   Prerequisite condition to use this function: ADC must be disabled
+  *         and voltage regulator must be enabled (done into HAL_ADC_Init()).
+  * @param  hadc ADC handle
+  * @retval HAL status.
+  */
+static HAL_StatusTypeDef ADC_Enable(ADC_HandleTypeDef* hadc)
+{
+  uint32_t tickstart = 0U;
+  __IO uint32_t wait_loop_index = 0U;
+  
+  /* ADC enable and wait for ADC ready (in case of ADC is disabled or         */
+  /* enabling phase not yet completed: flag ADC ready not yet set).           */
+  /* Timeout implemented to not be stuck if ADC cannot be enabled (possible   */
+  /* causes: ADC clock not running, ...).                                     */
+  if (ADC_IS_ENABLE(hadc) == RESET)
+  {
+    /* Enable the Peripheral */
+    __HAL_ADC_ENABLE(hadc);
+    
+    /* Delay for ADC stabilization time */
+    /* Compute number of CPU cycles to wait for */
+    wait_loop_index = (ADC_STAB_DELAY_US * (SystemCoreClock / 1000000U));
+    while(wait_loop_index != 0U)
+    {
+      wait_loop_index--;
+    }
+    
+    /* Get tick count */
+    tickstart = HAL_GetTick();
+    
+    /* Wait for ADC effectively enabled */
+    while(ADC_IS_ENABLE(hadc) == RESET)
+    {
+      if((HAL_GetTick() - tickstart) > ADC_ENABLE_TIMEOUT)
+      {
+        /* Update ADC state machine to error */
+        SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL);
+        
+        /* Set ADC error code to ADC IP internal error */
+        SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_INTERNAL);
+        
+        /* Process unlocked */
+        __HAL_UNLOCK(hadc);
+      
+        return HAL_ERROR;
+      }
+    }
+  }
+   
+  /* Return HAL status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stop ADC conversion and disable the selected ADC
+  * @param  hadc ADC handle
+  * @retval HAL status.
+  */
+static HAL_StatusTypeDef ADC_ConversionStop_Disable(ADC_HandleTypeDef* hadc)
+{
+  uint32_t tickstart = 0U;
+  
+  /* Verification if ADC is not already disabled:                             */
+  if (ADC_IS_ENABLE(hadc) != RESET)
+  {
+    /* Disable the ADC peripheral */
+    __HAL_ADC_DISABLE(hadc);
+     
+    /* Get tick count */
+    tickstart = HAL_GetTick();
+    
+    /* Wait for ADC effectively disabled */
+    while(ADC_IS_ENABLE(hadc) != RESET)
+    {
+      if((HAL_GetTick() - tickstart) > ADC_DISABLE_TIMEOUT)
+      {
+        /* Update ADC state machine to error */
+        SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL);
+        
+        /* Set ADC error code to ADC IP internal error */
+        SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_INTERNAL);
+        
+        return HAL_ERROR;
+      }
+    }
+  }
+  
+  /* Return HAL status */
+  return HAL_OK;
+}
+#endif /* STM32F373xC || STM32F378xx */  
+/**
+  * @}
+  */
+  
+#endif /* HAL_ADC_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */ 
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Add all samples
+add_subdirectory(adc)
 add_subdirectory(blink)
 add_subdirectory(can)
 add_subdirectory(pwm)

--- a/samples/adc/CMakeLists.txt
+++ b/samples/adc/CMakeLists.txt
@@ -1,0 +1,29 @@
+# Add example code
+set(SAMPLE_NAME adc)
+
+project(${SAMPLE_NAME} C CXX ASM)
+
+add_definitions(-DUSE_HAL_LIBRARY)
+
+add_executable(${SAMPLE_NAME}
+    main.cpp
+)
+
+set_target_properties(${SAMPLE_NAME} PROPERTIES
+    OUTPUT_NAME "${SAMPLE_NAME}"
+    SUFFIX ".elf"
+)
+
+# Generate map
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} \
+                            -Wl,-Map=${SAMPLE_NAME}.map")
+
+set(HEX_FILE "${SAMPLE_NAME}.hex")
+set(BIN_FILE "${SAMPLE_NAME}.bin")
+add_custom_command(TARGET ${SAMPLE_NAME} POST_BUILD
+    COMMAND ${CMAKE_OBJCOPY} -Oihex $<TARGET_FILE:${SAMPLE_NAME}> ${HEX_FILE}
+    COMMAND ${CMAKE_OBJCOPY} -Obinary $<TARGET_FILE:${SAMPLE_NAME}> ${BIN_FILE}
+    COMMENT "Building ${HEX_FILE} \nBuilding ${BIN_FILE}")
+
+# Link the EVT library
+target_link_libraries(${SAMPLE_NAME} EVT)

--- a/samples/adc/main.cpp
+++ b/samples/adc/main.cpp
@@ -16,19 +16,21 @@ int main() {
 
     uart.printf("Starting ADC test\r\n");
 
+    time::wait(500);
+
     IO::ADC& adc0 = IO::getADC<IO::Pin::PA_0>();
-    IO::ADC& adc1 = IO::getADC<IO::Pin::PA_1>();
+    // IO::ADC& adc1 = IO::getADC<IO::Pin::PA_1>();
 
     while(1) {
         uart.printf("--------------------\r\n");
         uart.printf("ADC0 : %0.2fV\r\n", adc0.read());
         uart.printf("ADC0: %.2f%%\r\n", adc0.readPercentage());
         uart.printf("ADC0 raw: %d\r\n\r\n", adc0.readRaw());
-
+/*
         uart.printf("ADC1: %.2fV\r\n", adc1.read());
         uart.printf("ADC1: %.2f%%\r\n", adc1.readPercentage());
         uart.printf("ADC1 raw: %d\r\n", adc1.readRaw());
-
+*/
         uart.printf("--------------------\r\n\r\n");
         time::wait(500);
     }

--- a/samples/adc/main.cpp
+++ b/samples/adc/main.cpp
@@ -21,7 +21,7 @@ int main() {
     IO::ADC& adc0 = IO::getADC<IO::Pin::PA_0>();
     IO::ADC& adc1 = IO::getADC<IO::Pin::PA_1>();
 
-    while(1) {
+    while (1) {
         uart.printf("--------------------\r\n");
         uart.printf("ADC0 : %.2fV\r\n", adc0.read());
         uart.printf("ADC0: %.2f%%\r\n", adc0.readPercentage() * 100);
@@ -34,5 +34,4 @@ int main() {
         uart.printf("--------------------\r\n\r\n");
         time::wait(500);
     }
-
 }

--- a/samples/adc/main.cpp
+++ b/samples/adc/main.cpp
@@ -1,0 +1,36 @@
+/**
+ * This example shows off the use of the ADC. Two pins are setup for ADC
+ * functionality and the values are continuously read in and printed over
+ * UART.
+ */
+#include <EVT/io/ADC.hpp>
+#include <EVT/io/manager.hpp>
+#include <EVT/io/UART.hpp>
+#include <EVT/utils/time.hpp>
+
+namespace IO = EVT::core::IO;
+namespace time = EVT::core::time;
+
+int main() {
+    IO::UART& uart = IO::getUART<IO::Pin::UART_TX, IO::Pin::UART_RX>(9600);
+
+    uart.printf("Starting ADC test\r\n");
+
+    IO::ADC& adc0 = IO::getADC<IO::Pin::PA_0>();
+    IO::ADC& adc1 = IO::getADC<IO::Pin::PA_1>();
+
+    while(1) {
+        uart.printf("--------------------\r\n");
+        uart.printf("ADC0 : %0.2fV\r\n", adc0.read());
+        uart.printf("ADC0: %.2f%%\r\n", adc0.readPercentage());
+        uart.printf("ADC0 raw: %d\r\n\r\n", adc0.readRaw());
+
+        uart.printf("ADC1: %.2fV\r\n", adc1.read());
+        uart.printf("ADC1: %.2f%%\r\n", adc1.readPercentage());
+        uart.printf("ADC1 raw: %d\r\n", adc1.readRaw());
+
+        uart.printf("--------------------\r\n\r\n");
+        time::wait(500);
+    }
+
+}

--- a/samples/adc/main.cpp
+++ b/samples/adc/main.cpp
@@ -19,18 +19,18 @@ int main() {
     time::wait(500);
 
     IO::ADC& adc0 = IO::getADC<IO::Pin::PA_0>();
-    // IO::ADC& adc1 = IO::getADC<IO::Pin::PA_1>();
+    IO::ADC& adc1 = IO::getADC<IO::Pin::PA_1>();
 
     while(1) {
         uart.printf("--------------------\r\n");
-        uart.printf("ADC0 : %0.2fV\r\n", adc0.read());
-        uart.printf("ADC0: %.2f%%\r\n", adc0.readPercentage());
+        uart.printf("ADC0 : %.2fV\r\n", adc0.read());
+        uart.printf("ADC0: %.2f%%\r\n", adc0.readPercentage() * 100);
         uart.printf("ADC0 raw: %d\r\n\r\n", adc0.readRaw());
-/*
+
         uart.printf("ADC1: %.2fV\r\n", adc1.read());
         uart.printf("ADC1: %.2f%%\r\n", adc1.readPercentage());
         uart.printf("ADC1 raw: %d\r\n", adc1.readRaw());
-*/
+
         uart.printf("--------------------\r\n\r\n");
         time::wait(500);
     }

--- a/src/io/ADC.cpp
+++ b/src/io/ADC.cpp
@@ -1,0 +1,9 @@
+#include <EVT/io/ADC.hpp>
+
+namespace EVT::core::IO {
+
+ADC::ADC (Pin pin) {
+    this->pin = pin;
+}
+
+}  // namespace EVT::core::IO

--- a/src/io/ADC.cpp
+++ b/src/io/ADC.cpp
@@ -2,7 +2,7 @@
 
 namespace EVT::core::IO {
 
-ADC::ADC (Pin pin) {
+ADC::ADC(Pin pin) {
     this->pin = pin;
 }
 

--- a/src/io/platform/f3xx/f302x8/ADCf302x8.cpp
+++ b/src/io/platform/f3xx/f302x8/ADCf302x8.cpp
@@ -111,11 +111,11 @@ uint32_t ADCf302x8::readRaw() {
     uint8_t channelNum = 0;
     while(channels[channelNum] != pin)
         channelNum++;
-    return static_cast<float>(buffer[channelNum]);
+    return buffer[channelNum];
 }
 
 float ADCf302x8::readPercentage() {
-    uint32_t raw = readRaw();
+    float raw = static_cast<float>(readRaw());
     return static_cast<float>(raw / MAX_RAW);
 }
 

--- a/src/io/platform/f3xx/f302x8/ADCf302x8.cpp
+++ b/src/io/platform/f3xx/f302x8/ADCf302x8.cpp
@@ -56,7 +56,6 @@ static void lowLevelInit() {
     PeriphClkInit.Adc1ClockSelection = RCC_ADC1PLLCLK_DIV1;
 
     HAL_RCCEx_PeriphCLKConfig(&PeriphClkInit);
-
 }
 
 namespace EVT::core::IO {
@@ -69,7 +68,6 @@ DMA_HandleTypeDef ADCf302x8::halDMA = {0};
 
 
 ADCf302x8::ADCf302x8(Pin pin) : ADC(pin) {
-
     // Flag representing if the ADC has been configured yet
     static bool halADCisInit = false;
     // "Rank" represents the order in which the channels are added
@@ -78,7 +76,6 @@ ADCf302x8::ADCf302x8(Pin pin) : ADC(pin) {
     // Initialization of the HAL ADC should only take place once since there is
     // only one ADC device which has muliple channels supported.
     if (!halADCisInit) {
-
         __HAL_RCC_DMA1_CLK_ENABLE();
 
         lowLevelInit();
@@ -95,7 +92,8 @@ ADCf302x8::ADCf302x8(Pin pin) : ADC(pin) {
     addChannel(rank);
     initDMA();
 
-    HAL_ADC_Start_DMA(&halADC, (uint32_t*)&buffer[0], MAX_CHANNELS);
+    HAL_ADC_Start_DMA(&halADC, reinterpret_cast<uint32_t*>(&buffer[0]),
+            MAX_CHANNELS);
 
     rank++;
 }
@@ -109,7 +107,7 @@ uint32_t ADCf302x8::readRaw() {
     // Search through list of channels to determine which DMA buffer index to
     // use
     uint8_t channelNum = 0;
-    while(channels[channelNum] != pin)
+    while (channels[channelNum] != pin)
         channelNum++;
     return buffer[channelNum];
 }
@@ -142,9 +140,7 @@ void ADCf302x8::initADC() {
 }
 
 void ADCf302x8::initDMA() {
-
     // HAL_ADC_Stop(&halADC);
-
 
     // TODO: Add some way of selecting the next available DMA channel
     // Ideally we would have a "DMA" class dedicated to DMA resource
@@ -176,8 +172,7 @@ void ADCf302x8::addChannel(uint8_t rank) {
     gpioInit.Pull = GPIO_NOPULL;
 
     // Which GPIO bank?
-    switch ((static_cast<uint8_t>(pin) & 0xF0) >> 4)
-    {
+    switch ((static_cast<uint8_t>(pin) & 0xF0) >> 4) {
         case 0x0:
             __HAL_RCC_GPIOA_CLK_ENABLE();
             HAL_GPIO_Init(GPIOA, &gpioInit);
@@ -191,11 +186,10 @@ void ADCf302x8::addChannel(uint8_t rank) {
             HAL_GPIO_Init(GPIOC, &gpioInit);
             break;
         default:
-            break; // Should never get here
+            break;  // Should never get here
     }
 
-    switch (pin)
-    {
+    switch (pin) {
         case Pin::PA_0:
             adcChannel.Channel = ADC_CHANNEL_1;
             break;
@@ -242,7 +236,7 @@ void ADCf302x8::addChannel(uint8_t rank) {
             adcChannel.Channel = ADC_CHANNEL_15;
             break;
         default:
-            break; // Should never get here
+            break;  // Should never get here
     }
 
     // Subtract 1 because rank starts at 1

--- a/src/io/platform/f3xx/f302x8/ADCf302x8.cpp
+++ b/src/io/platform/f3xx/f302x8/ADCf302x8.cpp
@@ -1,0 +1,200 @@
+#include <EVT/io/platform/f3xx/f302x8/ADCf302x8.hpp>
+#include <EVT/io/pin.hpp>
+
+#include <HALf3/stm32f3xx_hal_adc.h>
+#include <HALf3/stm32f3xx_hal_adc_ex.h>
+
+
+namespace {
+    /// This is made as a global variable so that it is accessible in the
+    // interrupt.
+    DMA_HandleTypeDef* DMA;
+
+}  // namespace
+
+extern "C" void DMA1_Channel1_IRQHandler() {
+        HAL_DMA_IRQHandler(DMA);
+}
+
+namespace EVT::core::IO {
+
+// Init static member variables
+ADC_HandleTypeDef ADCf302x8::halADC = {0};
+Pin ADCf302x8::channels[MAX_CHANNELS];
+uint32_t ADCf302x8::buffer[MAX_CHANNELS];
+DMA_HandleTypeDef ADCf302x8::halDMA = {0};
+
+
+ADCf302x8::ADCf302x8(Pin pin) : ADC(pin) {
+
+    // Flag representing if the ADC has been configured yet
+    static bool halADCisInit = false;
+    // "Rank" represents the channel value
+    static uint8_t rank;
+
+    if (!halADCisInit) {
+
+        // Init ADC
+        halADC.Instance = ADC1;
+        halADC.Init.ClockPrescaler        = ADC_CLOCK_SYNC_PCLK_DIV4;     // TODO: Need a good value for this...seems to work for now
+        halADC.Init.Resolution            = ADC_RESOLUTION_12B;           // 12-bit resolution
+        halADC.Init.DataAlign             = ADC_DATAALIGN_RIGHT;          // LSB of data is located at bit 0
+        halADC.Init.ScanConvMode          = ENABLE;                       // Conversions performed in sequence across all channels
+        halADC.Init.EOCSelection          = DISABLE;                      // No end-of-conversion flag
+        halADC.Init.LowPowerAutoWait      = DISABLE;                      // Don't transition to low-power state when not in use
+        halADC.Init.ContinuousConvMode    = ENABLE;                       // Keep converting continuously after a trigger occurs (opposite of single mode / one conversion only)
+        halADC.Init.NbrOfConversion       = 0;                            // Number of channels we're going to convert
+        halADC.Init.DiscontinuousConvMode = DISABLE;                      // Perform all conversions in one complete sequence (as opposed to multiple discrete sequences)
+        halADC.Init.NbrOfDiscConversion   = 1;                            // Number of subdivisions for the main conversion sequence
+        halADC.Init.ExternalTrigConv      = ADC_SOFTWARE_START;           // Trigger manually with software
+        halADC.Init.ExternalTrigConvEdge  = ADC_EXTERNALTRIGCONVEDGE_NONE;// Don't care since we're using ADC_SOFTWARE_START as our trigger
+        halADC.Init.DMAContinuousRequests = ENABLE;                       // Keep going once a full DMA transfer is done (opposite of single-shot mode)
+        halADC.Init.Overrun               = ADC_OVR_DATA_OVERWRITTEN;     // Overwrite the data in the DMA buffer upon overrun
+
+        __HAL_RCC_ADC1_CLK_ENABLE();
+        HAL_ADC_Init(&halADC);
+
+        // Start DMA
+        HAL_ADC_Stop(&halADC);
+
+        DMA = &this->halDMA;
+
+        __HAL_RCC_DMA1_CLK_ENABLE();
+
+        this->halDMA.Instance                 = DMA1_Channel1;
+        this->halDMA.Init.Direction           = DMA_PERIPH_TO_MEMORY;    // Data going from the ADC peripheral to a buffer in memory
+        this->halDMA.Init.PeriphInc           = DMA_PINC_DISABLE;        // Disable peripheral pointer auto-increment
+        this->halDMA.Init.MemInc              = DMA_MINC_ENABLE;         // Enable memory pointer auto-increment
+        this->halDMA.Init.PeriphDataAlignment = DMA_PDATAALIGN_HALFWORD; // 16-bit data alignment (the ADC runs in 12-bit mode)
+        this->halDMA.Init.MemDataAlignment    = DMA_MDATAALIGN_HALFWORD;
+        this->halDMA.Init.Mode                = DMA_CIRCULAR;            // Wrap around to the beginning of the buffer when we reach the end
+        this->halDMA.Init.Priority            = DMA_PRIORITY_VERY_HIGH;
+
+        HAL_DMA_Init(&this->halDMA);
+        HAL_NVIC_SetPriority(DMA1_Channel1_IRQn, 0, 0);
+        HAL_NVIC_EnableIRQ(DMA1_Channel1_IRQn);
+
+        __HAL_LINKDMA(&halADC, DMA_Handle, this->halDMA);
+
+        HAL_ADC_Start_DMA(&halADC, &buffer[0], MAX_CHANNELS);
+
+        halADCisInit = true;
+    }
+
+    // Add on the new channel
+    halADC.Init.NbrOfConversion++;
+
+    HAL_ADC_Init(&halADC);
+
+    GPIO_InitTypeDef gpioInit;
+    ADC_ChannelConfTypeDef adcChannel;
+
+    // Configure GPIO for ADC
+    gpioInit.Pin  = (static_cast<uint8_t>(pin) & 0x0F) + 1;
+    gpioInit.Mode = GPIO_MODE_ANALOG;
+    gpioInit.Pull = GPIO_NOPULL;
+
+    // Which GPIO bank?
+    switch ((static_cast<uint8_t>(pin) & 0xF0) >> 4)
+    {
+        case 0x0:
+            __HAL_RCC_GPIOA_CLK_ENABLE();
+            HAL_GPIO_Init(GPIOA, &gpioInit);
+            break;
+        case 0x1:
+            __HAL_RCC_GPIOB_CLK_ENABLE();
+            HAL_GPIO_Init(GPIOB, &gpioInit);
+            break;
+        case 0x2:
+            __HAL_RCC_GPIOC_CLK_ENABLE();
+            HAL_GPIO_Init(GPIOC, &gpioInit);
+            break;
+        default:
+            break; // Should never get here
+    }
+
+    switch (pin)
+    {
+        case Pin::PA_0:
+            adcChannel.Channel = ADC_CHANNEL_1;
+            break;
+        case Pin::PA_1:
+            adcChannel.Channel = ADC_CHANNEL_2;
+            break;
+        case Pin::PA_2:
+            adcChannel.Channel = ADC_CHANNEL_3;
+            break;
+        case Pin::PA_3:
+            adcChannel.Channel = ADC_CHANNEL_4;
+            break;
+        case Pin::PA_4:
+            adcChannel.Channel = ADC_CHANNEL_5;
+            break;
+        case Pin::PC_0:
+            adcChannel.Channel = ADC_CHANNEL_6;
+            break;
+        case Pin::PC_1:
+            adcChannel.Channel = ADC_CHANNEL_7;
+            break;
+        case Pin::PC_2:
+            adcChannel.Channel = ADC_CHANNEL_8;
+            break;
+        case Pin::PC_3:
+            adcChannel.Channel = ADC_CHANNEL_9;
+            break;
+        case Pin::PA_6:
+            adcChannel.Channel = ADC_CHANNEL_10;
+            break;
+        case Pin::PB_0:
+            adcChannel.Channel = ADC_CHANNEL_11;
+            break;
+        case Pin::PB_1:
+            adcChannel.Channel = ADC_CHANNEL_12;
+            break;
+        case Pin::PB_13:
+            adcChannel.Channel = ADC_CHANNEL_13;
+            break;
+        case Pin::PB_11:
+            adcChannel.Channel = ADC_CHANNEL_14;
+            break;
+        case Pin::PA_7:
+            adcChannel.Channel = ADC_CHANNEL_15;
+            break;
+        default:
+            break; // Should never get here
+    }
+
+    // Subtract 1 because rank starts at 1
+    channels[rank-1] = pin;
+
+    adcChannel.Rank = rank++;
+    adcChannel.SamplingTime = ADC_SAMPLETIME_601CYCLES_5;
+    adcChannel.Offset = 0;
+
+    HAL_ADC_ConfigChannel(&halADC, &adcChannel);
+
+    HAL_DMA_Init(&this->halDMA);
+    HAL_ADC_Start_DMA(&halADC, &buffer[0], MAX_CHANNELS);
+
+}
+
+float ADCf302x8::read() {
+    float percentage = readPercentage();
+    return percentage * MAX_VOLTAGE;
+}
+
+uint32_t ADCf302x8::readRaw() {
+    // Search through list of channels to determine which DMA buffer index to
+    // use
+    uint8_t channelNum = 0;
+    while(channels[channelNum] != pin)
+        channelNum++;
+    return static_cast<float>(buffer[channelNum]);
+}
+
+float ADCf302x8::readPercentage() {
+    uint32_t raw = readRaw();
+    return static_cast<float>(raw / MAX_RAW);
+}
+
+}  // namespace EVT::core::IO


### PR DESCRIPTION
Brings in ADC support for the F302x8. ADC  works for a single pin so far.

Note worth TODOs.

1) Only single pin ADC is supported. The second pin does not seem to give back accurate values. This is actually identical behavior to the mbed_applications implementation as well. I believe it is how we keep the DMA buffer as 16 bit numbers, but the ADC works with 32 bit numbers.

2) There is system level initialization that takes place in the ADC. This is just so the basic ADC function can be proved. It will be resolved before 0.0.2 is merged into main.