### PR TITLE
Who took a byte out of my EEPROM size?

### DIFF
--- a/include/EVT/dev/storage/EEPROM.hpp
+++ b/include/EVT/dev/storage/EEPROM.hpp
@@ -42,7 +42,7 @@ public:
      * @param buffer[out] Buffer to output bytes to
      * @param numBytes[in] The number of bytes to read
      */
-    virtual void readBytes(uint8_t address, uint8_t* buffer, uint8_t numBytes) = 0;
+    virtual void readBytes(uint32_t address, uint8_t* buffer, uint8_t numBytes) = 0;
 
     /**
      * Read a number of consecutive half words starting at a given memory address.
@@ -93,7 +93,7 @@ public:
      * @param dataArr[in] The array of bytes to write out
      * @param numBytes[in] The number of bytes to write out
      */
-    virtual void writeBytes(uint8_t address, uint8_t* dataArr, uint8_t numBytes) = 0;
+    virtual void writeBytes(uint32_t address, uint8_t* dataArr, uint8_t numBytes) = 0;
 
     /**
      * Write a number of consecutive half words to a given memory address.

--- a/include/EVT/dev/storage/M24C32.hpp
+++ b/include/EVT/dev/storage/M24C32.hpp
@@ -48,7 +48,7 @@ public:
      * @param buffer[out] Buffer to output bytes to
      * @param numBytes[in] The number of bytes to read
      */
-    void readBytes(uint8_t address, uint8_t* buffer, uint8_t numBytes) override;
+    void readBytes(uint32_t address, uint8_t* buffer, uint8_t numBytes) override;
 
     /**
      * Read a number of consecutive half words starting at a given memory address.
@@ -99,7 +99,7 @@ public:
      * @param dataArr[in] The array of bytes to write out
      * @param numBytes[in] The number of bytes to write out
      */
-    void writeBytes(uint8_t address, uint8_t* dataArr, uint8_t numBytes) override;
+    void writeBytes(uint32_t address, uint8_t* dataArr, uint8_t numBytes) override;
 
     /**
      * Write a number of consecutive half words to a given memory address.

--- a/src/dev/storage/M24C32.cpp
+++ b/src/dev/storage/M24C32.cpp
@@ -24,7 +24,7 @@ uint32_t M24C32::readWord(uint32_t address) {
     return *out;
 }
 
-void M24C32::readBytes(uint8_t address, uint8_t* buffer, uint8_t numBytes) {
+void M24C32::readBytes(uint32_t address, uint8_t* buffer, uint8_t numBytes) {
     uint16_t currentAddress = address;
     uint8_t bytesRead = 0;
 
@@ -74,7 +74,7 @@ void M24C32::writeWord(uint32_t address, uint32_t data) {
     writeBytes(address, dataArr, 4);
 }
 
-void M24C32::writeBytes(uint8_t address, uint8_t* dataArr, uint8_t numBytes) {
+void M24C32::writeBytes(uint32_t address, uint8_t* dataArr, uint8_t numBytes) {
     uint16_t currentAddress = address;
     uint8_t bytesWritten = 0;
 


### PR DESCRIPTION
Change the size of the address size for reading and writing data from `uint8_t` to `uint32_t` to allow for EEPROM sizes larger then 256 bytes.