### PR TITLE
Bug/cbolles/uart receive

### DIFF
--- a/samples/queue/main.cpp
+++ b/samples/queue/main.cpp
@@ -80,7 +80,8 @@ int main() {
 
     // Try to pop from empty queue
     int value;
-    uart.printf("numberQueue.pop() success ? ->%d\r\n", numberQueue.pop(&value));
+    uart.printf("numberQueue.pop() success ? ->%d\r\n",
+            numberQueue.pop(&value));
 
     ///////////////////////////////////////////////////////////////////////////
     // Test a queue of numbers, with overwritting

--- a/src/io/platform/f3xx/f302x8/UARTf302x8.cpp
+++ b/src/io/platform/f3xx/f302x8/UARTf302x8.cpp
@@ -152,7 +152,7 @@ void UARTf302x8::puts(const char* s) {
 
 char UARTf302x8::getc() {
     uint8_t c;
-    HAL_UART_Receive(&halUART, &c, 1, DEFAULT_TIMEOUT);
+    while(HAL_UART_Receive(&halUART, &c, 1, DEFAULT_TIMEOUT) == HAL_TIMEOUT);
     return static_cast<char>(c);
 }
 

--- a/src/io/platform/f3xx/f302x8/UARTf302x8.cpp
+++ b/src/io/platform/f3xx/f302x8/UARTf302x8.cpp
@@ -152,7 +152,8 @@ void UARTf302x8::puts(const char* s) {
 
 char UARTf302x8::getc() {
     uint8_t c;
-    while(HAL_UART_Receive(&halUART, &c, 1, DEFAULT_TIMEOUT) == HAL_TIMEOUT);
+    while (HAL_UART_Receive(&halUART, &c, 1, DEFAULT_TIMEOUT) == HAL_TIMEOUT) {
+    }
     return static_cast<char>(c);
 }
 

--- a/src/platform/f3xx/stm32f302x8.cpp
+++ b/src/platform/f3xx/stm32f302x8.cpp
@@ -1,4 +1,6 @@
 #include <HALf3/stm32f3xx.h>
+#include <HALf3/stm32f3xx_hal.h>
+#include <HALf3/stm32f3xx_it.h>
 
 #include <EVT/platform/f3xx/stm32f302x8.hpp>
 
@@ -18,7 +20,7 @@ void stm32f302x8_init() {
     RCC_OscInitStruct.HSICalibrationValue = RCC_HSICALIBRATION_DEFAULT;
     RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
     RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSI;
-    RCC_OscInitStruct.PLL.PLLMUL = RCC_PLL_MUL2;
+    RCC_OscInitStruct.PLL.PLLMUL = RCC_PLL_MUL4;
     HAL_RCC_OscConfig(&RCC_OscInitStruct);
 
     /** Initializes the CPU, AHB and APB buses clocks
@@ -36,6 +38,7 @@ void stm32f302x8_init() {
 
     HAL_RCCEx_PeriphCLKConfig(&PeriphClkInit);
 
+    SysTick_Handler();
 }
 
 }  //namespace EVT::core::platform

--- a/src/platform/f3xx/stm32f302x8.cpp
+++ b/src/platform/f3xx/stm32f302x8.cpp
@@ -41,4 +41,4 @@ void stm32f302x8_init() {
     SysTick_Handler();
 }
 
-}  //namespace EVT::core::platform
+}  // namespace EVT::core::platform


### PR DESCRIPTION
Fix issue with UART TX + RX. The issue turned out to be a couple of things.

1. The UART needs the `SysTick_Handler` function to exist, but it is optimized out unless `EVT::core::time::wait` is called (this should be resolved)
2. The `getc` method was not actually blocking so was timing out and returning garbage data. The method is now blocking, but in the future a non-blocking variant should be added.
3. With the addition of the ADC the clock settings needed to be tweaked slightly