### PR TITLE
This Encoder is Driving me crazy (Dynamically!)

### DIFF
--- a/include/EVT/dev/Encoder.hpp
+++ b/include/EVT/dev/Encoder.hpp
@@ -28,16 +28,19 @@ public:
     Encoder(IO::GPIO& a, IO::GPIO& b, uint32_t range, uint32_t initialPosition, bool rollOver);
 
     /**
-     * Reads and updates the encoder position.
-     */
-    void update();
-
-    /**
      * Returns the current absolute position
      *
      * @return the current position of the encoder, between 0 and range, inclusive
      */
     uint64_t getPosition();
+
+    /**
+     * Sets the range and position of the encoder
+     *
+     * @param newRange the new range for the encoder positions
+     * @param newPosition a new position for the encoder (defaults to 0)
+     */
+    void setRangeAndPosition(uint32_t newRange, uint32_t newPosition = 0);
 
     /**
      * Static Wrapper for aInterruptHandler()

--- a/src/dev/Encoder.cpp
+++ b/src/dev/Encoder.cpp
@@ -98,6 +98,15 @@ uint64_t Encoder::getPosition() {
     return position;
 }
 
+void Encoder::setRangeAndPosition(uint32_t newRange, uint32_t newPosition) {
+    range = newRange;
+    if (newPosition <= range) {
+        position = newPosition;
+    } else {
+        position = 0;
+    }
+}
+
 int8_t Encoder::readPinValues() {
     bool aPos = (bool) a.readPin();
     bool bPos = (bool) b.readPin();


### PR DESCRIPTION
Added the ability to dynamically change the encoder range and position. This is important for the general use case of an encoder being used as an input device to a UI, because different UI menus may have different numbers of options.
I should have implemented this in the original pull request, but I forgor.

Also removed an hpp method that wasn't implemented anymore.