### PR TITLE
"I2C doesn't work", "Well did you turn it on?"

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,13 +146,13 @@ Below is the supported features associated with each board
 | CAN      | :heavy_check_mark: | :heavy_check_mark: |
 | CANopen  | :heavy_check_mark: | :heavy_check_mark: |
 | GPIO     | :heavy_check_mark: | :heavy_check_mark: |
-| I2C      | :heavy_check_mark: | :x:                |
+| I2C      | :heavy_check_mark: | :heavy_check_mark: |
 | PWM      | :heavy_check_mark: | :heavy_check_mark: |
 | RTC      | :heavy_check_mark: | :x:                |
 | SPI      | :x:                | :x:                |
 | Timer    | :heavy_check_mark: | :x:                |
 | UART     | :heavy_check_mark: | :heavy_check_mark: |
-| Watchdog | :heavy_check_mark: | :x:                |
+| Watchdog | :heavy_check_mark: | :heavy_check_mark: |
 
 ## Future Features
 

--- a/src/io/platform/f3xx/I2Cf3xx.cpp
+++ b/src/io/platform/f3xx/I2Cf3xx.cpp
@@ -85,6 +85,8 @@ static void getInstance(uint8_t portID, I2C_TypeDef** instance, uint8_t* altId) 
 #ifdef STM32F334x8
     *instance = I2C1;
     *altId = GPIO_AF4_I2C1;
+    if (!(__HAL_RCC_I2C1_IS_CLK_ENABLED()))
+        __HAL_RCC_I2C1_CLK_ENABLE();
 #endif
 }
 


### PR DESCRIPTION
Enables the clock for the I2C in the 334.

NOTE: The system won't compile for the 334 until the SPI PR is merged in.