### PR TITLE
Bug fix/dpopp/adc dma

### DIFF
--- a/include/EVT/io/platform/f3xx/f302x8/ADCf302x8.hpp
+++ b/include/EVT/io/platform/f3xx/f302x8/ADCf302x8.hpp
@@ -43,9 +43,9 @@ public:
 private:
     // Max number of channels supported by the ADC
     static constexpr uint8_t MAX_CHANNELS = 15;
-    // Max voltage of the ADC
-    static constexpr float MAX_VOLTAGE = 3.6;
-    // Max value for a 12 bit ADC reading
+    // Positive reference voltage of the ADC.  Needs to be updated based on the hardware configuration
+    static constexpr float VREF_POS = 3.3;
+    // Max value for a 12 bit ADC reading (2^12 - 1)
     static constexpr uint32_t MAX_RAW = 4095;
     /// This is static since the STM32F3xx only has a single ADC which
     /// supports muliple channels. The ADC will be initialized once then

--- a/include/EVT/io/platform/f3xx/f302x8/ADCf302x8.hpp
+++ b/include/EVT/io/platform/f3xx/f302x8/ADCf302x8.hpp
@@ -61,7 +61,7 @@ private:
     /**
      * Initialize the HAL ADC handler. This should only have to be run once
      */
-    void initADC();
+    void initADC(uint8_t num_channels);
 
     /**
      * Initialize the HALD DMA for the ADC, should only have to be run once

--- a/samples/adc/main.cpp
+++ b/samples/adc/main.cpp
@@ -22,17 +22,17 @@ int main() {
     time::wait(500);
 
     IO::ADC& adc0 = IO::getADC<IO::Pin::PA_0>();
-    IO::ADC& adc1 = IO::getADC<IO::Pin::PA_1>();
+//    IO::ADC& adc1 = IO::getADC<IO::Pin::PA_1>();
 
     while (1) {
         uart.printf("--------------------\r\n");
-        uart.printf("ADC0 : %.2fV\r\n", adc0.read());
-        uart.printf("ADC0: %.2f%%\r\n", adc0.readPercentage() * 100);
+        uart.printf("ADC0 : %d mV\r\n", static_cast<uint32_t>(adc0.read()*1000));
+        uart.printf("ADC0: %d%%\r\n", static_cast<uint32_t>(adc0.readPercentage() * 100));
         uart.printf("ADC0 raw: %d\r\n\r\n", adc0.readRaw());
 
-        uart.printf("ADC1: %.2fV\r\n", adc1.read());
-        uart.printf("ADC1: %.2f%%\r\n", adc1.readPercentage());
-        uart.printf("ADC1 raw: %d\r\n", adc1.readRaw());
+//        uart.printf("ADC1 : %d mV\r\n", static_cast<uint32_t>(adc1.read()*1000));
+//        uart.printf("ADC1: %d%%\r\n", static_cast<uint32_t>(adc1.readPercentage() * 100));
+//        uart.printf("ADC1 raw: %d\r\n", adc1.readRaw());
 
         uart.printf("--------------------\r\n\r\n");
         time::wait(500);

--- a/samples/adc/main.cpp
+++ b/samples/adc/main.cpp
@@ -22,7 +22,7 @@ int main() {
     time::wait(500);
 
     IO::ADC& adc0 = IO::getADC<IO::Pin::PA_0>();
-//    IO::ADC& adc1 = IO::getADC<IO::Pin::PA_1>();
+    IO::ADC& adc1 = IO::getADC<IO::Pin::PA_1>();
 
     while (1) {
         uart.printf("--------------------\r\n");
@@ -30,9 +30,9 @@ int main() {
         uart.printf("ADC0: %d%%\r\n", static_cast<uint32_t>(adc0.readPercentage() * 100));
         uart.printf("ADC0 raw: %d\r\n\r\n", adc0.readRaw());
 
-//        uart.printf("ADC1 : %d mV\r\n", static_cast<uint32_t>(adc1.read()*1000));
-//        uart.printf("ADC1: %d%%\r\n", static_cast<uint32_t>(adc1.readPercentage() * 100));
-//        uart.printf("ADC1 raw: %d\r\n", adc1.readRaw());
+        uart.printf("ADC1 : %d mV\r\n", static_cast<uint32_t>(adc1.read()*1000));
+        uart.printf("ADC1: %d%%\r\n", static_cast<uint32_t>(adc1.readPercentage() * 100));
+        uart.printf("ADC1 raw: %d\r\n", adc1.readRaw());
 
         uart.printf("--------------------\r\n\r\n");
         time::wait(500);

--- a/samples/adc/main.cpp
+++ b/samples/adc/main.cpp
@@ -26,11 +26,11 @@ int main() {
 
     while (1) {
         uart.printf("--------------------\r\n");
-        uart.printf("ADC0 : %d mV\r\n", static_cast<uint32_t>(adc0.read()*1000));
+        uart.printf("ADC0 : %d mV\r\n", static_cast<uint32_t>(adc0.read() * 1000));
         uart.printf("ADC0: %d%%\r\n", static_cast<uint32_t>(adc0.readPercentage() * 100));
         uart.printf("ADC0 raw: %d\r\n\r\n", adc0.readRaw());
 
-        uart.printf("ADC1 : %d mV\r\n", static_cast<uint32_t>(adc1.read()*1000));
+        uart.printf("ADC1 : %d mV\r\n", static_cast<uint32_t>(adc1.read() * 1000));
         uart.printf("ADC1: %d%%\r\n", static_cast<uint32_t>(adc1.readPercentage() * 100));
         uart.printf("ADC1 raw: %d\r\n", adc1.readRaw());
 

--- a/src/io/platform/f3xx/f302x8/ADCf302x8.cpp
+++ b/src/io/platform/f3xx/f302x8/ADCf302x8.cpp
@@ -58,7 +58,7 @@ ADCf302x8::ADCf302x8(Pin pin) : ADC(pin) {
     addChannel(rank);
 
     initDMA();
-    HAL_ADC_Start_DMA(&halADC, (uint32_t *) (&buffer[0]),
+    HAL_ADC_Start_DMA(&halADC, reinterpret_cast<uint32_t*>(&buffer[0]),
                       rank);
 
     rank++;

--- a/src/io/platform/f3xx/f302x8/ADCf302x8.cpp
+++ b/src/io/platform/f3xx/f302x8/ADCf302x8.cpp
@@ -46,6 +46,7 @@ ADCf302x8::ADCf302x8(Pin pin) : ADC(pin) {
 
         halADCisInit = true;
     } else {
+        // TODO: May not be necessary
         HAL_ADC_Stop_DMA(&halADC);
         HAL_DMA_DeInit(&halDMA);
     }

--- a/src/io/platform/f3xx/f302x8/ADCf302x8.cpp
+++ b/src/io/platform/f3xx/f302x8/ADCf302x8.cpp
@@ -84,7 +84,7 @@ float ADCf302x8::readPercentage() {
 }
 
 void ADCf302x8::initADC(uint8_t num_channels) {
-    halADC.Instance = ADC1;  // Only ADC the F3 supports
+    halADC.Instance = ADC1;// Only ADC the F3 supports
 
     // TODO: Figure out ADC calibration
 
@@ -93,14 +93,14 @@ void ADCf302x8::initADC(uint8_t num_channels) {
     halADC.Init.DataAlign = ADC_DATAALIGN_RIGHT;
     halADC.Init.ScanConvMode = ADC_SCAN_ENABLE;
     halADC.Init.EOCSelection = ADC_EOC_SEQ_CONV;
-    halADC.Init.LowPowerAutoWait = DISABLE;  // Wait for the previous value to be written by DMA before beginning
-                                             // next transfer.  Not recommended for DMA.
+    halADC.Init.LowPowerAutoWait = DISABLE;// Wait for the previous value to be written by DMA before beginning
+                                           // next transfer.  Not recommended for DMA.
     halADC.Init.ContinuousConvMode = ENABLE;
     halADC.Init.NbrOfConversion = num_channels;
     halADC.Init.DiscontinuousConvMode = DISABLE;
-    halADC.Init.NbrOfDiscConversion = 1;  // Parameter discarded when Discontinuous Conv Mode is Disabled
+    halADC.Init.NbrOfDiscConversion = 1;// Parameter discarded when Discontinuous Conv Mode is Disabled
     halADC.Init.ExternalTrigConv = ADC_SOFTWARE_START;
-    halADC.Init.ExternalTrigConvEdge = ADC_EXTERNALTRIGCONVEDGE_NONE;  // Parameter discared when set to ADC_SOFTWARE_START
+    halADC.Init.ExternalTrigConvEdge = ADC_EXTERNALTRIGCONVEDGE_NONE;// Parameter discared when set to ADC_SOFTWARE_START
     halADC.Init.DMAContinuousRequests = ENABLE;
     halADC.Init.Overrun = ADC_OVR_DATA_OVERWRITTEN;
 

--- a/src/io/platform/f3xx/f302x8/ADCf302x8.cpp
+++ b/src/io/platform/f3xx/f302x8/ADCf302x8.cpp
@@ -87,9 +87,9 @@ void ADCf302x8::initADC() {
     halADC.Init.Resolution = ADC_RESOLUTION_12B;
     halADC.Init.DataAlign = ADC_DATAALIGN_RIGHT;
     halADC.Init.ScanConvMode = ADC_SCAN_ENABLE;
-    halADC.Init.EOCSelection = ADC_EOC_SEQ_CONV;  // Trigger end-of-conversion only after entire sequence
-                                                  // Causes DMA interrupt to trigger.  Only DMA once per sequence
-    halADC.Init.LowPowerAutoWait = DISABLE;
+    halADC.Init.EOCSelection = ADC_EOC_SINGLE_CONV;
+    halADC.Init.LowPowerAutoWait = ENABLE;  // Wait for the previous value to be written by DMA before beginning
+                                            // next transfer
     halADC.Init.ContinuousConvMode = ENABLE;
     halADC.Init.NbrOfConversion = MAX_CHANNELS;
     halADC.Init.DiscontinuousConvMode = DISABLE;

--- a/src/io/platform/f3xx/f302x8/ADCf302x8.cpp
+++ b/src/io/platform/f3xx/f302x8/ADCf302x8.cpp
@@ -35,7 +35,7 @@ ADCf302x8::ADCf302x8(Pin pin) : ADC(pin) {
     static uint8_t rank = 1;
 
     // Initialization of the HAL ADC should only take place once since there is
-    // only one ADC device which has muliple channels supported.
+    // only one ADC device which has multiple channels supported.
     if (!halADCisInit) {
         __HAL_RCC_DMA1_CLK_ENABLE();
 
@@ -52,7 +52,7 @@ ADCf302x8::ADCf302x8(Pin pin) : ADC(pin) {
     addChannel(rank);
     initDMA();
 
-    HAL_ADC_Start_DMA(&halADC, reinterpret_cast<uint32_t*>(&buffer[0]),
+    HAL_ADC_Start_DMA(&halADC, (uint32_t *)(&buffer[0]),
                       MAX_CHANNELS);
 
     rank++;
@@ -78,7 +78,7 @@ float ADCf302x8::readPercentage() {
 }
 
 void ADCf302x8::initADC() {
-    halADC.Instance = ADC1;// Only ADC the F3 supportes
+    halADC.Instance = ADC1;  // Only ADC the F3 supports
 
     halADC.Init.ClockPrescaler = ADC_CLOCK_ASYNC_DIV1;
     halADC.Init.Resolution = ADC_RESOLUTION_12B;
@@ -87,7 +87,7 @@ void ADCf302x8::initADC() {
     halADC.Init.EOCSelection = DISABLE;
     halADC.Init.LowPowerAutoWait = DISABLE;
     halADC.Init.ContinuousConvMode = ENABLE;
-    halADC.Init.NbrOfConversion = MAX_CHANNELS;
+    halADC.Init.NbrOfConversion = 1;
     halADC.Init.DiscontinuousConvMode = DISABLE;
     halADC.Init.NbrOfDiscConversion = 1;
     halADC.Init.ExternalTrigConv = ADC_SOFTWARE_START;
@@ -188,6 +188,8 @@ void ADCf302x8::addChannel(uint8_t rank) {
     adcChannel.Rank = rank;
     adcChannel.SamplingTime = ADC_SAMPLETIME_601CYCLES_5;
     adcChannel.Offset = 0;
+    adcChannel.SingleDiff = ADC_SINGLE_ENDED;
+    adcChannel.OffsetNumber = ADC_OFFSET_NONE;
 
     HAL_ADC_ConfigChannel(&halADC, &adcChannel);
 }

--- a/src/io/platform/f3xx/f302x8/ADCf302x8.cpp
+++ b/src/io/platform/f3xx/f302x8/ADCf302x8.cpp
@@ -33,7 +33,13 @@ ADCf302x8::ADCf302x8(Pin pin) : ADC(pin) {
     // Flag representing if the ADC has been configured yet
     static bool halADCisInit = false;
     // "Rank" represents the order in which the channels are added
+    // Also represents the total number of added channels
     static uint8_t rank = 1;
+
+    // Maximum number of ADC channels have already been added
+    if (rank == MAX_CHANNELS) {
+        return;
+    }
 
     // Initialization of the HAL ADC should only take place once since there is
     // only one ADC device which has multiple channels supported.
@@ -89,7 +95,7 @@ void ADCf302x8::initADC(uint8_t num_channels) {
     halADC.Init.ScanConvMode = ADC_SCAN_ENABLE;
     halADC.Init.EOCSelection = ADC_EOC_SEQ_CONV;
     halADC.Init.LowPowerAutoWait = DISABLE;  // Wait for the previous value to be written by DMA before beginning
-                                            // next transfer
+                                             // next transfer.  Not recommended for DMA.
     halADC.Init.ContinuousConvMode = ENABLE;
     halADC.Init.NbrOfConversion = num_channels;
     halADC.Init.DiscontinuousConvMode = DISABLE;

--- a/src/io/platform/f3xx/f302x8/ADCf302x8.cpp
+++ b/src/io/platform/f3xx/f302x8/ADCf302x8.cpp
@@ -50,7 +50,6 @@ ADCf302x8::ADCf302x8(Pin pin) : ADC(pin) {
         __HAL_RCC_DMA1_CLK_ENABLE();
         halADCisInit = true;
     }
-
     initADC(rank);
 
     dmaHandle = &this->halDMA;
@@ -67,7 +66,7 @@ ADCf302x8::ADCf302x8(Pin pin) : ADC(pin) {
 
 float ADCf302x8::read() {
     float percentage = readPercentage();
-    return percentage * MAX_VOLTAGE;
+    return percentage * VREF_POS;
 }
 
 uint32_t ADCf302x8::readRaw() {

--- a/src/io/platform/f3xx/f302x8/ADCf302x8.cpp
+++ b/src/io/platform/f3xx/f302x8/ADCf302x8.cpp
@@ -50,11 +50,11 @@ ADCf302x8::ADCf302x8(Pin pin) : ADC(pin) {
     }
 
     addChannel(rank);
-    initDMA();
 
 //    HAL_ADC_Stop_DMA(&halADC);
     static int num = 1;
     if (num > 1) {
+        initDMA();
         HAL_ADC_Start_DMA(&halADC, (uint32_t *) (&buffer[0]),
                           MAX_CHANNELS);
     }
@@ -93,7 +93,8 @@ void ADCf302x8::initADC() {
     halADC.Init.Resolution = ADC_RESOLUTION_12B;
     halADC.Init.DataAlign = ADC_DATAALIGN_RIGHT;
     halADC.Init.ScanConvMode = ADC_SCAN_ENABLE;
-    halADC.Init.EOCSelection = ADC_EOC_SINGLE_CONV;
+    halADC.Init.EOCSelection = ADC_EOC_SEQ_CONV;  // Trigger end-of-conversion only after entire sequence
+                                                  // Causes DMA interrupt to trigger.  Only DMA once per sequence
     halADC.Init.LowPowerAutoWait = DISABLE;
     halADC.Init.ContinuousConvMode = ENABLE;
     halADC.Init.NbrOfConversion = MAX_CHANNELS;

--- a/src/io/platform/f3xx/f302x8/ADCf302x8.cpp
+++ b/src/io/platform/f3xx/f302x8/ADCf302x8.cpp
@@ -41,26 +41,20 @@ ADCf302x8::ADCf302x8(Pin pin) : ADC(pin) {
 
         initADC();
 
-        initDMA();
-
         dmaHandle = &this->halDMA;
         adcHandle = &this->halADC;
 
         halADCisInit = true;
+    } else {
+        HAL_ADC_Stop_DMA(&halADC);
+        HAL_DMA_DeInit(&halDMA);
     }
 
     addChannel(rank);
 
-//    HAL_ADC_Stop_DMA(&halADC);
-    static int num = 1;
-    if (num > 1) {
-        initDMA();
-        HAL_ADC_Start_DMA(&halADC, (uint32_t *) (&buffer[0]),
-                          MAX_CHANNELS);
-    }
-    else {
-        num++;
-    }
+    initDMA();
+    HAL_ADC_Start_DMA(&halADC, (uint32_t *) (&buffer[0]),
+                      MAX_CHANNELS);
 
     rank++;
 }


### PR DESCRIPTION
Fixed the bug where the ADC would not generate the correct values.  
- The main fix applied was to only run the ADC for the number of conversions as ADC channels configured.  
- The DMA buffer was also updated to have this same effective size.
- Some modifications were also made to stop and de-init peripherals when adding new channels.