### PR TITLE
✉️ Mail Forgery ✉️

### DIFF
--- a/src/io/platform/f3xx/CANf3xx.cpp
+++ b/src/io/platform/f3xx/CANf3xx.cpp
@@ -158,7 +158,7 @@ CAN::CANStatus CANf3xx::transmit(CANMessage& message) {
     while (HAL_CAN_GetTxMailboxesFreeLevel(&halCAN) == 0) {
         if (timeout < 255) {
             time::wait(1);
-            timeout ++;
+            timeout++;
         } else {
             break;
         }

--- a/src/io/platform/f3xx/CANf3xx.cpp
+++ b/src/io/platform/f3xx/CANf3xx.cpp
@@ -153,7 +153,9 @@ CAN::CANStatus CANf3xx::transmit(CANMessage& message) {
     // Copy over bytes
     std::memcpy(payload, message.getPayload(), message.getDataLength());
 
-    // Wait until mailbox 0 is available TODO: Add interrupt implementation
+    // Wait until there is a free mailbox available for use. Timeout is necessary when there is no CAN
+    // network available. If there is no CAN network the mailboxes will fill and this function will infinitely
+    // loop. The timeout prevents that by just cancelling and then overwriting the mailbox.
     uint8_t timeout = 0;
     while (HAL_CAN_GetTxMailboxesFreeLevel(&halCAN) == 0) {
         if (timeout < 255) {

--- a/src/io/platform/f3xx/CANf3xx.cpp
+++ b/src/io/platform/f3xx/CANf3xx.cpp
@@ -153,9 +153,15 @@ CAN::CANStatus CANf3xx::transmit(CANMessage& message) {
     // Copy over bytes
     std::memcpy(payload, message.getPayload(), message.getDataLength());
 
-    // Wait unil mailbox 0 is available TODO: Add interrupt implementation
+    // Wait until mailbox 0 is available TODO: Add interrupt implementation
+    uint8_t timeout = 0;
     while (HAL_CAN_GetTxMailboxesFreeLevel(&halCAN) == 0) {
-        time::wait(1);
+        if (timeout < 255) {
+            time::wait(1);
+            timeout ++;
+        } else {
+            break;
+        }
     }
 
     HAL_StatusTypeDef result = HAL_CAN_AddTxMessage(&halCAN, &txHeader, payload, &mailbox);


### PR DESCRIPTION
Added a timeout in the HAL_CAN_GetTxMailboxesFreeLevel while loop. This allows us to overwrite the full mailboxes if there is no CAN network available.