### PR TITLE
Added import and updated linelength cpplint param

### DIFF
--- a/cmake/evt-core_compiler.cmake
+++ b/cmake/evt-core_compiler.cmake
@@ -51,7 +51,7 @@ if(EVT_LINT)
     # TODO: In the future these filter settings sound be included in cfg
     # files.
     set(CMAKE_CXX_CPPLINT "cpplint;--filter=-legal/copyright, \
-                          -readability/todo,-build/include_order")
+                          -readability/todo,-build/include_order;--linelength=120")
 endif()
 
 ###############################################################################

--- a/include/EVT/io/UART.hpp
+++ b/include/EVT/io/UART.hpp
@@ -1,7 +1,8 @@
 #ifndef _EVT_UART_
 #define _EVT_UART_
 
-#include <stdint.h>
+#include <cstdint>
+#include <cstdlib>
 
 namespace EVT::core::IO {
 


### PR DESCRIPTION
- Small updates.  Added include so `size_t` type was visible to APM code in UART.hpp
- Updated linelength param for cpplint to 120