### PR TITLE
Pulling us in a new direction

### DIFF
--- a/include/EVT/io/GPIO.hpp
+++ b/include/EVT/io/GPIO.hpp
@@ -72,7 +72,7 @@ public:
      * @param[in] pin The pin for the GPIO instance to use.
      * @param[in] direction The directional flow of data.
      */
-    GPIO(Pin pin, Direction direction, Pull pull=Pull::PULL_DOWN);
+    GPIO(Pin pin, Direction direction, Pull pull = Pull::PULL_DOWN);
 
     /**
      * Set the direction of the pin.

--- a/include/EVT/io/GPIO.hpp
+++ b/include/EVT/io/GPIO.hpp
@@ -71,6 +71,7 @@ public:
      *
      * @param[in] pin The pin for the GPIO instance to use.
      * @param[in] direction The directional flow of data.
+     * @param[in] pull The direction of the internal pull resistor
      */
     GPIO(Pin pin, Direction direction, Pull pull = Pull::PULL_DOWN);
 

--- a/include/EVT/io/GPIO.hpp
+++ b/include/EVT/io/GPIO.hpp
@@ -50,6 +50,15 @@ public:
     };
 
     /**
+     * Direction for the internal resistor
+     */
+    enum class Pull {
+        NO_PULL = 0u,
+        PULL_UP = 1u,
+        PULL_DOWN = 2u,
+    };
+
+    /**
      * Create a new GPIO interface on a specific pin. The direction will not
      * be set and will have to be set manually.
      *
@@ -63,7 +72,7 @@ public:
      * @param[in] pin The pin for the GPIO instance to use.
      * @param[in] direction The directional flow of data.
      */
-    GPIO(Pin pin, Direction direction);
+    GPIO(Pin pin, Direction direction, Pull pull=Pull::PULL_DOWN);
 
     /**
      * Set the direction of the pin.
@@ -99,6 +108,8 @@ protected:
     Pin pin;
     /// Direction of the flow of information, input or output
     Direction direction;
+    /// The direction the pin is pulled internally
+    Pull pull;
 };
 
 }// namespace EVT::core::IO

--- a/include/EVT/io/manager.hpp
+++ b/include/EVT/io/manager.hpp
@@ -65,6 +65,7 @@ CAN& getCAN(bool loopbackEnabled = false) {
  *
  * @param[in] pin The pin to attach to the GPIO
  * @param[in] direction The direction, either input or output
+ * @param[in] pull The direction of the internal pull resistor
  */
 template<Pin pin>
 GPIO& getGPIO(GPIO::Direction direction = GPIO::Direction::OUTPUT,

--- a/include/EVT/io/manager.hpp
+++ b/include/EVT/io/manager.hpp
@@ -67,9 +67,10 @@ CAN& getCAN(bool loopbackEnabled = false) {
  * @param[in] direction The direction, either input or output
  */
 template<Pin pin>
-GPIO& getGPIO(GPIO::Direction direction = GPIO::Direction::OUTPUT) {
+GPIO& getGPIO(GPIO::Direction direction = GPIO::Direction::OUTPUT,
+              GPIO::Pull pull = GPIO::Pull::PULL_DOWN) {
 #ifdef STM32F3xx
-    static GPIOf3xx gpioPin(pin, direction);
+    static GPIOf3xx gpioPin(pin, direction, pull);
     return gpioPin;
 #endif
 }

--- a/include/EVT/io/platform/f3xx/GPIOf3xx.hpp
+++ b/include/EVT/io/platform/f3xx/GPIOf3xx.hpp
@@ -24,6 +24,7 @@ public:
      *
      * @param[in] pin The pin for the GPIO instance to use.
      * @param[in] direction The flow of data (either input or output).
+     * @param[in] pull The direction of the internal pull resistor
      */
     GPIOf3xx(Pin pin, Direction direction, Pull pull = Pull::PULL_DOWN);
 

--- a/include/EVT/io/platform/f3xx/GPIOf3xx.hpp
+++ b/include/EVT/io/platform/f3xx/GPIOf3xx.hpp
@@ -25,7 +25,7 @@ public:
      * @param[in] pin The pin for the GPIO instance to use.
      * @param[in] direction The flow of data (either input or output).
      */
-    GPIOf3xx(Pin pin, Direction direction);
+    GPIOf3xx(Pin pin, Direction direction, Pull pull=Pull::PULL_DOWN);
 
     void setDirection(Direction direction) override;
 

--- a/include/EVT/io/platform/f3xx/GPIOf3xx.hpp
+++ b/include/EVT/io/platform/f3xx/GPIOf3xx.hpp
@@ -25,7 +25,7 @@ public:
      * @param[in] pin The pin for the GPIO instance to use.
      * @param[in] direction The flow of data (either input or output).
      */
-    GPIOf3xx(Pin pin, Direction direction, Pull pull=Pull::PULL_DOWN);
+    GPIOf3xx(Pin pin, Direction direction, Pull pull = Pull::PULL_DOWN);
 
     void setDirection(Direction direction) override;
 

--- a/src/io/GPIO.cpp
+++ b/src/io/GPIO.cpp
@@ -7,9 +7,10 @@ GPIO::GPIO(Pin pin) {
     this->pin = pin;
 }
 
-GPIO::GPIO(Pin pin, Direction direction) {
+GPIO::GPIO(Pin pin, Direction direction, Pull pull) {
     this->pin = pin;
     this->direction = direction;
+    this->pull = pull;
 }
 
 }// namespace EVT::core::IO

--- a/src/io/platform/f3xx/GPIOf3xx.cpp
+++ b/src/io/platform/f3xx/GPIOf3xx.cpp
@@ -59,15 +59,17 @@ extern "C" void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin) {
 
 namespace EVT::core::IO {
 
-GPIOf3xx::GPIOf3xx(Pin pin, GPIO::Direction direction)
-    : GPIO(pin, direction) {
+GPIOf3xx::GPIOf3xx(Pin pin, GPIO::Direction direction, Pull pull)
+    : GPIO(pin, direction, pull) {
 
     GPIO_InitTypeDef gpioInit;
     Pin myPins[] = {pin};
     uint8_t numOfPins = 1;
 
     gpioStateInit(&gpioInit, myPins, numOfPins,
-                  static_cast<uint32_t>(direction), GPIO_PULLDOWN, GPIO_SPEED_FREQ_HIGH);
+                  static_cast<uint32_t>(direction),
+                  static_cast<uint32_t>(pull),
+                  GPIO_SPEED_FREQ_HIGH);
 
     switch ((static_cast<uint8_t>(pin) & 0xF0) >> 4) {
     case 0x0:


### PR DESCRIPTION
Add the ability to specify a pull direction (up, down, no pull) on GPIOs. Defaults to the previous hard coded value of `PULL_DOWN`.