### PR TITLE
Release the code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,8 @@ add_library(${PROJECT_NAME} STATIC)
 
 # Add sources
 target_sources(${PROJECT_NAME} PRIVATE
+    src/platform/f3xx/stm32f302x8.cpp
+
     src/io/ADC.cpp
     src/io/CAN.cpp
     src/io/GPIO.cpp

--- a/cmake/evt-core_build.cmake
+++ b/cmake/evt-core_build.cmake
@@ -1,0 +1,29 @@
+#[[
+Creates an executable with the provided name. Generates bin, hex, elf, and map
+files for the given name. This will make a dedicated project.
+]]#
+macro(make_exe proj_name sources)
+    project(${proj_name} C CXX ASM)
+    add_definitions(-DUSE_HAL_LIBRARY)
+
+    add_executable(${proj_name} ${sources})
+
+    # Make the main executable have an ".elf" suffix
+    set_target_properties(${proj_name} PROPERTIES
+        OUTPUT_NAME "${proj_name}"
+        SUFFIX ".elf"
+    )
+
+    # Generate a map file
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} \
+                                -Wl,-Map=${proj_name}.map")
+    set(HEX_FILE "${proj_name}.hex")
+    set(BIN_FILE "${proj_name}.bin")
+    add_custom_command(TARGET ${proj_name} POST_BUILD
+    COMMAND ${CMAKE_OBJCOPY} -Oihex $<TARGET_FILE:${proj_name}> ${HEX_FILE}
+    COMMAND ${CMAKE_OBJCOPY} -Obinary $<TARGET_FILE:${proj_name}> ${BIN_FILE}
+    COMMENT "Building ${HEX_FILE} \nBuilding ${BIN_FILE}")
+
+    # Link the EVT-core library
+    target_link_libraries(${proj_name} EVT)
+endmacro()

--- a/include/EVT/io/manager.hpp
+++ b/include/EVT/io/manager.hpp
@@ -28,8 +28,8 @@ namespace EVT::core::IO
  * init logic.
  */
 void init() {
-    #ifndef STM32F302x8
-        stm32f302x8_init();
+    #ifdef STM32F302x8
+    EVT::core::platform::stm32f302x8_init();
     #endif
 }
 

--- a/include/EVT/io/manager.hpp
+++ b/include/EVT/io/manager.hpp
@@ -9,6 +9,8 @@
 #include <EVT/io/PWM.hpp>
 
 #ifdef STM32F302x8
+    #include <EVT/platform/f3xx/stm32f302x8.hpp>
+
     #include <EVT/io/platform/f3xx/f302x8/ADCf302x8.hpp>
     #include <EVT/io/platform/f3xx/f302x8/CANf302x8.hpp>
     #include <EVT/io/platform/f3xx/f302x8/GPIOf302x8.hpp>
@@ -19,6 +21,17 @@
 
 namespace EVT::core::IO
 {
+
+/**
+ * Initialize the low level components of the system. This is highly
+ * platform specific and usually involves clock setup and other peripheral
+ * init logic.
+ */
+void init() {
+    #ifndef STM32F302x8
+        stm32f302x8_init();
+    #endif
+}
 
 /**
  * Get an instance of an ADC channel

--- a/include/EVT/platform/f3xx/stm32f302x8.hpp
+++ b/include/EVT/platform/f3xx/stm32f302x8.hpp
@@ -1,0 +1,13 @@
+#ifndef _EVT_STM32F302x8_
+#define _EVT_STM32F302x8_
+
+namespace EVT::core::platform {
+/**
+ * Handles system level initialization of the STM32F302x8. This makes a
+ * series of calls into the HAL to enable system peripherals and enable
+ * all required clock.
+ */
+void stm32f302x8_init();
+
+}  // namespace EVT::core::platform
+#endif

--- a/samples/adc/CMakeLists.txt
+++ b/samples/adc/CMakeLists.txt
@@ -1,29 +1,3 @@
-# Add example code
-set(SAMPLE_NAME adc)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/evt-core_build.cmake)
 
-project(${SAMPLE_NAME} C CXX ASM)
-
-add_definitions(-DUSE_HAL_LIBRARY)
-
-add_executable(${SAMPLE_NAME}
-    main.cpp
-)
-
-set_target_properties(${SAMPLE_NAME} PROPERTIES
-    OUTPUT_NAME "${SAMPLE_NAME}"
-    SUFFIX ".elf"
-)
-
-# Generate map
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} \
-                            -Wl,-Map=${SAMPLE_NAME}.map")
-
-set(HEX_FILE "${SAMPLE_NAME}.hex")
-set(BIN_FILE "${SAMPLE_NAME}.bin")
-add_custom_command(TARGET ${SAMPLE_NAME} POST_BUILD
-    COMMAND ${CMAKE_OBJCOPY} -Oihex $<TARGET_FILE:${SAMPLE_NAME}> ${HEX_FILE}
-    COMMAND ${CMAKE_OBJCOPY} -Obinary $<TARGET_FILE:${SAMPLE_NAME}> ${BIN_FILE}
-    COMMENT "Building ${HEX_FILE} \nBuilding ${BIN_FILE}")
-
-# Link the EVT library
-target_link_libraries(${SAMPLE_NAME} EVT)
+make_exe(adc main.cpp)

--- a/samples/adc/main.cpp
+++ b/samples/adc/main.cpp
@@ -12,6 +12,9 @@ namespace IO = EVT::core::IO;
 namespace time = EVT::core::time;
 
 int main() {
+    // Initialize system
+    IO::init();
+
     IO::UART& uart = IO::getUART<IO::Pin::UART_TX, IO::Pin::UART_RX>(9600);
 
     uart.printf("Starting ADC test\r\n");

--- a/samples/blink/CMakeLists.txt
+++ b/samples/blink/CMakeLists.txt
@@ -1,29 +1,3 @@
-# Add example code
-set(SAMPLE_NAME blink)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/evt-core_build.cmake)
 
-project(${SAMPLE_NAME} C CXX ASM)
-
-add_definitions(-DUSE_HAL_LIBRARY)
-
-add_executable(${SAMPLE_NAME} 
-    main.cpp  
-)
-
-set_target_properties(${SAMPLE_NAME} PROPERTIES 
-    OUTPUT_NAME "${SAMPLE_NAME}"
-    SUFFIX ".elf"
-)
-
-# Generate map
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} \
-                            -Wl,-Map=${SAMPLE_NAME}.map")
-
-set(HEX_FILE "${SAMPLE_NAME}.hex")
-set(BIN_FILE "${SAMPLE_NAME}.bin")
-add_custom_command(TARGET ${SAMPLE_NAME} POST_BUILD
-    COMMAND ${CMAKE_OBJCOPY} -Oihex $<TARGET_FILE:${SAMPLE_NAME}> ${HEX_FILE}
-    COMMAND ${CMAKE_OBJCOPY} -Obinary $<TARGET_FILE:${SAMPLE_NAME}> ${BIN_FILE}
-    COMMENT "Building ${HEX_FILE} \nBuilding ${BIN_FILE}")
-
-# Link the EVT library
-target_link_libraries(${SAMPLE_NAME} EVT)
+make_exe(blink main.cpp)

--- a/samples/blink/main.cpp
+++ b/samples/blink/main.cpp
@@ -17,6 +17,9 @@ namespace DEV = EVT::core::DEV;
 namespace time = EVT::core::time;
 
 int main() {
+    // Initialize system
+    IO::init();
+
     // Setup the GPIO pin.
     // Notice that the pin used is called "LED". Each platform has a dedicated
     // LED pin, for the f3xx that is PB_13.

--- a/samples/can/CMakeLists.txt
+++ b/samples/can/CMakeLists.txt
@@ -1,29 +1,3 @@
-# Add example code
-set(SAMPLE_NAME can)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/evt-core_build.cmake)
 
-project(${SAMPLE_NAME} C CXX ASM)
-
-add_definitions(-DUSE_HAL_LIBRARY)
-
-add_executable(${SAMPLE_NAME} 
-    main.cpp  
-)
-
-set_target_properties(${SAMPLE_NAME} PROPERTIES 
-    OUTPUT_NAME "${SAMPLE_NAME}"
-    SUFFIX ".elf"
-)
-
-# Generate map
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} \
-                            -Wl,-Map=${SAMPLE_NAME}.map")
-
-set(HEX_FILE "${SAMPLE_NAME}.hex")
-set(BIN_FILE "${SAMPLE_NAME}.bin")
-add_custom_command(TARGET ${SAMPLE_NAME} POST_BUILD
-    COMMAND ${CMAKE_OBJCOPY} -Oihex $<TARGET_FILE:${SAMPLE_NAME}> ${HEX_FILE}
-    COMMAND ${CMAKE_OBJCOPY} -Obinary $<TARGET_FILE:${SAMPLE_NAME}> ${BIN_FILE}
-    COMMENT "Building ${HEX_FILE} \nBuilding ${BIN_FILE}")
-
-# Link the EVT library
-target_link_libraries(${SAMPLE_NAME} EVT)
+make_exe(can main.cpp)

--- a/samples/can/main.cpp
+++ b/samples/can/main.cpp
@@ -12,6 +12,9 @@ namespace IO = EVT::core::IO;
 namespace time = EVT::core::time;
 
 int main() {
+    // Initialize system
+    IO::init();
+
     // Get CAN instance with loopback enabled
     IO::CAN& can = IO::getCAN<IO::Pin::PA_12, IO::Pin::PA_11>(true);
     IO::UART& uart = IO::getUART<IO::Pin::UART_TX, IO::Pin::UART_RX>(9600);

--- a/samples/echo/CMakeLists.txt
+++ b/samples/echo/CMakeLists.txt
@@ -1,29 +1,3 @@
-# Add example code
-set(SAMPLE_NAME echo)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/evt-core_build.cmake)
 
-project(${SAMPLE_NAME} C CXX ASM)
-
-add_definitions(-DUSE_HAL_LIBRARY)
-
-add_executable(${SAMPLE_NAME}
-    main.cpp
-)
-
-set_target_properties(${SAMPLE_NAME} PROPERTIES
-    OUTPUT_NAME "${SAMPLE_NAME}"
-    SUFFIX ".elf"
-)
-
-# Generate map
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} \
-                            -Wl,-Map=${SAMPLE_NAME}.map")
-
-set(HEX_FILE "${SAMPLE_NAME}.hex")
-set(BIN_FILE "${SAMPLE_NAME}.bin")
-add_custom_command(TARGET ${SAMPLE_NAME} POST_BUILD
-    COMMAND ${CMAKE_OBJCOPY} -Oihex $<TARGET_FILE:${SAMPLE_NAME}> ${HEX_FILE}
-    COMMAND ${CMAKE_OBJCOPY} -Obinary $<TARGET_FILE:${SAMPLE_NAME}> ${BIN_FILE}
-    COMMENT "Building ${HEX_FILE} \nBuilding ${BIN_FILE}")
-
-# Link the EVT library
-target_link_libraries(${SAMPLE_NAME} EVT)
+make_exe(echo main.cpp)

--- a/samples/echo/main.cpp
+++ b/samples/echo/main.cpp
@@ -10,6 +10,9 @@
 namespace IO = EVT::core::IO;
 
 int main() {
+    // Initialize system
+    IO::init();
+
     // Setup UART
     IO::UART& uart = IO::getUART<IO::Pin::UART_TX, IO::Pin::UART_RX>(9600);
 

--- a/samples/i2c/CMakeLists.txt
+++ b/samples/i2c/CMakeLists.txt
@@ -1,29 +1,3 @@
-# Add example code
-set(SAMPLE_NAME i2c)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/evt-core_build.cmake)
 
-project(${SAMPLE_NAME} C CXX ASM)
-
-add_definitions(-DUSE_HAL_LIBRARY)
-
-add_executable(${SAMPLE_NAME}
-    main.cpp
-)
-
-set_target_properties(${SAMPLE_NAME} PROPERTIES
-    OUTPUT_NAME "${SAMPLE_NAME}"
-    SUFFIX ".elf"
-)
-
-# Generate map
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} \
-                            -Wl,-Map=${SAMPLE_NAME}.map")
-
-set(HEX_FILE "${SAMPLE_NAME}.hex")
-set(BIN_FILE "${SAMPLE_NAME}.bin")
-add_custom_command(TARGET ${SAMPLE_NAME} POST_BUILD
-    COMMAND ${CMAKE_OBJCOPY} -Oihex $<TARGET_FILE:${SAMPLE_NAME}> ${HEX_FILE}
-    COMMAND ${CMAKE_OBJCOPY} -Obinary $<TARGET_FILE:${SAMPLE_NAME}> ${BIN_FILE}
-    COMMENT "Building ${HEX_FILE} \nBuilding ${BIN_FILE}")
-
-# Link the EVT library
-target_link_libraries(${SAMPLE_NAME} EVT)
+make_exe(i2c main.cpp)

--- a/samples/i2c/main.cpp
+++ b/samples/i2c/main.cpp
@@ -23,6 +23,9 @@ constexpr uint8_t O_REGISTER = 0x00;
 constexpr uint8_t K_REGISTER = 0x01;
 
 int main() {
+    // Initialize system
+    IO::init();
+
     IO::I2C& i2c = IO::getI2C<IO::Pin::PB_8, IO::Pin::PB_9>();
     IO::UART& uart = IO::getUART<IO::Pin::UART_TX, IO::Pin::UART_RX>(9600);
 

--- a/samples/pwm/CMakeLists.txt
+++ b/samples/pwm/CMakeLists.txt
@@ -1,29 +1,3 @@
-# Add example code
-set(SAMPLE_NAME pwm)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/evt-core_build.cmake)
 
-project(${SAMPLE_NAME} C CXX ASM)
-
-add_definitions(-DUSE_HAL_LIBRARY)
-
-add_executable(${SAMPLE_NAME} 
-    main.cpp  
-)
-
-set_target_properties(${SAMPLE_NAME} PROPERTIES 
-    OUTPUT_NAME "${SAMPLE_NAME}"
-    SUFFIX ".elf"
-)
-
-# Generate map
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} \
-                            -Wl,-Map=${SAMPLE_NAME}.map")
-
-set(HEX_FILE "${SAMPLE_NAME}.hex")
-set(BIN_FILE "${SAMPLE_NAME}.bin")
-add_custom_command(TARGET ${SAMPLE_NAME} POST_BUILD
-    COMMAND ${CMAKE_OBJCOPY} -Oihex $<TARGET_FILE:${SAMPLE_NAME}> ${HEX_FILE}
-    COMMAND ${CMAKE_OBJCOPY} -Obinary $<TARGET_FILE:${SAMPLE_NAME}> ${BIN_FILE}
-    COMMENT "Building ${HEX_FILE} \nBuilding ${BIN_FILE}")
-
-# Link the EVT library
-target_link_libraries(${SAMPLE_NAME} EVT)
+make_exe(pwm main.cpp)

--- a/samples/pwm/main.cpp
+++ b/samples/pwm/main.cpp
@@ -10,6 +10,9 @@ namespace IO = EVT::core::IO;
 namespace time = EVT::core::time;
 
 int main() {
+    // Initialize system
+    IO::init();
+
     IO::PWM& pwm = IO::getPWM<IO::Pin::PC_0>();
     // 1 second period
     pwm.setPeriod(1);

--- a/samples/queue/CMakeLists.txt
+++ b/samples/queue/CMakeLists.txt
@@ -1,29 +1,3 @@
-# Add example code
-set(SAMPLE_NAME queue)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/evt-core_build.cmake)
 
-project(${SAMPLE_NAME} C CXX ASM)
-
-add_definitions(-DUSE_HAL_LIBRARY)
-
-add_executable(${SAMPLE_NAME}
-    main.cpp
-)
-
-set_target_properties(${SAMPLE_NAME} PROPERTIES
-    OUTPUT_NAME "${SAMPLE_NAME}"
-    SUFFIX ".elf"
-)
-
-# Generate map
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} \
-                            -Wl,-Map=${SAMPLE_NAME}.map")
-
-set(HEX_FILE "${SAMPLE_NAME}.hex")
-set(BIN_FILE "${SAMPLE_NAME}.bin")
-add_custom_command(TARGET ${SAMPLE_NAME} POST_BUILD
-    COMMAND ${CMAKE_OBJCOPY} -Oihex $<TARGET_FILE:${SAMPLE_NAME}> ${HEX_FILE}
-    COMMAND ${CMAKE_OBJCOPY} -Obinary $<TARGET_FILE:${SAMPLE_NAME}> ${BIN_FILE}
-    COMMENT "Building ${HEX_FILE} \nBuilding ${BIN_FILE}")
-
-# Link the EVT library
-target_link_libraries(${SAMPLE_NAME} EVT)
+make_exe(queue main.cpp)

--- a/samples/queue/main.cpp
+++ b/samples/queue/main.cpp
@@ -43,6 +43,9 @@ class TestClass {
 };
 
 int main() {
+    // Initialize system
+    IO::init();
+
     // Setup UART
     IO::UART& uart = IO::getUART<IO::Pin::UART_TX, IO::Pin::UART_RX>(9600);
 

--- a/samples/read_write/CMakeLists.txt
+++ b/samples/read_write/CMakeLists.txt
@@ -1,29 +1,3 @@
-# Add example code
-set(SAMPLE_NAME read_write)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/evt-core_build.cmake)
 
-project(${SAMPLE_NAME} C CXX ASM)
-
-add_definitions(-DUSE_HAL_LIBRARY)
-
-add_executable(${SAMPLE_NAME} 
-    main.cpp  
-)
-
-set_target_properties(${SAMPLE_NAME} PROPERTIES 
-    OUTPUT_NAME "${SAMPLE_NAME}"
-    SUFFIX ".elf"
-)
-
-# Generate map
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} \
-                            -Wl,-Map=${SAMPLE_NAME}.map")
-
-set(HEX_FILE "${SAMPLE_NAME}.hex")
-set(BIN_FILE "${SAMPLE_NAME}.bin")
-add_custom_command(TARGET ${SAMPLE_NAME} POST_BUILD
-    COMMAND ${CMAKE_OBJCOPY} -Oihex $<TARGET_FILE:${SAMPLE_NAME}> ${HEX_FILE}
-    COMMAND ${CMAKE_OBJCOPY} -Obinary $<TARGET_FILE:${SAMPLE_NAME}> ${BIN_FILE}
-    COMMENT "Building ${HEX_FILE} \nBuilding ${BIN_FILE}")
-
-# Link the EVT library
-target_link_libraries(${SAMPLE_NAME} EVT)
+make_exe(read_write main.cpp)

--- a/samples/read_write/main.cpp
+++ b/samples/read_write/main.cpp
@@ -14,6 +14,9 @@ namespace DEV = EVT::core::DEV;
 namespace time = EVT::core::time;
 
 int main() {
+    // Initialize system
+    IO::init();
+
     // Setup the GPIO input pin
     IO::GPIO& inputGPIO = IO::getGPIO<IO::Pin::PC_3>(
             IO::GPIO::Direction::INPUT);

--- a/src/io/platform/f3xx/f302x8/ADCf302x8.cpp
+++ b/src/io/platform/f3xx/f302x8/ADCf302x8.cpp
@@ -19,45 +19,6 @@ extern "C" void DMA1_Channel1_IRQHandler(void) {
     HAL_DMA_IRQHandler(dmaHandle);
 }
 
-/**
- * Current "work around" solution that ensurs the clock settings are applied
- * and the HAL is initialized. This will later be moved into a common place
- * that will happen once at system start up. For the time being this can be
- * used for basic setup. This is not a long term solution.
- */
-static void lowLevelInit() {
-    HAL_Init();
-    RCC_OscInitTypeDef RCC_OscInitStruct = {0};
-    RCC_ClkInitTypeDef RCC_ClkInitStruct = {0};
-    RCC_PeriphCLKInitTypeDef PeriphClkInit = {0};
-
-    /** Initializes the RCC Oscillators according to the specified parameters
-    * in the RCC_OscInitTypeDef structure.
-    */
-    RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSI;
-    RCC_OscInitStruct.HSIState = RCC_HSI_ON;
-    RCC_OscInitStruct.HSICalibrationValue = RCC_HSICALIBRATION_DEFAULT;
-    RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
-    RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSI;
-    RCC_OscInitStruct.PLL.PLLMUL = RCC_PLL_MUL2;
-    HAL_RCC_OscConfig(&RCC_OscInitStruct);
-
-    /** Initializes the CPU, AHB and APB buses clocks
-    */
-    RCC_ClkInitStruct.ClockType = RCC_CLOCKTYPE_HCLK|RCC_CLOCKTYPE_SYSCLK
-                              |RCC_CLOCKTYPE_PCLK1|RCC_CLOCKTYPE_PCLK2;
-    RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_HSI;
-    RCC_ClkInitStruct.AHBCLKDivider = RCC_SYSCLK_DIV1;
-    RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV1;
-    RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV1;
-
-    HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_0);
-    PeriphClkInit.PeriphClockSelection = RCC_PERIPHCLK_ADC1;
-    PeriphClkInit.Adc1ClockSelection = RCC_ADC1PLLCLK_DIV1;
-
-    HAL_RCCEx_PeriphCLKConfig(&PeriphClkInit);
-}
-
 namespace EVT::core::IO {
 
 // Init static member variables
@@ -78,7 +39,6 @@ ADCf302x8::ADCf302x8(Pin pin) : ADC(pin) {
     if (!halADCisInit) {
         __HAL_RCC_DMA1_CLK_ENABLE();
 
-        lowLevelInit();
         initADC();
 
         initDMA();

--- a/src/platform/f3xx/stm32f302x8.cpp
+++ b/src/platform/f3xx/stm32f302x8.cpp
@@ -1,0 +1,37 @@
+#include <HALf3/stm32f3xx.h>
+
+#include <EVT/platform/f3xx/stm32f302x8.hpp>
+
+void stm32f302x8_init() {
+    HAL_Init();
+    RCC_OscInitTypeDef RCC_OscInitStruct = {0};
+    RCC_ClkInitTypeDef RCC_ClkInitStruct = {0};
+    RCC_PeriphCLKInitTypeDef PeriphClkInit = {0};
+
+    /** Initializes the RCC Oscillators according to the specified parameters
+    * in the RCC_OscInitTypeDef structure.
+    */
+    RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSI;
+    RCC_OscInitStruct.HSIState = RCC_HSI_ON;
+    RCC_OscInitStruct.HSICalibrationValue = RCC_HSICALIBRATION_DEFAULT;
+    RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
+    RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSI;
+    RCC_OscInitStruct.PLL.PLLMUL = RCC_PLL_MUL2;
+    HAL_RCC_OscConfig(&RCC_OscInitStruct);
+
+    /** Initializes the CPU, AHB and APB buses clocks
+    */
+    RCC_ClkInitStruct.ClockType = RCC_CLOCKTYPE_HCLK|RCC_CLOCKTYPE_SYSCLK
+                              |RCC_CLOCKTYPE_PCLK1|RCC_CLOCKTYPE_PCLK2;
+    RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_HSI;
+    RCC_ClkInitStruct.AHBCLKDivider = RCC_SYSCLK_DIV1;
+    RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV1;
+    RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV1;
+
+    HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_0);
+    PeriphClkInit.PeriphClockSelection = RCC_PERIPHCLK_ADC1;
+    PeriphClkInit.Adc1ClockSelection = RCC_ADC1PLLCLK_DIV1;
+
+    HAL_RCCEx_PeriphCLKConfig(&PeriphClkInit);
+
+}

--- a/src/platform/f3xx/stm32f302x8.cpp
+++ b/src/platform/f3xx/stm32f302x8.cpp
@@ -2,6 +2,8 @@
 
 #include <EVT/platform/f3xx/stm32f302x8.hpp>
 
+namespace EVT::core::platform {
+
 void stm32f302x8_init() {
     HAL_Init();
     RCC_OscInitTypeDef RCC_OscInitStruct = {0};
@@ -35,3 +37,5 @@ void stm32f302x8_init() {
     HAL_RCCEx_PeriphCLKConfig(&PeriphClkInit);
 
 }
+
+}  //namespace EVT::core::platform


### PR DESCRIPTION
We are ready for our first "official release" 0.1.0 which is currently based off of `dev/0.0.2` will include everything from `dev/0.0.2` as well as the clean up commits I have made. The idea is that EVT-core is now feature complete enough to start writing various board in EVT-core. v0.1.0 will be the starting point from which to start development.

We will continue to make tweaks until EVT-core is considered "stable" (no longer having large scale changes), At which point we will have our 1.0.0 release.

The main things added in the cleanup are

1. A macro for creating an executable that  can be used to flash a board
2. Creation of a system level init function which handles initializing the board including clock settings