### PR TITLE
Kicking the bigger CAN

### DIFF
--- a/include/EVT/io/CANopen.hpp
+++ b/include/EVT/io/CANopen.hpp
@@ -14,7 +14,7 @@
 #include <EVT/io/types/CANMessage.hpp>
 #include <EVT/utils/types/FixedQueue.hpp>
 
-#define CANOPEN_QUEUE_SIZE 15
+#define CANOPEN_QUEUE_SIZE 300
 
 namespace EVT::core::IO {
 


### PR DESCRIPTION
Increase the size of CANopen related data. This includes increasing the size of the CANopen buffer and updating the canopen submodule to include code that increases the size of the SDO buffer.