### PR TITLE
I2C and Error

### DIFF
--- a/include/EVT/io/I2C.hpp
+++ b/include/EVT/io/I2C.hpp
@@ -3,6 +3,13 @@
 
 #include <stdint.h>
 
+#define I2C_RETURN_IF_ERR(func) {\
+    I2C::I2CStatus status = func;\
+    if (status != I2C::I2CStatus::OK) {\
+        return status;\
+    }\
+}
+
 namespace EVT::core::IO {
 // Forward declarations:
 // The different pins are hardware specific. Forward declaration to allow
@@ -11,6 +18,18 @@ enum class Pin;
 
 class I2C {
 public:
+    /**
+     * Represents potential errors that may take place when using the I2C
+     * interface. Each method that interfaces over I2C could potentially
+     * return one of these errors, or OK if no error.
+     */
+    enum class I2CStatus {
+        TIMEOUT = 0,
+        BUSY = 1,
+        ERROR = 2,
+        OK = 3
+    };
+
     /**
      * Make an instance of an I2C interface that will use the given pins
      * for clock and data lines.
@@ -25,16 +44,18 @@ public:
      *
      * @param addr[in] The 7 bit unshifted I2C address to write to
      * @param byte[in] The value to write over I2C
+     * @return The status of making the write request
      */
-    virtual void write(uint8_t addr, uint8_t byte) = 0;
+    virtual I2CStatus write(uint8_t addr, uint8_t byte) = 0;
 
     /**
      * Read a single byte back from the I2C bus.
      *
      * @param addr[in] The 7 bit unshifted I2C address to read from
-     * @return The byte read from the address
+     * @param output[out] The location to store the result from the read
+     * @return The status of making the read request
      */
-    virtual uint8_t read(uint8_t addr) = 0;
+    virtual I2CStatus read(uint8_t addr, uint8_t* output) = 0;
 
     /**
      * Write out multiple bytes over I2C. Each byte will be written one by
@@ -43,8 +64,9 @@ public:
      * @param addr[in] The 7 bit unshifted I2C address to write to
      * @param bytes[in] The bytes to write out over I2C
      * @param length[in] The number of bytes to write out
+     * @return The status of making the write request
      */
-    void write(uint8_t addr, uint8_t* bytes, uint8_t length);
+    I2CStatus write(uint8_t addr, uint8_t* bytes, uint8_t length);
 
     /**
      * Read multiple bytes from an I2C device.
@@ -52,8 +74,9 @@ public:
      * @param addr[in] The 7 bit unshifted I2C address to write to
      * @param bytes[out] The buffer to fill with the read in bytes
      * @param length[in] The number of bytes to read
+     * @return The status of making the read request
      */
-    void read(uint8_t addr, uint8_t* bytes, uint8_t length);
+    I2CStatus read(uint8_t addr, uint8_t* bytes, uint8_t length);
 
     /**
      * Write a value to a register has that 8 bit addresses and 8 bit values.
@@ -61,17 +84,19 @@ public:
      * @param addr The 7 bit unshifted I2C address to write to
      * @param reg The 8 bit register
      * @param byte The byte to write out
+     * @return The status of attepting to write out to a register
      */
-    void writeReg(uint8_t addr, uint8_t reg, uint8_t byte);
+    I2CStatus writeReg(uint8_t addr, uint8_t reg, uint8_t byte);
 
     /**
      * Read a value from a register that has an 8 bit address and 8 bit value.
      *
      * @param addr[in] The 7 bit unshifted I2C address to read from
      * @param reg[in] The 8 bit register
+     * @param output[out] Will store the value of the read request
      * @return The 8 bit value of the register
      */
-    uint8_t readReg(uint8_t addr, uint8_t reg);
+    I2CStatus readReg(uint8_t addr, uint8_t reg, uint8_t* output);
 
     /**
      * Write out a multi byte register value.
@@ -81,8 +106,9 @@ public:
      * @param regLength[in] The number of bytes in the register address
      * @param bytes[in] The data to write out
      * @param length[in] The number of bytes in the data
+     * @return The status of attempting to write out to the register
      */
-    void writeReg(uint8_t addr, uint8_t* reg, uint8_t regLength,
+    I2CStatus writeReg(uint8_t addr, uint8_t* reg, uint8_t regLength,
                   uint8_t* bytes, uint8_t length);
 
     /**
@@ -93,8 +119,9 @@ public:
      * @param regLength[in] The size in bytes of the register
      * @param bytes[out] The bytes read from the register
      * @param length[in] The size of the data returned by the register in bytes
+     * @return The status of reading from the register
      */
-    void readReg(uint8_t addr, uint8_t* reg, uint8_t regLength,
+    I2CStatus readReg(uint8_t addr, uint8_t* reg, uint8_t regLength,
                  uint8_t* bytes, uint8_t length);
 
     /**
@@ -106,22 +133,26 @@ public:
      * @param memAddress[in] The word containing the register to write to
      * @param byte[in] The data to write out
      * @param memAddSize[in] The number of bytes in the memory address (1 or 2)
+     * @return The status of writing out a memory register
      */
-    virtual void writeMemReg(uint8_t addr, uint32_t memAddress, uint8_t byte, uint16_t memAddSize,
-                             uint8_t maxWriteTime) = 0;
+    virtual I2CStatus writeMemReg(uint8_t addr, uint32_t memAddress,
+                                  uint8_t byte, uint16_t memAddSize,
+                                  uint8_t maxWriteTime) = 0;
 
     /**
      * Read a single byte from a register in memory.
-     * This is a separate method from normal I2C communication because memory read/write methods use
+     * This is a separate method from normal I2C communication because
+     * memory read/write methods use
      * a slightly different I2C pattern.
      *
      * @param addr[in] The 7 bit unshifted I2C address to read from
      * @param memAddress[in] The word containing the register to read from
      * @param byte[out] The byte read from memory
      * @param memAddSize[in] The number of bytes in the memory address (1 or 2)
+     * @param output[out] The value read back from the memory register
      */
-    virtual uint8_t readMemReg(uint8_t addr, uint32_t memAddress, uint8_t* byte,
-                               uint16_t memAddSize) = 0;
+    virtual I2CStatus readMemReg(uint8_t addr, uint32_t memAddress,
+                                 uint8_t* byte, uint16_t memAddSize) = 0;
 
     /**
      * Write a number of bytes to consecutive registers in memory, starting at a specified register.
@@ -133,9 +164,12 @@ public:
      * @param byte[in] The list of data to write out
      * @param size[in] The number of bytes to be written
      * @param memAddSize[in] The number of bytes in the memory address (1 or 2)
+     * @return The status of writing out to the memory address
      */
-    virtual void writeMemReg(uint8_t addr, uint32_t memAddress, uint8_t* byte, uint8_t size,
-                             uint16_t memAddSize, uint8_t maxWriteTime) = 0;
+    virtual I2CStatus writeMemReg(uint8_t addr, uint32_t memAddress,
+                                  uint8_t* byte, uint8_t size,
+                                  uint16_t memAddSize,
+                                  uint8_t maxWriteTime) = 0;
 
     /**
      * Read a number of consecutive bytes, starting at a specified register in memory.
@@ -147,9 +181,12 @@ public:
      * @param byte[out] The list of bytes read from memory
      * @param size[in] The number of bytes to be read
      * @param memAddSize[in] The number of bytes in the memory address (1 or 2)
+     * @param output[out] The value to store the read back memory
+     * @return The status of reading from the memory address;
      */
-    virtual uint8_t readMemReg(uint8_t addr, uint32_t memAddress, uint8_t* byte, uint8_t size,
-                               uint16_t memAddSize) = 0;
+    virtual I2CStatus readMemReg(uint8_t addr, uint32_t memAddress,
+                                 uint8_t* byte, uint8_t size,
+                                 uint16_t memAddSize) = 0;
 
 private:
     /** The I2C clock line */

--- a/include/EVT/io/I2C.hpp
+++ b/include/EVT/io/I2C.hpp
@@ -3,12 +3,13 @@
 
 #include <stdint.h>
 
-#define I2C_RETURN_IF_ERR(func) {\
-    I2C::I2CStatus status = func;\
-    if (status != I2C::I2CStatus::OK) {\
-        return status;\
-    }\
-}
+#define I2C_RETURN_IF_ERR(func)             \
+    {                                       \
+        I2C::I2CStatus status = func;       \
+        if (status != I2C::I2CStatus::OK) { \
+            return status;                  \
+        }                                   \
+    }
 
 namespace EVT::core::IO {
 // Forward declarations:
@@ -109,7 +110,7 @@ public:
      * @return The status of attempting to write out to the register
      */
     I2CStatus writeReg(uint8_t addr, uint8_t* reg, uint8_t regLength,
-                  uint8_t* bytes, uint8_t length);
+                       uint8_t* bytes, uint8_t length);
 
     /**
      * Read a value from a register.
@@ -122,7 +123,7 @@ public:
      * @return The status of reading from the register
      */
     I2CStatus readReg(uint8_t addr, uint8_t* reg, uint8_t regLength,
-                 uint8_t* bytes, uint8_t length);
+                      uint8_t* bytes, uint8_t length);
 
     /**
      * Write a single byte to a register in memory.

--- a/include/EVT/io/platform/f3xx/f302x8/I2Cf302x8.hpp
+++ b/include/EVT/io/platform/f3xx/f302x8/I2Cf302x8.hpp
@@ -21,11 +21,11 @@ public:
 
     I2C::I2CStatus write(uint8_t addr, uint8_t byte) override;
 
-    I2C::I2CStatus read(uint8_t addr, uint8_t*output) override;
+    I2C::I2CStatus read(uint8_t addr, uint8_t* output) override;
 
     I2C::I2CStatus write(uint8_t addr, uint8_t* bytes, uint8_t length);
 
-    I2C::I2CStatus read(uint8_t addr, uint8_t*bytes, uint8_t length);
+    I2C::I2CStatus read(uint8_t addr, uint8_t* bytes, uint8_t length);
 
     I2C::I2CStatus writeMemReg(uint8_t addr, uint32_t memAddress,
                                uint8_t byte, uint16_t memAddSize,

--- a/include/EVT/io/platform/f3xx/f302x8/I2Cf302x8.hpp
+++ b/include/EVT/io/platform/f3xx/f302x8/I2Cf302x8.hpp
@@ -19,136 +19,30 @@ public:
      */
     I2Cf302x8(Pin sclPin, Pin sdaPin);
 
-    /**
-     * Write a single byte out over I2C.
-     *
-     * @param addr[in] The 7 bit unshifted I2C address to write to
-     * @param byte[in] The value to write over I2C.
-     */
-    void write(uint8_t addr, uint8_t byte);
+    I2C::I2CStatus write(uint8_t addr, uint8_t byte) override;
 
-    /**
-     * Read a single byte back from the I2C bus.
-     *
-     * @param addr[in] The 7 bit unshifted I2C address to read from.
-     * @return The byte read from the address.
-     */
-    uint8_t read(uint8_t addr);
+    I2C::I2CStatus read(uint8_t addr, uint8_t*output) override;
 
-    /**
-     * Write out multiple bytes over I2C. Each byte will be written one by
-     * one.
-     *
-     * @param addr[in] The 7 bit unshifted I2C address to write to.
-     * @param bytes[in] The bytes to write out over I2C.
-     * @param length[in] The number of bytes to write out.
-     */
-    void write(uint8_t addr, uint8_t* bytes, uint8_t length);
+    I2C::I2CStatus write(uint8_t addr, uint8_t* bytes, uint8_t length);
 
-    /**
-     * Read multiple bytes from an I2C device.
-     *
-     * @param addr[in] The 7 bit unshifted I2C address to write to
-     * @param bytes[out] The buffer to fill with the read in bytes.
-     * @param length[in] The number of bytes to read.
-     */
-    void read(uint8_t addr, uint8_t* bytes, uint8_t length);
+    I2C::I2CStatus read(uint8_t addr, uint8_t*bytes, uint8_t length);
 
-    /**
-     * Write a value to a register has that 8 bit addresses and 8 bit values.
-     *
-     * @param addr[in] The 7 bit unshifted I2C address to write to.
-     * @param reg[in] The 8 bit register
-     * @param byte[in] The byte to write out
-     */
-    void writeReg(uint8_t addr, uint8_t reg, uint8_t byte);
+    I2C::I2CStatus writeMemReg(uint8_t addr, uint32_t memAddress,
+                               uint8_t byte, uint16_t memAddSize,
+                               uint8_t maxWriteTime);
 
-    /**
-     * Read a value from a register that has an 8 bit address and 8 bit value
-     *
-     * @param addr[in] The 7 bit unshifted I2C address to read from.
-     * @param reg[in] The 8 bit register
-     * @return The 8 bit value of the register.
-     */
-    uint8_t readReg(uint8_t addr, uint8_t reg);
+    I2C::I2CStatus readMemReg(uint8_t addr, uint32_t memAddress,
+                              uint8_t* byte,
+                              uint16_t memAddSize);
 
-    /**
-     * Write out a multi byte register value.
-     *
-     * @param addr[in] The 7 bit unshifted I2C address to write to
-     * @param reg[in] The register bytes
-     * @param regLength[in] The number of bytes in the register address
-     * @param bytes[in] The data to write out
-     * @param length[in] The number of bytes in the data
-     */
-    void writeReg(uint8_t addr, uint8_t* reg, uint8_t regLength,
-                  uint8_t* bytes, uint8_t length);
+    I2C::I2CStatus writeMemReg(uint8_t addr, uint32_t memAddress,
+                               uint8_t* bytes, uint8_t size,
+                               uint16_t memAddSize,
+                               uint8_t maxWriteTime);
 
-    /**
-     * Read a value from a register.
-     *
-     * @param addr[in] The 7 bit unshifted I2C address to read from.
-     * @param reg[in] The bytes containing the register to read from
-     * @param regLength[in] The size in bytes of the register
-     * @param bytes[out] The bytes read from the register
-     * @param length[in] The size of the data returned by the register in bytes
-     */
-    void readReg(uint8_t addr, uint8_t* reg, uint8_t regLength,
-                 uint8_t* bytes, uint8_t length);
-
-    /**
-     * Write a single byte to a register in memory.
-     * This is a separate method from normal I2C communication because memory read/write methods use
-     * a slightly different I2C pattern.
-     *
-     * @param addr[in] The 7 bit unshifted I2C address to write to
-     * @param memAddress[in] The word containing the register to write to
-     * @param byte[in] The data to write out
-     * @param memAddSize[in] The number of bytes in the memory address (1 or 2)
-     */
-    void writeMemReg(uint8_t addr, uint32_t memAddress, uint8_t byte, uint16_t memAddSize,
-                     uint8_t maxWriteTime) override;
-
-    /**
-     * Read a single byte from a register in memory.
-     * This is a separate method from normal I2C communication because memory read/write methods use
-     * a slightly different I2C pattern.
-     *
-     * @param addr[in] The 7 bit unshifted I2C address to read from
-     * @param memAddress[in] The word containing the register to read from
-     * @param byte[out] The byte read from memory
-     * @param memAddSize[in] The number of bytes in the memory address (1 or 2)
-     */
-    uint8_t readMemReg(uint8_t addr, uint32_t memAddress, uint8_t* byte,
-                       uint16_t memAddSize) override;
-
-    /**
-     * Write a number of bytes to consecutive registers in memory, starting at a specified register.
-     * This is a separate method from normal I2C communication because memory read/write methods use
-     * a slightly different I2C pattern.
-     *
-     * @param addr[in] The 7 bit unshifted I2C address to write to
-     * @param memAddress[in] The word containing the register to start writing to
-     * @param byte[in] The list of data to write out
-     * @param size[in] The number of bytes to be written
-     * @param memAddSize[in] The number of bytes in the memory address (1 or 2)
-     */
-    void writeMemReg(uint8_t addr, uint32_t memAddress, uint8_t* byte, uint8_t size,
-                     uint16_t memAddSize, uint8_t maxWriteTime) override;
-
-    /**
-     * Read a number of consecutive bytes, starting at a specified register in memory.
-     * This is a separate method from normal I2C communication because memory read/write methods use
-     * a slightly different I2C pattern.
-     *
-     * @param addr[in] The 7 bit unshifted I2C address to read from
-     * @param memAddress[in] The word containing the register to start reading from
-     * @param byte[out] The list of bytes read from memory
-     * @param size[in] The number of bytes to be read
-     * @param memAddSize[in] The number of bytes in the memory address (1 or 2)
-     */
-    uint8_t readMemReg(uint8_t addr, uint32_t memAddress, uint8_t* byte, uint8_t size,
-                       uint16_t memAddSize) override;
+    I2C::I2CStatus readMemReg(uint8_t addr, uint32_t memAddress,
+                              uint8_t* bytes, uint8_t size,
+                              uint16_t memAddSize);
 
 private:
     constexpr static uint32_t DEFAULT_I2C_FREQ = 100000;
@@ -156,6 +50,14 @@ private:
     constexpr static uint32_t DEFAULT_I2C_TIMEOUT = 100;
     /** Interface into the HAL */
     I2C_HandleTypeDef halI2C;
+
+    /**
+     * Convert the STM HAL status to an I2C::I2CStatus
+     *
+     * @param The HAL status
+     * @return The I2C::I2CStatus
+     */
+    I2C::I2CStatus halToI2CStatus(HAL_StatusTypeDef halStatus);
 };
 
 }// namespace EVT::core::IO

--- a/samples/i2c/main.cpp
+++ b/samples/i2c/main.cpp
@@ -33,9 +33,23 @@ int main() {
 
     while (1) {
         uart.printf("Requesting first byte\n\r");
-        uint8_t oValue = i2c.readReg(I2C_SLAVE_ADDR, O_REGISTER);
+
+        // Read the value of 'o'
+        uint8_t oValue;
+        IO::I2C::I2CStatus status = i2c.readReg(I2C_SLAVE_ADDR, O_REGISTER, &oValue);
+        if (status != IO::I2C::I2CStatus::OK) {
+            uart.printf("Failed read 'o' register\n\r");
+            break;
+        }
+
+
         uart.printf("Reading second bytes\n\r");
-        uint8_t kValue = i2c.readReg(I2C_SLAVE_ADDR, K_REGISTER);
+        uint8_t kValue;
+        status = i2c.readReg(I2C_SLAVE_ADDR, K_REGISTER, &kValue);
+        if (status != IO::I2C::I2CStatus::OK) {
+            uart.printf("Failed to read 'k' register\n\r");
+            break;
+        }
 
         uart.printf("Bytes Read: %c %c\n\r", oValue, kValue);
 

--- a/samples/i2c/main.cpp
+++ b/samples/i2c/main.cpp
@@ -38,16 +38,19 @@ int main() {
         uint8_t oValue;
         IO::I2C::I2CStatus status = i2c.readReg(I2C_SLAVE_ADDR, O_REGISTER, &oValue);
         if (status != IO::I2C::I2CStatus::OK) {
-            uart.printf("Failed read 'o' register\n\r");
+            uart.printf("Failed read 'o' register with I2C::I2CStatus: %d\n\r",
+                    status);
             break;
         }
 
-
         uart.printf("Reading second bytes\n\r");
+
+        // Read the value of 'k'
         uint8_t kValue;
         status = i2c.readReg(I2C_SLAVE_ADDR, K_REGISTER, &kValue);
         if (status != IO::I2C::I2CStatus::OK) {
-            uart.printf("Failed to read 'k' register\n\r");
+            uart.printf("Failed read 'k' register with I2C::I2CStatus: %d\n\r",
+                    status);
             break;
         }
 

--- a/samples/i2c/main.cpp
+++ b/samples/i2c/main.cpp
@@ -39,7 +39,7 @@ int main() {
         IO::I2C::I2CStatus status = i2c.readReg(I2C_SLAVE_ADDR, O_REGISTER, &oValue);
         if (status != IO::I2C::I2CStatus::OK) {
             uart.printf("Failed read 'o' register with I2C::I2CStatus: %d\n\r",
-                    status);
+                        status);
             break;
         }
 
@@ -50,7 +50,7 @@ int main() {
         status = i2c.readReg(I2C_SLAVE_ADDR, K_REGISTER, &kValue);
         if (status != IO::I2C::I2CStatus::OK) {
             uart.printf("Failed read 'k' register with I2C::I2CStatus: %d\n\r",
-                    status);
+                        status);
             break;
         }
 

--- a/src/io/I2C.cpp
+++ b/src/io/I2C.cpp
@@ -18,7 +18,7 @@ I2C::I2CStatus I2C::write(uint8_t addr, uint8_t* bytes, uint8_t length) {
 
 I2C::I2CStatus I2C::read(uint8_t addr, uint8_t* bytes, uint8_t length) {
     for (int i = 0; i < length; i++)
-       I2C_RETURN_IF_ERR(read(addr, &bytes[i]));
+        I2C_RETURN_IF_ERR(read(addr, &bytes[i]));
     return I2C::I2CStatus::OK;
 }
 
@@ -52,7 +52,7 @@ I2C::I2CStatus I2C::writeReg(uint8_t addr, uint8_t* reg, uint8_t regLength,
  * starting with the LSB.
  */
 I2C::I2CStatus I2C::readReg(uint8_t addr, uint8_t* reg, uint8_t regLength,
-                  uint8_t* bytes, uint8_t length) {
+                            uint8_t* bytes, uint8_t length) {
     // Write out register address
     for (int i = 0; i < regLength; i++)
         I2C_RETURN_IF_ERR(write(addr, reg[i]));

--- a/src/io/I2C.cpp
+++ b/src/io/I2C.cpp
@@ -10,34 +10,39 @@ namespace EVT::core::IO {
 
 I2C::I2C(Pin sclPin, Pin sdaPin) : sclPin(sclPin), sdaPin(sdaPin) {}
 
-void I2C::write(uint8_t addr, uint8_t* bytes, uint8_t length) {
+I2C::I2CStatus I2C::write(uint8_t addr, uint8_t* bytes, uint8_t length) {
     for (int i = 0; i < length; i++)
-        write(addr, bytes[i]);
+        I2C_RETURN_IF_ERR(write(addr, bytes[i]));
+    return I2C::I2CStatus::OK;
 }
 
-void I2C::read(uint8_t addr, uint8_t* bytes, uint8_t length) {
+I2C::I2CStatus I2C::read(uint8_t addr, uint8_t* bytes, uint8_t length) {
     for (int i = 0; i < length; i++)
-        bytes[i] = read(addr);
+       I2C_RETURN_IF_ERR(read(addr, &bytes[i]));
+    return I2C::I2CStatus::OK;
 }
 
-void I2C::writeReg(uint8_t addr, uint8_t reg, uint8_t byte) {
-    write(addr, reg);
-    write(addr, byte);
+I2C::I2CStatus I2C::writeReg(uint8_t addr, uint8_t reg, uint8_t byte) {
+
+    I2C_RETURN_IF_ERR(write(addr, reg));
+    I2C_RETURN_IF_ERR(write(addr, byte));
+
+    return I2C::I2CStatus::OK;
 }
 
 /**
  * Reading a register usually involves writing out a byte then reading
  * a byte.
  */
-uint8_t I2C::readReg(uint8_t addr, uint8_t reg) {
-    write(addr, reg);
-    return read(addr);
+I2C::I2CStatus I2C::readReg(uint8_t addr, uint8_t reg, uint8_t* output) {
+    I2C_RETURN_IF_ERR(write(addr, reg));
+    return read(addr, output);
 }
 
-void I2C::writeReg(uint8_t addr, uint8_t* reg, uint8_t regLength,
-                   uint8_t* bytes, uint8_t length) {
-    write(addr, reg, regLength);
-    write(addr, bytes, length);
+I2C::I2CStatus I2C::writeReg(uint8_t addr, uint8_t* reg, uint8_t regLength,
+                             uint8_t* bytes, uint8_t length) {
+    I2C_RETURN_IF_ERR(write(addr, reg, regLength));
+    return write(addr, bytes, length);
 }
 
 /**
@@ -46,14 +51,15 @@ void I2C::writeReg(uint8_t addr, uint8_t* reg, uint8_t regLength,
  * of 8 bytes starting with the MSB. Reading the response is also done
  * starting with the LSB.
  */
-void I2C::readReg(uint8_t addr, uint8_t* reg, uint8_t regLength,
+I2C::I2CStatus I2C::readReg(uint8_t addr, uint8_t* reg, uint8_t regLength,
                   uint8_t* bytes, uint8_t length) {
     // Write out register address
     for (int i = 0; i < regLength; i++)
-        write(addr, reg[i]);
+        I2C_RETURN_IF_ERR(write(addr, reg[i]));
     // Read in response
     for (int i = 0; i < length; i++)
-        bytes[i] = read(addr);
+        I2C_RETURN_IF_ERR(read(addr, &bytes[i]));
+    return I2C::I2CStatus::OK;
 }
 
 }// namespace EVT::core::IO

--- a/src/io/platform/f3xx/f302x8/I2Cf302x8.cpp
+++ b/src/io/platform/f3xx/f302x8/I2Cf302x8.cpp
@@ -112,7 +112,7 @@ I2C::I2CStatus I2Cf302x8::read(uint8_t addr, uint8_t* output) {
 I2C::I2CStatus I2Cf302x8::write(uint8_t addr, uint8_t* bytes, uint8_t length) {
     HAL_StatusTypeDef status = HAL_I2C_Master_Transmit(&halI2C, addr << 1,
                                                        bytes, length,
-                                                        DEFAULT_I2C_TIMEOUT);
+                                                       DEFAULT_I2C_TIMEOUT);
     return halToI2CStatus(status);
 }
 
@@ -121,10 +121,10 @@ I2C::I2CStatus I2Cf302x8::write(uint8_t addr, uint8_t* bytes, uint8_t length) {
  * this via the HAL.
  */
 I2C::I2CStatus I2Cf302x8::read(uint8_t addr, uint8_t* bytes, uint8_t length) {
-     HAL_StatusTypeDef status = HAL_I2C_Master_Receive(&halI2C, addr << 1,
-                                                       bytes, length,
-                                                       DEFAULT_I2C_TIMEOUT);
-     return halToI2CStatus(status);
+    HAL_StatusTypeDef status = HAL_I2C_Master_Receive(&halI2C, addr << 1,
+                                                      bytes, length,
+                                                      DEFAULT_I2C_TIMEOUT);
+    return halToI2CStatus(status);
 }
 
 I2C::I2CStatus I2Cf302x8::writeMemReg(uint8_t addr, uint32_t memAddress,
@@ -152,10 +152,10 @@ I2C::I2CStatus I2Cf302x8::writeMemReg(uint8_t addr, uint32_t memAddress,
                                       uint16_t memAddSize,
                                       uint8_t maxWriteTime) {
     uint16_t memAddress16 = memAddress;
-    HAL_StatusTypeDef status =  HAL_I2C_Mem_Write(&halI2C, addr << 1,
-                                                  memAddress16, memAddSize,
-                                                  bytes, size,
-                                                  DEFAULT_I2C_TIMEOUT);
+    HAL_StatusTypeDef status = HAL_I2C_Mem_Write(&halI2C, addr << 1,
+                                                 memAddress16, memAddSize,
+                                                 bytes, size,
+                                                 DEFAULT_I2C_TIMEOUT);
     return halToI2CStatus(status);
 }
 
@@ -171,18 +171,18 @@ I2C::I2CStatus I2Cf302x8::readMemReg(uint8_t addr, uint32_t memAddress,
 }
 
 I2C::I2CStatus I2Cf302x8::halToI2CStatus(HAL_StatusTypeDef halStatus) {
-    switch(halStatus) {
-        case HAL_OK:
-            return I2C::I2CStatus::OK;
-        case HAL_ERROR:
-            return I2C::I2CStatus::ERROR;
-        case HAL_BUSY:
-            return I2C::I2CStatus::BUSY;
-        case HAL_TIMEOUT:
-            return I2C::I2CStatus::TIMEOUT;
-        // Should not get here
-        default:
-            return I2C::I2CStatus::ERROR;
+    switch (halStatus) {
+    case HAL_OK:
+        return I2C::I2CStatus::OK;
+    case HAL_ERROR:
+        return I2C::I2CStatus::ERROR;
+    case HAL_BUSY:
+        return I2C::I2CStatus::BUSY;
+    case HAL_TIMEOUT:
+        return I2C::I2CStatus::TIMEOUT;
+    // Should not get here
+    default:
+        return I2C::I2CStatus::ERROR;
     }
 }
 

--- a/src/io/platform/f3xx/f302x8/I2Cf302x8.cpp
+++ b/src/io/platform/f3xx/f302x8/I2Cf302x8.cpp
@@ -91,57 +91,99 @@ I2Cf302x8::I2Cf302x8(Pin sclPin, Pin sdaPin) : I2C(sclPin, sdaPin) {
     HAL_I2C_Init(&halI2C);
 }
 
-void I2Cf302x8::write(uint8_t addr, uint8_t byte) {
-    HAL_I2C_Master_Transmit(&halI2C, addr << 1, &byte, 1,
-                            DEFAULT_I2C_TIMEOUT);
+I2C::I2CStatus I2Cf302x8::write(uint8_t addr, uint8_t byte) {
+    HAL_StatusTypeDef status = HAL_I2C_Master_Transmit(&halI2C, addr << 1,
+                                                       &byte, 1,
+                                                       DEFAULT_I2C_TIMEOUT);
+    return halToI2CStatus(status);
 }
 
-uint8_t I2Cf302x8::read(uint8_t addr) {
-    uint8_t data;
-    HAL_I2C_Master_Receive(&halI2C, addr << 1, &data, 1,
-                           DEFAULT_I2C_TIMEOUT);
-    return data;
+I2C::I2CStatus I2Cf302x8::read(uint8_t addr, uint8_t* output) {
+    HAL_StatusTypeDef status = HAL_I2C_Master_Receive(&halI2C, addr << 1,
+                                                      output, 1,
+                                                      DEFAULT_I2C_TIMEOUT);
+    return halToI2CStatus(status);
 }
 
 /**
  * Override the default multi byte write since the F302x8 supports doing
  * this via the HAL.
  */
-void I2Cf302x8::write(uint8_t addr, uint8_t* bytes, uint8_t length) {
-    HAL_I2C_Master_Transmit(&halI2C, addr << 1, bytes, length,
-                            DEFAULT_I2C_TIMEOUT);
+I2C::I2CStatus I2Cf302x8::write(uint8_t addr, uint8_t* bytes, uint8_t length) {
+    HAL_StatusTypeDef status = HAL_I2C_Master_Transmit(&halI2C, addr << 1,
+                                                       bytes, length,
+                                                        DEFAULT_I2C_TIMEOUT);
+    return halToI2CStatus(status);
 }
 
 /**
  * Override the default multi byte read since the F302x8 supports doing
  * this via the HAL.
  */
-void I2Cf302x8::read(uint8_t addr, uint8_t* bytes, uint8_t length) {
-    HAL_I2C_Master_Receive(&halI2C, addr << 1, bytes, length,
-                           DEFAULT_I2C_TIMEOUT);
+I2C::I2CStatus I2Cf302x8::read(uint8_t addr, uint8_t* bytes, uint8_t length) {
+     HAL_StatusTypeDef status = HAL_I2C_Master_Receive(&halI2C, addr << 1,
+                                                       bytes, length,
+                                                       DEFAULT_I2C_TIMEOUT);
+     return halToI2CStatus(status);
 }
 
-void I2Cf302x8::writeMemReg(uint8_t addr, uint32_t memAddress, uint8_t byte, uint16_t memAddSize, uint8_t maxWriteTime) {
+I2C::I2CStatus I2Cf302x8::writeMemReg(uint8_t addr, uint32_t memAddress,
+                                      uint8_t byte, uint16_t memAddSize,
+                                      uint8_t maxWriteTime) {
     uint16_t memAddress16 = memAddress;
-    HAL_I2C_Mem_Write(&halI2C, addr << 1, memAddress16, memAddSize, &byte, 1, DEFAULT_I2C_TIMEOUT);
-    HAL_Delay(maxWriteTime);// TODO: If possible, replace with a flag check instead of hardcoded timer
+    HAL_StatusTypeDef status = HAL_I2C_Mem_Write(&halI2C, addr << 1,
+                                                 memAddress16, memAddSize,
+                                                 &byte, 1, DEFAULT_I2C_TIMEOUT);
+    return halToI2CStatus(status);
 }
 
-uint8_t I2Cf302x8::readMemReg(uint8_t addr, uint32_t memAddress, uint8_t* byte, uint16_t memAddSize) {
+I2C::I2CStatus I2Cf302x8::readMemReg(uint8_t addr, uint32_t memAddress,
+                                     uint8_t* byte,
+                                     uint16_t memAddSize) {
     uint16_t memAddress16 = memAddress;
-    return HAL_I2C_Mem_Read(&halI2C, addr << 1, memAddress16, memAddSize, byte, 1, DEFAULT_I2C_TIMEOUT);
+    HAL_StatusTypeDef status = HAL_I2C_Mem_Read(&halI2C, addr << 1,
+                                                memAddress16, memAddSize, byte,
+                                                1, DEFAULT_I2C_TIMEOUT);
+    return halToI2CStatus(status);
 }
 
-void I2Cf302x8::writeMemReg(uint8_t addr, uint32_t memAddress, uint8_t bytes[], uint8_t size, uint16_t memAddSize,
-                            uint8_t maxWriteTime) {
+I2C::I2CStatus I2Cf302x8::writeMemReg(uint8_t addr, uint32_t memAddress,
+                                      uint8_t* bytes, uint8_t size,
+                                      uint16_t memAddSize,
+                                      uint8_t maxWriteTime) {
     uint16_t memAddress16 = memAddress;
-    HAL_I2C_Mem_Write(&halI2C, addr << 1, memAddress16, memAddSize, bytes, size, DEFAULT_I2C_TIMEOUT);
-    HAL_Delay(maxWriteTime);
+    HAL_StatusTypeDef status =  HAL_I2C_Mem_Write(&halI2C, addr << 1,
+                                                  memAddress16, memAddSize,
+                                                  bytes, size,
+                                                  DEFAULT_I2C_TIMEOUT);
+    return halToI2CStatus(status);
 }
 
-uint8_t I2Cf302x8::readMemReg(uint8_t addr, uint32_t memAddress, uint8_t bytes[], uint8_t size, uint16_t memAddSize) {
+I2C::I2CStatus I2Cf302x8::readMemReg(uint8_t addr, uint32_t memAddress,
+                                     uint8_t* bytes, uint8_t size,
+                                     uint16_t memAddSize) {
     uint16_t memAddress16 = memAddress;
-    return HAL_I2C_Mem_Read(&halI2C, addr << 1, memAddress16, memAddSize, bytes, size, DEFAULT_I2C_TIMEOUT);
+    HAL_StatusTypeDef status = HAL_I2C_Mem_Read(&halI2C, addr << 1,
+                                                memAddress16, memAddSize,
+                                                bytes, size,
+                                                DEFAULT_I2C_TIMEOUT);
+    return halToI2CStatus(status);
+}
+
+I2C::I2CStatus I2Cf302x8::halToI2CStatus(HAL_StatusTypeDef halStatus) {
+    switch(halStatus) {
+        case HAL_OK:
+            return I2C::I2CStatus::OK;
+        case HAL_ERROR:
+            return I2C::I2CStatus::ERROR;
+        case HAL_BUSY:
+            return I2C::I2CStatus::BUSY;
+        case HAL_TIMEOUT:
+            return I2C::I2CStatus::TIMEOUT;
+        // Should not get here
+        default:
+            return I2C::I2CStatus::ERROR;
+    }
 }
 
 }// namespace EVT::core::IO

--- a/src/io/platform/f3xx/f302x8/I2Cf302x8.cpp
+++ b/src/io/platform/f3xx/f302x8/I2Cf302x8.cpp
@@ -153,10 +153,10 @@ I2C::I2CStatus I2Cf302x8::writeMemReg(uint8_t addr, uint32_t memAddress,
                                       uint16_t memAddSize,
                                       uint8_t maxWriteTime) {
     uint16_t memAddress16 = memAddress;
-    HAL_StatusTypeDef status =  HAL_I2C_Mem_Write(&halI2C, addr << 1,
-                                                  memAddress16, memAddSize,
-                                                  bytes, size,
-                                                  DEFAULT_I2C_TIMEOUT);
+    HAL_StatusTypeDef status = HAL_I2C_Mem_Write(&halI2C, addr << 1,
+                                                 memAddress16, memAddSize,
+                                                 bytes, size,
+                                                 DEFAULT_I2C_TIMEOUT);
     HAL_Delay(maxWriteTime);
     return halToI2CStatus(status);
 }

--- a/src/io/platform/f3xx/f302x8/I2Cf302x8.cpp
+++ b/src/io/platform/f3xx/f302x8/I2Cf302x8.cpp
@@ -134,6 +134,7 @@ I2C::I2CStatus I2Cf302x8::writeMemReg(uint8_t addr, uint32_t memAddress,
     HAL_StatusTypeDef status = HAL_I2C_Mem_Write(&halI2C, addr << 1,
                                                  memAddress16, memAddSize,
                                                  &byte, 1, DEFAULT_I2C_TIMEOUT);
+    HAL_Delay(maxWriteTime);
     return halToI2CStatus(status);
 }
 
@@ -152,10 +153,11 @@ I2C::I2CStatus I2Cf302x8::writeMemReg(uint8_t addr, uint32_t memAddress,
                                       uint16_t memAddSize,
                                       uint8_t maxWriteTime) {
     uint16_t memAddress16 = memAddress;
-    HAL_StatusTypeDef status = HAL_I2C_Mem_Write(&halI2C, addr << 1,
-                                                 memAddress16, memAddSize,
-                                                 bytes, size,
-                                                 DEFAULT_I2C_TIMEOUT);
+    HAL_StatusTypeDef status =  HAL_I2C_Mem_Write(&halI2C, addr << 1,
+                                                  memAddress16, memAddSize,
+                                                  bytes, size,
+                                                  DEFAULT_I2C_TIMEOUT);
+    HAL_Delay(maxWriteTime);
     return halToI2CStatus(status);
 }
 


### PR DESCRIPTION
This PR adds error handling to the I2C interface. Each I2C method now returns an I2CStatus. "Return" values are now passed in via a pointer and updated indirectly. This is a common practice in C/C++ especially in the Linux kernel. This allows us to now tell when an error has taken place and respond accordingly.

For now, only the I2C interface has been updated to have the error handling. But in the future all interfaces will have it. So be critical as this system will then be used throughout EVT-core with each interface having a "status" that is returned. This will then extend to include the devices as well.