### PR TITLE
Making Better Options

### DIFF
--- a/cmake/evt-core_compiler.cmake
+++ b/cmake/evt-core_compiler.cmake
@@ -33,10 +33,10 @@ else()
 endif()
 message(STATUS "${TARGET_DEV} targeted")
 
-option (FORCE_COLORED_OUTPUT "Always produce ANSI-colored output (GNU/Clang only)." FALSE)
-if (${FORCE_COLORED_OUTPUT})
-    add_compile_options (-fdiagnostics-color=always)
-endif ()
+option(FORCE_COLORED_OUTPUT "Always produce ANSI-colored output (GNU/Clang only)." OFF)
+if(FORCE_COLORED_OUTPUT)
+    add_compile_options(-fdiagnostics-color=always)
+endif()
 
 # Flags to skip compiler check
 set(CMAKE_C_COMPILER_WORKS 1)
@@ -47,7 +47,7 @@ file(TO_CMAKE_PATH "$ENV{GCC_ARM_TOOLS_PATH}" GCC_ARM_TOOLS_PATH)
 set(CMAKE_SYSTEM_NAME       Generic)
 set(CMAKE_SYSTEM_PROCESSOR  arm)
 
-if (WIN32)
+if(WIN32)
     set(CMAKE_AR                "${GCC_ARM_TOOLS_PATH}/arm-none-eabi-ar.exe")
     set(CMAKE_ASM_COMPILER      "${GCC_ARM_TOOLS_PATH}/arm-none-eabi-gcc.exe")
     set(CMAKE_C_COMPILER        "${GCC_ARM_TOOLS_PATH}/arm-none-eabi-gcc.exe")
@@ -107,4 +107,4 @@ endif()
 
 set(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} -mfloat-abi=hard \
                             -specs=nano.specs -specs=nosys.specs \
-                            -lc -lm -lnosys -Wl,--gc-section -Wl,--print-memory-usage")
+                            -lc -lm -lnosys -Wl,--gc-section,--print-memory-usage")

--- a/cmake/evt-core_compiler.cmake
+++ b/cmake/evt-core_compiler.cmake
@@ -8,6 +8,7 @@ if(NOT DEFINED ENV{GCC_ARM_TOOLS_PATH})
     message(WARNING
             "Set your environment variables you frickin' hecker."
             "   --Shane Snover"
+            "(GCC_ARM_TOOLS_PATH is not set)"
             )
 endif()
 
@@ -32,6 +33,10 @@ else()
 endif()
 message(STATUS "${TARGET_DEV} targeted")
 
+option (FORCE_COLORED_OUTPUT "Always produce ANSI-colored output (GNU/Clang only)." FALSE)
+if (${FORCE_COLORED_OUTPUT})
+    add_compile_options (-fdiagnostics-color=always)
+endif ()
 
 # Flags to skip compiler check
 set(CMAKE_C_COMPILER_WORKS 1)
@@ -102,4 +107,4 @@ endif()
 
 set(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} -mfloat-abi=hard \
                             -specs=nano.specs -specs=nosys.specs \
-                            -lc -lm -lnosys -Wl,--gc-section")
+                            -lc -lm -lnosys -Wl,--gc-section -Wl,--print-memory-usage")


### PR DESCRIPTION
Added a memory summary to the cmake build configuration to print memory usage for each target. Also added an option to force color output when using the command line with ninja. 

- Added memory usage summary to builds
- Added FORCE_COLORED_OUTPUT option to always colorize build output