### PR TITLE
Dev/cbolles/cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ endif()
 # Project Setup
 ###############################################################################
 project(EVT
-        VERSION 0.0.1
+        VERSION 0.1.1
         LANGUAGES CXX C
 )
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,0 +1,15 @@
+# Changelog
+
+Contains notable changes there were added, fixed, or removed in each release.
+
+## 0.1.0
+
+### Added
+
+* I2C Support for the STM32F302r8
+* PWM Support for the STM32F302r8
+* UART Support for the STM32F302r8
+* CAN Support for the STM32F302r8
+* GPIO Support for the STM32F302r8
+* Basic System Intialization for the STM32F302r8
+* Ability to build as library

--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ Below is the state of supported features on each platform.
 
 NOTE: In these early releases testing is not fully verbose.
 
-| Platform    | I2C | SPI | PWM                | CAN | ADC | Flash | RTC | UART                | GPIO                |
-|-------------|-----|-----|--------------------|-----|-----|-------|-----|---------------------|---------------------|
-| STM32F302R8 | :x: | :x: | :heavy_check_mark: | :heavy_check_mark: | :x: | :x:   | :x: | :heavy_check_mark:  | :heavy_check_mark:  |
-| STM32F446RE | :x: | :x: | :x:                | :x: | :x: | :x:   | :x: | :x:                 | :x:                 |
+| Platform    | I2C                | SPI | PWM                | CAN                | ADC                | Flash | RTC | UART                | GPIO                |
+|-------------|--------------------|-----|--------------------|--------------------|--------------------|-------|-----|---------------------|---------------------|
+| STM32F302R8 | :heavy_check_mark: | :x: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :x:   | :x: | :heavy_check_mark:  | :heavy_check_mark:  |
+| STM32F446RE | :x:                | :x: | :x:                | :x:                | :x:                | :x:   | :x: | :x:                 | :x:                 |
 
 ## Future Features
 
@@ -98,5 +98,3 @@ or concepts that EVT-Core should support.
 accomplished by calling the target handler once from main code execution.
 * Style checking should be part of the build process.
 * Add documentation for using this library.
-
-## Release Notes

--- a/include/EVT/io/types/CANMessage.hpp
+++ b/include/EVT/io/types/CANMessage.hpp
@@ -75,7 +75,14 @@ public:
      *
      * @param payload The payload to copy over
      */
-    void setPayload(uint8_t* payload);
+    void setPayload(const uint8_t* payload);
+    
+    /**
+     * Assignment operator where the contents of the CANMessage is copied into
+     * this message.
+     * @param other The CANMessage to copy from
+     */
+    CANMessage& operator= (const CANMessage& other);
 
 private:
     /** ID of the CAN message */

--- a/src/io/types/CANMessage.cpp
+++ b/src/io/types/CANMessage.cpp
@@ -42,8 +42,15 @@ void CANMessage::setDataLength(uint8_t size) {
     this->dataLength = size;
 }
 
-void CANMessage::setPayload(uint8_t *payload) {
+void CANMessage::setPayload(const uint8_t *payload) {
     std::memcpy(this->payload, payload, CAN_MAX_PAYLOAD_SIZE);
+}
+
+CANMessage& CANMessage::operator=(const CANMessage& other) {
+    this->id = other.id;
+    this->dataLength = other.dataLength;
+    this->setPayload(other.payload);
+    return *this;
 }
 
 }  // namespace EVT::core::IO


### PR DESCRIPTION
Some basic cleanup. Part of this was missing from the v0.1.0 release (updated README, Changelog, version bump in CMakeLists). This fixes that and adds an explicit override of the equals operator for CANMessage. This isn't strictly required, but removed some ambiguity. 