### PR TITLE
Fix a bug where interrupt triggers immediately when starting a new ti…

### DIFF
--- a/src/dev/platform/f3xx/f302x8/Timerf302x8.cpp
+++ b/src/dev/platform/f3xx/f302x8/Timerf302x8.cpp
@@ -142,6 +142,8 @@ void Timerf302x8::initTimer(TIM_TypeDef *timerPeripheral, uint32_t clockPeriod) 
     masterConfig.MasterSlaveMode = TIM_MASTERSLAVEMODE_DISABLE;
     HAL_TIMEx_MasterConfigSynchronization(&htim, &masterConfig);
 
+    __HAL_TIM_CLEAR_IT(&htim, TIM_IT_UPDATE);   // Clear the interrupt flag so interrupt doesn't
+                                                           // trigger immediately
     HAL_TIM_Base_Start_IT(&htim);
 }
 


### PR DESCRIPTION
Fixed a small bug where the interrupt would trigger as soon as the timer device was enabled due to the TIME_IT_UPDATE flag already being set.  Clear this flag before enabling the device so the first interrupt is triggered after the expected period.