### PR TITLE
Don't blow your Stack

### DIFF
--- a/include/EVT/io/CANopen.hpp
+++ b/include/EVT/io/CANopen.hpp
@@ -14,7 +14,10 @@
 #include <EVT/io/types/CANMessage.hpp>
 #include <EVT/utils/types/FixedQueue.hpp>
 
-#define CANOPEN_QUEUE_SIZE 300
+//Allows for resizable CANOpen queue if needed
+#ifndef CANOPEN_QUEUE_SIZE
+    #define CANOPEN_QUEUE_SIZE 150
+#endif
 
 namespace EVT::core::IO {
 

--- a/include/EVT/io/platform/f3xx/CANf3xx.hpp
+++ b/include/EVT/io/platform/f3xx/CANf3xx.hpp
@@ -9,7 +9,10 @@
 #include <EVT/io/CAN.hpp>
 #include <EVT/utils/types/FixedQueue.hpp>
 
-#define CAN_MESSAGE_QUEUE_SIZE 100
+//Allows for resizable CAN queue if needed
+#ifndef CAN_MESSAGE_QUEUE_SIZE
+    #define CAN_MESSAGE_QUEUE_SIZE 100
+#endif
 
 namespace EVT::core::IO {
 


### PR DESCRIPTION
- Added macro tests to allow the queue sizes to be adjusted with a simple compile flag. 
- Also cut the CANOpen queue size in half to significantly reduce stack usage.

_*Note: Each CANMessage in the queue is 16 bytes so the original 300 used 4,800 bytes of stack (a literal third). This fix reduces this to 2,400 bytes. I would probably recommend dropping this further to 50 elements or 800 bytes_