### PR TITLE
FWT-16 We CAN do 2 For 4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Build files
-build/
+build*/
 html/
 latex/
 compile_commands.json

--- a/include/core/io/CAN.hpp
+++ b/include/core/io/CAN.hpp
@@ -133,12 +133,12 @@ protected:
     Pin txPin;
     /** The CAN receive pin */
     Pin rxPin;
-    /** Function pointer to call for the interrupt handler */
-    void (*handler)(CANMessage&, void* priv);
-    /** Private data to pass into the IRQ handler */
-    void* priv;
     /** If CAN should operate in loop back mode */
     bool loopbackEnabled;
+    /** Function pointer to call for the interrupt handler */
+    void (*handler)(CANMessage&, void* priv);
+    /** Context to pass into the IRQ handler */
+    void* priv;
 };
 
 } // namespace core::io

--- a/include/core/io/CAN.hpp
+++ b/include/core/io/CAN.hpp
@@ -128,15 +128,11 @@ public:
      */
     static constexpr uint32_t DEFAULT_BAUD = 500000;
 
-private:
+protected:
     /** The CAN transmit pin */
     Pin txPin;
     /** The CAN receive pin */
     Pin rxPin;
-    /** Represents if filtering should take place for CAN ids */
-    bool filtering;
-
-protected:
     /** Function pointer to call for the interrupt handler */
     void (*handler)(CANMessage&, void* priv);
     /** Private data to pass into the IRQ handler */

--- a/include/core/io/platform/f3xx/CANf3xx.hpp
+++ b/include/core/io/platform/f3xx/CANf3xx.hpp
@@ -57,15 +57,15 @@ public:
      *
      * @return CANStatus::OK if we successfully de-init the CAN interface
      */
-    CANStatus disconnect();
+    CANStatus disconnect() override;
 
-    CANStatus transmit(CANMessage& message);
+    CANStatus transmit(CANMessage& message) override;
 
-    CANStatus receive(CANMessage* message, bool blocking = false);
+    CANStatus receive(CANMessage* message, bool blocking = false) override;
 
-    CANStatus addCANFilter(uint16_t filterExplicitId, uint16_t filterMask, uint8_t filterBank);
+    CANStatus addCANFilter(uint16_t filterExplicitId, uint16_t filterMask, uint8_t filterBank) override;
 
-    CANStatus enableEmergencyFilter(uint32_t state);
+    CANStatus enableEmergencyFilter(uint32_t state) override;
 
     void addIRQHandler(void (*handler)(CANMessage&, void* priv), void* priv);
 

--- a/include/core/io/platform/f4xx/CANf4xx.hpp
+++ b/include/core/io/platform/f4xx/CANf4xx.hpp
@@ -17,8 +17,8 @@
 namespace core::io {
 
 /**
- * STMF4xx implementation of the CAN protocol. The STM32f4xx has an on
- * board CAN controller which adds additional features.
+ * STM32f4xx implementation of the CAN protocol. The STM32f4xx has an
+ * onboard CAN controller which adds additional features.
  *
  * 1. Ability to generate interrupts which allows users to add custom call
  * backs
@@ -92,10 +92,22 @@ public:
      */
     bool triggerIRQ(CANMessage& message);
 
+    static constexpr uint8_t EMERGENCY_FILTER_BANK_INDEX = 1;
+
     /** Second filter bank start index*/
     static constexpr uint8_t SECOND_FILTER_BANK_INDEX = 14;
 
 private:
+    /**
+     * Get the CAN ID that is associated with the given pin
+     * combination. This information is pulled from the STM32F446xx
+     * documentation with easier documentation on in CUBEMX
+     *
+     * @param sclPin The selected I2C clock pin
+     * @return The port ID associated with the selected pins
+     */
+    static uint8_t getPortID(Pin txPin, Pin rxPin);
+
     /** Instance of the HAL can interface */
     CAN_HandleTypeDef halCAN;
     /** Queue which holds received CAN messages */

--- a/include/core/io/platform/f4xx/CANf4xx.hpp
+++ b/include/core/io/platform/f4xx/CANf4xx.hpp
@@ -1,0 +1,104 @@
+#ifndef _EVT_CANf4xx_
+#define _EVT_CANf4xx_
+
+#include <stdint.h>
+
+#include <HALf4/stm32f4xx.h>
+#include <HALf4/stm32f4xx_hal_can.h>
+
+#include <core/io/CAN.hpp>
+#include <core/utils/types/FixedQueue.hpp>
+
+// Allows for resizable CAN queue if needed
+#ifndef CAN_MESSAGE_QUEUE_SIZE
+    #define CAN_MESSAGE_QUEUE_SIZE 100
+#endif
+
+namespace core::io {
+
+/**
+ * STMF4xx implementation of the CAN protocol. The STM32f4xx has an on
+ * board CAN controller which adds additional features.
+ *
+ * 1. Ability to generate interrupts which allows users to add custom call
+ * backs
+ *
+ * 2. Hardware based message filtering which allows the filtering of messages
+ * to be handled by hardware not software.
+ */
+class CANf4xx : public CAN {
+public:
+    /**
+     * Create a new instance of an STM32f4xx CAN interface
+     *
+     * @param[in] txPin The pin to trasmit CAN messages on
+     * @param[in] rxPin The pin to receive CAN messages on
+     * @param[in] loopbackEnabled Flag for enabling CAN loop back
+     */
+    CANf4xx(Pin txPin, Pin rxPin, bool loopbackEnabled = false);
+
+    /**
+     * Attempt to join the CAN network.
+     *
+     * For the STM32f4xx this involves attempting to startup the CAN
+     * interface. This could cause an error in the case of invalid
+     * parameters.
+     *
+     * @param[in] autoBusOff Indicates the state halCAN.Init.AutoBusOff should be in
+     *
+     * @return CANStatus::OK on success, CANStatus::ERROR otherwise
+     */
+    CANStatus connect(bool autoBusOff = false) override;
+
+    /**
+     * Disconnect from the CAN network.
+     *
+     * For the STM32f4xx this involves disconnect from the CAN interface.
+     *
+     * @return CANStatus::OK if we successfully de-init the CAN interface
+     */
+    CANStatus disconnect();
+
+    CANStatus transmit(CANMessage& message);
+
+    CANStatus receive(CANMessage* message, bool blocking = false);
+
+    CANStatus addCANFilter(uint16_t filterExplicitId, uint16_t filterMask, uint8_t filterBank);
+
+    CANStatus enableEmergencyFilter(uint32_t state);
+
+    void addIRQHandler(void (*handler)(CANMessage&, void* priv), void* priv);
+
+    /**
+     * Add a message to the CAN receive queue.
+     *
+     * NOTE: This is public for use with the STM HAL interrupt handler. This
+     * method should not be used outside of that application.
+     *
+     * @param[in] message The CANmessage to add to the receive queue
+     */
+    void addCANMessage(CANMessage& message);
+
+    /**
+     * Manually trigger the user specified interrupt handler. This is intended
+     * to be used by the STM HAL interrupt handler and generally should
+     * not be used beyound that use case.
+     *
+     * NOTE: This is public for use with the STM HAL interrupt handler. This
+     * method should not be used outside of that application.
+     *
+     * @param[in] message The message to pass to the interrupt handler
+     * @return True if the interrupt handler exists and has handled the message
+     */
+    bool triggerIRQ(CANMessage& message);
+
+private:
+    /** Instance of the HAL can interface */
+    CAN_HandleTypeDef halCAN;
+    /** Queue which holds received CAN messages */
+    core::types::FixedQueue<CAN_MESSAGE_QUEUE_SIZE, CANMessage> messageQueue;
+};
+
+} // namespace core::io
+
+#endif

--- a/include/core/io/platform/f4xx/CANf4xx.hpp
+++ b/include/core/io/platform/f4xx/CANf4xx.hpp
@@ -57,15 +57,15 @@ public:
      *
      * @return CANStatus::OK if we successfully de-init the CAN interface
      */
-    CANStatus disconnect();
+    CANStatus disconnect() override;
 
-    CANStatus transmit(CANMessage& message);
+    CANStatus transmit(CANMessage& message) override;
 
-    CANStatus receive(CANMessage* message, bool blocking = false);
+    CANStatus receive(CANMessage* message, bool blocking = false) override;
 
-    CANStatus addCANFilter(uint16_t filterExplicitId, uint16_t filterMask, uint8_t filterBank);
+    CANStatus addCANFilter(uint16_t filterExplicitId, uint16_t filterMask, uint8_t filterBank) override;
 
-    CANStatus enableEmergencyFilter(uint32_t state);
+    CANStatus enableEmergencyFilter(uint32_t state) override;
 
     void addIRQHandler(void (*handler)(CANMessage&, void* priv), void* priv);
 
@@ -92,6 +92,7 @@ public:
      */
     bool triggerIRQ(CANMessage& message);
 
+    /** The filter bank index for emergency CAN messages */
     static constexpr uint8_t EMERGENCY_FILTER_BANK_INDEX = 1;
 
     /** Second filter bank start index*/

--- a/include/core/io/platform/f4xx/CANf4xx.hpp
+++ b/include/core/io/platform/f4xx/CANf4xx.hpp
@@ -92,6 +92,9 @@ public:
      */
     bool triggerIRQ(CANMessage& message);
 
+    /** Second filter bank start index*/
+    static constexpr uint8_t SECOND_FILTER_BANK_INDEX = 14;
+
 private:
     /** Instance of the HAL can interface */
     CAN_HandleTypeDef halCAN;

--- a/include/core/manager.hpp
+++ b/include/core/manager.hpp
@@ -12,16 +12,16 @@
 #include <core/io/pin.hpp>
 
 #ifdef STM32F3xx
-    #define IWDG_SUPPORTED
-    #define RTC_SUPPORTED
-    #define MCU_SUPPORTED
     #define ADC_SUPPORTED
+    #define CAN_SUPPORTED
     #define GPIO_SUPPORTED
     #define I2C_SUPPORTED
+    #define IWDG_SUPPORTED
+    #define MCU_SUPPORTED
     #define PWM_SUPPORTED
-    #define UART_SUPPORTED
+    #define RTC_SUPPORTED
     #define SPI_SUPPORTED
-    #define CAN_SUPPORTED
+    #define UART_SUPPORTED
 
     #include <core/dev/MCUTimer.hpp>
     #include <core/dev/platform/f3xx/IWDGf3xx.hpp>

--- a/include/core/manager.hpp
+++ b/include/core/manager.hpp
@@ -38,27 +38,29 @@
 #endif
 
 #ifdef STM32F4xx
-    #define GPIO_SUPPORTED
-    #define UART_SUPPORTED
-    #define PWM_SUPPORTED
-    #define SPI_SUPPORTED
     #define ADC_SUPPORTED
-    #define RTC_SUPPORTED
+    #define CAN_SUPPORTED
+    #define GPIO_SUPPORTED
     #define I2C_SUPPORTED
     #define MCU_SUPPORTED
+    #define PWM_SUPPORTED
+    #define RTC_SUPPORTED
+    #define SPI_SUPPORTED
+    #define UART_SUPPORTED
 
     #include <core/dev/MCUTimer.hpp>
-    #include <core/dev/platform/f4xx/Timerf4xx.hpp>
-    #include <core/io/platform/f4xx/ADCf4xx.hpp>
-    #include <core/platform/f4xx/stm32f4xx.hpp>
-    //    #include <core/io/platform/f4xx/CANf4xx.hpp>
     #include <core/dev/platform/f4xx/IWDGf4xx.hpp>
     #include <core/dev/platform/f4xx/RTCf4xx.hpp>
+    #include <core/dev/platform/f4xx/Timerf4xx.hpp>
+    #include <core/io/platform/f4xx/ADCf4xx.hpp>
+    #include <core/io/platform/f4xx/CANf4xx.hpp>
     #include <core/io/platform/f4xx/GPIOf4xx.hpp>
     #include <core/io/platform/f4xx/I2Cf4xx.hpp>
     #include <core/io/platform/f4xx/PWMf4xx.hpp>
     #include <core/io/platform/f4xx/SPIf4xx.hpp>
     #include <core/io/platform/f4xx/UARTf4xx.hpp>
+    #include <core/platform/f4xx/stm32f4xx.hpp>
+
 #endif
 
 namespace core::platform {

--- a/samples/can/CMakeLists.txt
+++ b/samples/can/CMakeLists.txt
@@ -1,3 +1,4 @@
 # Add all samples
 add_subdirectory(loopback)
 add_subdirectory(back_and_forth)
+add_subdirectory(multiCAN)

--- a/samples/can/back_and_forth/main.cpp
+++ b/samples/can/back_and_forth/main.cpp
@@ -35,17 +35,9 @@ int main() {
     io::UART& uart = io::getUART<io::Pin::UART_TX, io::Pin::UART_RX>(9600);
     can.addIRQHandler(canIRQHandler, &uart);
 
-    uint8_t count = 0;
-// CAN message that will be sent
-#ifdef STM32F446xx
+    // CAN message that will be sent
     uint8_t payload[] = {0xDE, 0xAD, 0xBE, 0xBE, 0xEF, 0x00, 0x01, 0x02};
-    uint8_t id        = 4;
-#else
-    uint8_t payload[] = {0xBE, 0xEF, 0xBE, 0xDE, 0xAD, 0x09, 0x08, 0x07};
-    uint8_t id        = 3;
-#endif
-
-    io::CANMessage transmit_message(id, 8, &payload[0], false);
+    io::CANMessage transmit_message(1, 8, &payload[0], false);
     io::CANMessage received_message;
 
     uart.printf("Starting CAN testing\r\n");
@@ -60,10 +52,12 @@ int main() {
         return 1;
     }
 
+    uint8_t count = 0;
     while (true) {
         // Transmit every second
         payload[7] = count;
-        result     = can.transmit(transmit_message);
+        transmit_message.setPayload(payload);
+        result = can.transmit(transmit_message);
         if (result != io::CAN::CANStatus::OK) {
             uart.printf("Failed to transmit message\r\n");
             return 1;

--- a/samples/can/back_and_forth/main.cpp
+++ b/samples/can/back_and_forth/main.cpp
@@ -35,9 +35,17 @@ int main() {
     io::UART& uart = io::getUART<io::Pin::UART_TX, io::Pin::UART_RX>(9600);
     can.addIRQHandler(canIRQHandler, &uart);
 
-    // CAN message that will be sent
+    uint8_t count = 0;
+// CAN message that will be sent
+#ifdef STM32F446xx
     uint8_t payload[] = {0xDE, 0xAD, 0xBE, 0xBE, 0xEF, 0x00, 0x01, 0x02};
-    io::CANMessage transmit_message(1, 8, &payload[0], true);
+    uint8_t id        = 4;
+#else
+    uint8_t payload[] = {0xBE, 0xEF, 0xBE, 0xDE, 0xAD, 0x09, 0x08, 0x07};
+    uint8_t id        = 3;
+#endif
+
+    io::CANMessage transmit_message(id, 8, &payload[0], false);
     io::CANMessage received_message;
 
     uart.printf("Starting CAN testing\r\n");
@@ -54,11 +62,13 @@ int main() {
 
     while (true) {
         // Transmit every second
-        result = can.transmit(transmit_message);
+        payload[7] = count;
+        result     = can.transmit(transmit_message);
         if (result != io::CAN::CANStatus::OK) {
             uart.printf("Failed to transmit message\r\n");
             return 1;
         }
+        count++;
 
         time::wait(1000);
     }

--- a/samples/can/back_and_forth/main.cpp
+++ b/samples/can/back_and_forth/main.cpp
@@ -37,7 +37,7 @@ int main() {
 
     // CAN message that will be sent
     uint8_t payload[] = {0xDE, 0xAD, 0xBE, 0xBE, 0xEF, 0x00, 0x01, 0x02};
-    io::CANMessage transmit_message(1, 8, &payload[0], false);
+    io::CANMessage transmit_message(1, 8, &payload[0], true);
     io::CANMessage received_message;
 
     uart.printf("Starting CAN testing\r\n");

--- a/samples/can/multiCAN/CMakeLists.txt
+++ b/samples/can/multiCAN/CMakeLists.txt
@@ -1,0 +1,9 @@
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake/evt-core_build.cmake)
+
+if(COMPDEFS MATCHES "(.*)STM32F4xx(.*)")
+    make_exe(multiCAN main.cpp)
+else()
+    add_custom_target(multiCAN ${CMAKE_COMMAND} -E cmake_echo_color --red "multiCAN only works on an STM32F446 due to dual CAN interfaces")
+endif()
+
+

--- a/samples/can/multiCAN/README.md
+++ b/samples/can/multiCAN/README.md
@@ -1,5 +1,5 @@
 # MultiCAN
 
 This sample is intended to show the ability to use dual CANbus interfaces on
-the STM32F446xx. The two CAN interface can be connected together on the same
+the STM32F446xx. The two CAN interfaces can be connected together on the same
 network as a more complicated loopback with transceivers

--- a/samples/can/multiCAN/README.md
+++ b/samples/can/multiCAN/README.md
@@ -1,0 +1,5 @@
+# MultiCAN
+
+This sample is intended to show the ability to use dual CANbus interfaces on
+the STM32F446xx. The two CAN interface can be connected together on the same
+network as a more complicated loopback with transceivers

--- a/samples/can/multiCAN/main.cpp
+++ b/samples/can/multiCAN/main.cpp
@@ -1,7 +1,7 @@
 /**
  * Example of CAN communication using dual CAN interfaces. The two interfaces need
- * to be connected to a CAN network. Both interfaces can be connected to the same
- * network as a loop back with a CAN transceiver.
+ * to be connected to a CAN network. Both interfaces also can be connected to the
+ * same network as a loop back with a CAN transceiver. ONLY WORKS ON STM32F4xx!
  */
 
 #include <stdint.h>
@@ -80,22 +80,20 @@ int main() {
     io::CANMessage can1TransmitMessage(1, 8, &payload1[0], false);
     io::CANMessage can2TransmitMessage(2, 8, &payload2[0], false);
 
-    uart.printf("\r\nClock: %d\r\n", SystemCoreClock);
-
-    uart.printf("Starting CAN testing\r\n");
+    log::LOGGER.log(log::Logger::LogLevel::INFO, "Starting CAN testing\r\n");
 
     io::CAN::CANStatus result;
 
     // Attempt to join the CAN network.
     result = can1.connect();
     if (result != io::CAN::CANStatus::OK) {
-        uart.printf("[CAN1] Failed to connect to the CAN network\r\n");
+        log::LOGGER.log(log::Logger::LogLevel::ERROR, "[CAN1] Failed to connect to the CAN network\r\n");
         return 1;
     }
 
     result = can2.connect();
     if (result != io::CAN::CANStatus::OK) {
-        uart.printf("[CAN2] Failed to connect to the CAN network\r\n");
+        log::LOGGER.log(log::Logger::LogLevel::ERROR, "[CAN2] Failed to connect to the CAN network\r\n");
         return 1;
     }
 
@@ -110,13 +108,13 @@ int main() {
         // Send both messages on the two different buses.
         result = can1.transmit(can1TransmitMessage);
         if (result != io::CAN::CANStatus::OK) {
-            uart.printf("[CAN1] Failed to transmit message\r\n");
+            log::LOGGER.log(log::Logger::LogLevel::ERROR, "[CAN1] Failed to transmit message\r\n");
             return 1;
         }
 
         result = can2.transmit(can2TransmitMessage);
         if (result != io::CAN::CANStatus::OK) {
-            uart.printf("[CAN2] Failed to transmit message\r\n");
+            log::LOGGER.log(log::Logger::LogLevel::ERROR, "[CAN2] Failed to transmit message\r\n");
             return 1;
         }
 

--- a/samples/can/multiCAN/main.cpp
+++ b/samples/can/multiCAN/main.cpp
@@ -3,11 +3,14 @@
  * to be connected to a CAN network. Both interfaces can be connected to the same
  * network as a loop back with a CAN transceiver.
  */
+
+#include <stdint.h>
+#include <string>
+
 #include <core/io/CAN.hpp>
 #include <core/manager.hpp>
 #include <core/utils/log.hpp>
 #include <core/utils/time.hpp>
-#include <stdint.h>
 
 namespace io   = core::io;
 namespace time = core::time;
@@ -17,28 +20,34 @@ namespace log  = core::log;
  * CAN 1 interrupt handler to print out received CAN messages.
  */
 void can1IRQHandler(io::CANMessage& message, void* priv) {
-    io::UART* uart = (io::UART*) priv;
-    uart->printf(
-        "[CAN1] Message received from %d with %d bytes containing: \r\n\t", message.getId(), message.getDataLength());
+    char messageString[50];
     uint8_t* message_payload = message.getPayload();
     for (int i = 0; i < message.getDataLength(); i++) {
-        uart->printf("0x%02X ", message_payload[i]);
+        snprintf(&messageString[i * 5], 6, "0x%02X ", message_payload[i]);
     }
-    uart->printf("\r\n\r\n");
+
+    log::LOGGER.log(log::Logger::LogLevel::DEBUG,
+                    "[CAN1] Message received from %d with %d bytes containing: \r\n\t%s\r\n",
+                    message.getId(),
+                    message.getDataLength(),
+                    messageString);
 }
 
 /**
  * CAN 2 interrupt handler to print out received CAN messages.
  */
 void can2IRQHandler(io::CANMessage& message, void* priv) {
-    io::UART* uart = (io::UART*) priv;
-    uart->printf(
-        "[CAN2] Message received from %d with %d bytes containing: \r\n\t", message.getId(), message.getDataLength());
+    char messageString[50];
     uint8_t* message_payload = message.getPayload();
     for (int i = 0; i < message.getDataLength(); i++) {
-        uart->printf("0x%02X ", message_payload[i]);
+        snprintf(&messageString[i * 5], 6, "0x%02X ", message_payload[i]);
     }
-    uart->printf("\r\n\r\n");
+
+    log::LOGGER.log(log::Logger::LogLevel::DEBUG,
+                    "[CAN2] Message received from %d with %d bytes containing: \r\n\t%s\r\n",
+                    message.getId(),
+                    message.getDataLength(),
+                    messageString);
 }
 
 int main() {
@@ -59,8 +68,8 @@ int main() {
     io::CAN& can2 = io::getCAN<io::Pin::PB_13, io::Pin::PB_12>();
 
     // Setup interrupt handlers
-    can1.addIRQHandler(can1IRQHandler, &uart);
-    can2.addIRQHandler(can2IRQHandler, &uart);
+    can1.addIRQHandler(can1IRQHandler, nullptr);
+    can2.addIRQHandler(can2IRQHandler, nullptr);
 
     uint8_t can1Count = 0;
     uint8_t can2Count = 0;

--- a/samples/can/multiCAN/main.cpp
+++ b/samples/can/multiCAN/main.cpp
@@ -1,0 +1,122 @@
+/**
+ * Example of CAN communication using dual CAN interfaces. The two interfaces need
+ * to be connected to a CAN network. Both interfaces can be connected to the same
+ * network as a loop back with a CAN transceiver.
+ */
+#include <core/io/CAN.hpp>
+#include <core/manager.hpp>
+#include <core/utils/log.hpp>
+#include <core/utils/time.hpp>
+#include <stdint.h>
+
+namespace io   = core::io;
+namespace time = core::time;
+namespace log  = core::log;
+
+/**
+ * CAN 1 interrupt handler to print out received CAN messages.
+ */
+void can1IRQHandler(io::CANMessage& message, void* priv) {
+    io::UART* uart = (io::UART*) priv;
+    uart->printf(
+        "[CAN1] Message received from %d with %d bytes containing: \r\n\t", message.getId(), message.getDataLength());
+    uint8_t* message_payload = message.getPayload();
+    for (int i = 0; i < message.getDataLength(); i++) {
+        uart->printf("0x%02X ", message_payload[i]);
+    }
+    uart->printf("\r\n\r\n");
+}
+
+/**
+ * CAN 2 interrupt handler to print out received CAN messages.
+ */
+void can2IRQHandler(io::CANMessage& message, void* priv) {
+    io::UART* uart = (io::UART*) priv;
+    uart->printf(
+        "[CAN2] Message received from %d with %d bytes containing: \r\n\t", message.getId(), message.getDataLength());
+    uint8_t* message_payload = message.getPayload();
+    for (int i = 0; i < message.getDataLength(); i++) {
+        uart->printf("0x%02X ", message_payload[i]);
+    }
+    uart->printf("\r\n\r\n");
+}
+
+int main() {
+    // Initialize system
+    core::platform::init();
+    io::UART& uart = io::getUART<io::Pin::UART_TX, io::Pin::UART_RX>(9600);
+    log::LOGGER.setUART(&uart);
+    log::LOGGER.setLogLevel(log::Logger::LogLevel::DEBUG);
+
+    // Get CAN instances
+
+    // CAN 1
+    io::CAN& can1 = io::getCAN<io::Pin::PA_12, io::Pin::PA_11>();
+    // io::CAN& can1 = io::getCAN<io::Pin::PB_9, io::Pin::PB_8>();
+
+    // CAN 2
+    // io::CAN& can2 = io::getCAN<io::Pin::PB_6, io::Pin::PB_5>();
+    io::CAN& can2 = io::getCAN<io::Pin::PB_13, io::Pin::PB_12>();
+
+    // Setup interrupt handlers
+    can1.addIRQHandler(can1IRQHandler, &uart);
+    can2.addIRQHandler(can2IRQHandler, &uart);
+
+    uint8_t can1Count = 0;
+    uint8_t can2Count = 0;
+
+    // CAN message that will be sent
+    uint8_t payload1[] = {0xDE, 0xAD, 0xBE, 0xBE, 0xEF, 0x09, 0x08, 0x07};
+    uint8_t payload2[] = {0xBE, 0xEF, 0xBE, 0xDE, 0xAD, 0x00, 0x01, 0x02};
+    io::CANMessage can1TransmitMessage(1, 8, &payload1[0], false);
+    io::CANMessage can2TransmitMessage(2, 8, &payload2[0], false);
+
+    uart.printf("\r\nClock: %d\r\n", SystemCoreClock);
+
+    uart.printf("Starting CAN testing\r\n");
+
+    io::CAN::CANStatus result;
+
+    // Attempt to join the CAN network.
+    result = can1.connect();
+    if (result != io::CAN::CANStatus::OK) {
+        uart.printf("[CAN1] Failed to connect to the CAN network\r\n");
+        return 1;
+    }
+
+    result = can2.connect();
+    if (result != io::CAN::CANStatus::OK) {
+        uart.printf("[CAN2] Failed to connect to the CAN network\r\n");
+        return 1;
+    }
+
+    while (true) {
+        // Update the payload of the CAN messages with the counts.
+        payload1[7] = can1Count;
+        payload2[5] = can2Count;
+
+        can1TransmitMessage.setPayload(payload1);
+        can2TransmitMessage.setPayload(payload2);
+
+        // Send both messages on the two different buses.
+        result = can1.transmit(can1TransmitMessage);
+        if (result != io::CAN::CANStatus::OK) {
+            uart.printf("[CAN1] Failed to transmit message\r\n");
+            return 1;
+        }
+
+        result = can2.transmit(can2TransmitMessage);
+        if (result != io::CAN::CANStatus::OK) {
+            uart.printf("[CAN2] Failed to transmit message\r\n");
+            return 1;
+        }
+
+        // Update the counts.
+        can1Count++;
+        can2Count--;
+
+        time::wait(1000);
+    }
+
+    return 0;
+}

--- a/src/core/io/platform/f4xx/CANf4xx.cpp
+++ b/src/core/io/platform/f4xx/CANf4xx.cpp
@@ -1,45 +1,51 @@
-// TODO:
-//      * Implement choosing between polling and interrupt mode
-//      * Add flexible baud rates
-//      * Add hardware based filtering settings
-//      * "Thread" safty for queue access
-//      * Support hardware based filtering
+
 
 #include <cstring>
 #include <stdint.h>
 
 #include <HALf4/stm32f4xx.h>
 
+#include <core/io/pin.hpp>
 #include <core/io/platform/f4xx/CANf4xx.hpp>
 #include <core/io/platform/f4xx/GPIOf4xx.hpp>
 #include <core/platform/f4xx/stm32f4xx.hpp>
+#include <core/utils/log.hpp>
 #include <core/utils/time.hpp>
 #include <core/utils/types/FixedQueue.hpp>
 
 namespace {
 
-// Pointer to the CANf446r8 interface
-//
-// NOTE: Part of the reason this works is because the STM32F4xx only supports
-// a single CAN interface at a time.
-core::io::CANf4xx* canIntf;
+/**
+ * Struct to hold the global pointers to the CAN F4 interfaces. This is necessary
+ * for the interrupts to have a call back to the classes.
+ */
+struct CANf4Global {
+    // Pointer to the CANf446xx interface
+    core::io::CANf4xx* canInstance = nullptr;
 
-// Pointer to the CAN interface, made global for similar reasons to the
-// variable above.
-CAN_HandleTypeDef* hcan;
+    // Pointer to the CAN handler for HAL,
+    CAN_HandleTypeDef* canHandler = nullptr;
+};
 
-} // namespace
+struct CANf4Global globalCAN[2];
 
+// Interrupt handler for CAN 1 or index 0 in the global CAN array
 extern "C" void CAN1_RX0_IRQHandler(void) {
-    HAL_CAN_IRQHandler(hcan);
+    if (globalCAN[0].canHandler != nullptr) {
+        HAL_CAN_IRQHandler(globalCAN[0].canHandler);
+    }
+}
+
+// Interrupt handler for CAN 2 or index 1 in the global CAN array
+extern "C" void CAN2_RX0_IRQHandler(void) {
+    if (globalCAN[1].canHandler != nullptr) {
+        HAL_CAN_IRQHandler(globalCAN[1].canHandler);
+    }
 }
 
 /**
- * Interrupt handler for incoming CAN messages. The messages are added to
+ * HAL interrupt handler for incoming CAN messages. The messages are added to
  * a queue for receiving.
- *
- * NOTE: Ideally a pointer to the queue would be stored in the CAN handle
- * typedef. It may be worth considering changing the HAL code.
  */
 extern "C" void HAL_CAN_RxFifo0MsgPendingCallback(CAN_HandleTypeDef* hcan) {
     CAN_RxHeaderTypeDef rxHeader = {0};
@@ -52,15 +58,74 @@ extern "C" void HAL_CAN_RxFifo0MsgPendingCallback(CAN_HandleTypeDef* hcan) {
     uint32_t id     = isExtended ? rxHeader.ExtId : rxHeader.StdId;
     core::io::CANMessage message(id, rxHeader.DLC, payload, isExtended);
 
+    core::io::CANf4xx* canInstance;
+    if (hcan == globalCAN[0].canHandler) {
+        canInstance = globalCAN[0].canInstance;
+    } else {
+        canInstance = globalCAN[1].canInstance;
+    }
+
     // Check to see if a user defined IRQ has been provided
-    if (canIntf->triggerIRQ(message))
+    if (canInstance->triggerIRQ(message))
         return;
 
-    // TODO: Part of an error system should log when the CAN buffer has filled
-    canIntf->addCANMessage(message);
+    canInstance->addCANMessage(message);
 }
 
+} // namespace
+
 namespace core::io {
+
+/**
+ * Get the CAN ID that is associated with the given pin
+ * combination. This information is pulled from the STM32F446xx
+ * documentation with easier documentation on in CUBEMX
+ *
+ * @param sclPin The selected I2C clock pin
+ * @return The port ID associated with the selected pins
+ */
+static uint8_t getPortID(Pin txPin, Pin rxPin) {
+    uint8_t txPort = 0;
+    uint8_t rxPort = 0;
+
+#ifdef STM32F446xx
+    switch (txPin) {
+    case Pin::PA_12:
+    case Pin::PB_9:
+        txPort = 1;
+        break;
+    case Pin::PB_6:
+    case Pin::PB_13:
+        txPort = 2;
+        break;
+    default:
+        log::LOGGER.log(log::Logger::LogLevel::ERROR, "Invalid CAN TX Pin");
+        txPort = 0;
+        break;
+    }
+
+    switch (rxPin) {
+    case Pin::PA_11:
+    case Pin::PB_8:
+        rxPort = 1;
+        break;
+    case Pin::PB_5:
+    case Pin::PB_12:
+        rxPort = 2;
+        break;
+    default:
+        log::LOGGER.log(log::Logger::LogLevel::ERROR, "Invalid CAN RX Pin");
+        rxPort = 0;
+        break;
+    }
+#endif
+
+    if (txPort == rxPort) {
+        return txPort;
+    }
+
+    return 0;
+}
 
 CANf4xx::CANf4xx(Pin txPin, Pin rxPin, bool loopbackEnabled) : CAN(txPin, rxPin, loopbackEnabled) {
 
@@ -68,18 +133,41 @@ CANf4xx::CANf4xx(Pin txPin, Pin rxPin, bool loopbackEnabled) : CAN(txPin, rxPin,
     GPIO_InitTypeDef gpioInit = {0};
     Pin canPins[]             = {txPin, rxPin};
     uint8_t numOfPins         = 2;
+
+    // Both CAN 1 and CAN 2 use AF9 for the GPIO so initialization can be identical
     GPIOf4xx::gpioStateInit(
-        &gpioInit, canPins, numOfPins, GPIO_MODE_AF_OD, GPIO_PULLUP, GPIO_SPEED_FREQ_HIGH, GPIO_AF9_CAN1);
+        &gpioInit, canPins, numOfPins, GPIO_MODE_AF_PP, GPIO_NOPULL, GPIO_SPEED_FREQ_VERY_HIGH, GPIO_AF9_CAN1);
 }
 
 CAN::CANStatus CANf4xx::connect(bool autoBusOff) {
     // Initialize HAL CAN
     // Bit timing values calculated from the website
     // http://www.bittiming.can-wiki.info/
-    uint32_t mode = loopbackEnabled ? CAN_MODE_LOOPBACK : CAN_MODE_NORMAL;
+    uint32_t mode  = loopbackEnabled ? CAN_MODE_LOOPBACK : CAN_MODE_NORMAL;
+    uint8_t portID = getPortID(txPin, rxPin);
 
-    halCAN.Instance               = CAN1;
-    halCAN.Init.Prescaler         = 5;
+    IRQn_Type IRQn;
+
+    // Select the instance to use from the pins.
+    switch (portID) {
+    case 1:
+        halCAN.Instance = CAN1;
+        IRQn            = CAN1_RX0_IRQn;
+        __HAL_RCC_CAN1_CLK_ENABLE();
+        break;
+    case 2:
+        halCAN.Instance = CAN2;
+        IRQn            = CAN2_RX0_IRQn;
+        __HAL_RCC_CAN1_CLK_ENABLE();
+        __HAL_RCC_CAN2_CLK_ENABLE();
+        break;
+    default:
+        log::LOGGER.log(log::Logger::LogLevel::ERROR, "Failed to initalized CAN, Bad pin configuration");
+        return CANStatus::ERROR;
+    }
+
+    // Configure the rest of the parameters.
+    halCAN.Init.Prescaler         = (HAL_RCC_GetHCLKFreq() / DEFAULT_BAUD / 20); // At 50MHz prescaler of 5
     halCAN.Init.Mode              = mode;
     halCAN.Init.SyncJumpWidth     = CAN_SJW_1TQ;
     halCAN.Init.TimeSeg1          = CAN_BS1_8TQ;
@@ -96,31 +184,32 @@ CAN::CANStatus CANf4xx::connect(bool autoBusOff) {
     halCAN.Init.TransmitFifoPriority = DISABLE;
 
     // Setup global variables
-    hcan    = &this->halCAN;
-    canIntf = this;
+    globalCAN[portID - 1].canHandler  = &this->halCAN;
+    globalCAN[portID - 1].canInstance = this;
 
-    __HAL_RCC_CAN1_CLK_ENABLE();
     HAL_CAN_Init(&halCAN);
 
     // Intialize interrupts
     HAL_CAN_ActivateNotification(&halCAN, CAN_IT_RX_FIFO0_MSG_PENDING);
-    HAL_NVIC_SetPriority(CAN1_RX0_IRQn, core::platform::CAN_INTERRUPT_PRIORITY, 0);
-    HAL_NVIC_EnableIRQ(CAN1_RX0_IRQn);
+
+    HAL_NVIC_SetPriority(IRQn, core::platform::CAN_INTERRUPT_PRIORITY, 0);
+    HAL_NVIC_EnableIRQ(IRQn);
 
     // By default - filter that accepts all incoming messages
-    CAN_FilterTypeDef defaultFilter;
-    defaultFilter.FilterBank           = 0;
-    defaultFilter.FilterMode           = CAN_FILTERMODE_IDMASK;
-    defaultFilter.FilterScale          = CAN_FILTERSCALE_32BIT;
-    defaultFilter.FilterIdHigh         = 0x0000;
-    defaultFilter.FilterIdLow          = 0x0000;
-    defaultFilter.FilterMaskIdHigh     = 0x0000;
-    defaultFilter.FilterMaskIdLow      = 0xFFFF;
-    defaultFilter.FilterFIFOAssignment = CAN_FILTER_FIFO0;
-    defaultFilter.FilterActivation     = ENABLE;
-    defaultFilter.SlaveStartFilterBank = 14;
+    // // TODO per can filter configuration
+    // CAN_FilterTypeDef defaultFilter;
+    // defaultFilter.FilterBank           = 0;
+    // defaultFilter.FilterMode           = CAN_FILTERMODE_IDMASK;
+    // defaultFilter.FilterScale          = CAN_FILTERSCALE_32BIT;
+    // defaultFilter.FilterIdHigh         = 0x0000;
+    // defaultFilter.FilterIdLow          = 0x0000;
+    // defaultFilter.FilterMaskIdHigh     = 0x0000;
+    // defaultFilter.FilterMaskIdLow      = 0xFFFF;
+    // defaultFilter.FilterFIFOAssignment = CAN_FILTER_FIFO0;
+    // defaultFilter.FilterActivation     = ENABLE;
+    // defaultFilter.SlaveStartFilterBank = CANf4xx::SECOND_FILTER_BANK_INDEX;
 
-    if (HAL_CAN_ConfigFilter(&halCAN, &defaultFilter) != HAL_OK) {
+    if (addCANFilter(0, 0, 0) != CANStatus::OK) {
         return CANStatus::ERROR;
     }
 
@@ -149,7 +238,7 @@ CAN::CANStatus CANf4xx::transmit(CANMessage& message) {
         txHeader.ExtId = message.getId();
     else
         txHeader.StdId = message.getId();
-    txHeader.IDE = message.isCANExtended() ? CAN_ID_EXT : CAN_ID_STD;
+    txHeader.IDE                = message.isCANExtended() ? CAN_ID_EXT : CAN_ID_STD;
     txHeader.RTR                = CAN_RTR_DATA;
     txHeader.DLC                = message.getDataLength();
     txHeader.TransmitGlobalTime = DISABLE;
@@ -206,16 +295,39 @@ CAN::CANStatus CANf4xx::receive(CANMessage* message, bool blocking) {
 }
 
 CAN::CANStatus CANf4xx::addCANFilter(uint16_t filterExplicitId, uint16_t filterMask, uint8_t filterBank) {
+
+    // CAN_FilterTypeDef defaultFilter;
+    // defaultFilter.FilterBank           = 0;
+    // defaultFilter.FilterMode           = CAN_FILTERMODE_IDMASK;
+    // defaultFilter.FilterScale          = CAN_FILTERSCALE_32BIT;
+
+    // defaultFilter.FilterIdHigh         = 0x0000;
+    // defaultFilter.FilterIdLow          = 0x0000;
+    // defaultFilter.FilterMaskIdHigh     = 0x0000;
+    // defaultFilter.FilterMaskIdLow      = 0xFFFF;
+    // defaultFilter.FilterFIFOAssignment = CAN_FILTER_FIFO0;
+
+    // if (HAL_CAN_ConfigFilter(&halCAN, &defaultFilter) != HAL_OK) {
+    //     return CANStatus::ERROR;
+    // }
+
     CAN_FilterTypeDef newFilter;
+    if (halCAN.Instance == CAN1) {
+        newFilter.FilterBank = filterBank;
+    } else {
+        newFilter.FilterBank = filterBank + CANf4xx::SECOND_FILTER_BANK_INDEX;
+    }
+    newFilter.FilterMode  = CAN_FILTERMODE_IDMASK;
+    newFilter.FilterScale = CAN_FILTERSCALE_32BIT;
+
     newFilter.FilterIdHigh         = filterExplicitId << 5; // must shift 11-bits to MSB of 16-bits
     newFilter.FilterIdLow          = 0;
     newFilter.FilterMaskIdHigh     = filterMask;
     newFilter.FilterMaskIdLow      = 0xFFFF; // block off second filter with all 1s
     newFilter.FilterFIFOAssignment = CAN_FILTER_FIFO0;
-    newFilter.FilterBank           = filterBank;
-    newFilter.FilterMode           = CAN_FILTERMODE_IDMASK;
-    newFilter.FilterScale          = CAN_FILTERSCALE_16BIT;
+
     newFilter.FilterActivation     = ENABLE;
+    newFilter.SlaveStartFilterBank = CANf4xx::SECOND_FILTER_BANK_INDEX;
 
     if (HAL_CAN_ConfigFilter(&halCAN, &newFilter) != HAL_OK) {
         return CANStatus::ERROR;
@@ -226,15 +338,22 @@ CAN::CANStatus CANf4xx::addCANFilter(uint16_t filterExplicitId, uint16_t filterM
 CAN::CANStatus CANf4xx::enableEmergencyFilter(uint32_t state) {
     CAN_FilterTypeDef emergencyFilter;
 
-    emergencyFilter.FilterIdHigh         = 0x1000; // only 0001 (emergency code) allowed
-    emergencyFilter.FilterIdLow          = 0;
-    emergencyFilter.FilterMaskIdHigh     = 0xF000; // 1111000000000000 Only looking for 4-bit code
-    emergencyFilter.FilterMaskIdLow      = 0xFFFF; // block off second filter with all 1s
+    if (halCAN.Instance == CAN1) {
+        emergencyFilter.FilterBank = 1;
+    } else {
+        emergencyFilter.FilterBank = 1 + CANf4xx::SECOND_FILTER_BANK_INDEX;
+    }
+
+    emergencyFilter.FilterIdHigh     = 0x1000; // only 0001 (emergency code) allowed
+    emergencyFilter.FilterIdLow      = 0;
+    emergencyFilter.FilterMaskIdHigh = 0xF000; // 1111000000000000 Only looking for 4-bit code
+    emergencyFilter.FilterMaskIdLow  = 0xFFFF; // block off second filter with all 1s
+
     emergencyFilter.FilterFIFOAssignment = CAN_FILTER_FIFO0;
-    emergencyFilter.FilterBank           = 1;
     emergencyFilter.FilterMode           = CAN_FILTERMODE_IDMASK;
     emergencyFilter.FilterScale          = CAN_FILTERSCALE_16BIT;
     emergencyFilter.FilterActivation     = state;
+    emergencyFilter.SlaveStartFilterBank = CANf4xx::SECOND_FILTER_BANK_INDEX;
 
     if (HAL_CAN_ConfigFilter(&halCAN, &emergencyFilter) != HAL_OK) {
         return CANStatus::ERROR;

--- a/src/core/io/platform/f4xx/CANf4xx.cpp
+++ b/src/core/io/platform/f4xx/CANf4xx.cpp
@@ -1,5 +1,3 @@
-
-
 #include <cstring>
 #include <stdint.h>
 
@@ -110,11 +108,12 @@ uint8_t CANf4xx::getPortID(Pin txPin, Pin rxPin) {
     }
 #endif
 
-    if (txPort == rxPort) {
-        return txPort;
+    if (txPort != rxPort) {
+        log::LOGGER.log(log::Logger::LogLevel::ERROR, "Mismatched CAN interfaces! %d & %d", txPort, rxPort);
+        return 0;
     }
 
-    return 0;
+    return txPort;
 }
 
 CANf4xx::CANf4xx(Pin txPin, Pin rxPin, bool loopbackEnabled) : CAN(txPin, rxPin, loopbackEnabled) {

--- a/src/core/io/platform/f4xx/CANf4xx.cpp
+++ b/src/core/io/platform/f4xx/CANf4xx.cpp
@@ -195,20 +195,6 @@ CAN::CANStatus CANf4xx::connect(bool autoBusOff) {
     HAL_NVIC_SetPriority(IRQn, core::platform::CAN_INTERRUPT_PRIORITY, 0);
     HAL_NVIC_EnableIRQ(IRQn);
 
-    // By default - filter that accepts all incoming messages
-    // // TODO per can filter configuration
-    // CAN_FilterTypeDef defaultFilter;
-    // defaultFilter.FilterBank           = 0;
-    // defaultFilter.FilterMode           = CAN_FILTERMODE_IDMASK;
-    // defaultFilter.FilterScale          = CAN_FILTERSCALE_32BIT;
-    // defaultFilter.FilterIdHigh         = 0x0000;
-    // defaultFilter.FilterIdLow          = 0x0000;
-    // defaultFilter.FilterMaskIdHigh     = 0x0000;
-    // defaultFilter.FilterMaskIdLow      = 0xFFFF;
-    // defaultFilter.FilterFIFOAssignment = CAN_FILTER_FIFO0;
-    // defaultFilter.FilterActivation     = ENABLE;
-    // defaultFilter.SlaveStartFilterBank = CANf4xx::SECOND_FILTER_BANK_INDEX;
-
     if (addCANFilter(0, 0, 0) != CANStatus::OK) {
         return CANStatus::ERROR;
     }
@@ -295,22 +281,6 @@ CAN::CANStatus CANf4xx::receive(CANMessage* message, bool blocking) {
 }
 
 CAN::CANStatus CANf4xx::addCANFilter(uint16_t filterExplicitId, uint16_t filterMask, uint8_t filterBank) {
-
-    // CAN_FilterTypeDef defaultFilter;
-    // defaultFilter.FilterBank           = 0;
-    // defaultFilter.FilterMode           = CAN_FILTERMODE_IDMASK;
-    // defaultFilter.FilterScale          = CAN_FILTERSCALE_32BIT;
-
-    // defaultFilter.FilterIdHigh         = 0x0000;
-    // defaultFilter.FilterIdLow          = 0x0000;
-    // defaultFilter.FilterMaskIdHigh     = 0x0000;
-    // defaultFilter.FilterMaskIdLow      = 0xFFFF;
-    // defaultFilter.FilterFIFOAssignment = CAN_FILTER_FIFO0;
-
-    // if (HAL_CAN_ConfigFilter(&halCAN, &defaultFilter) != HAL_OK) {
-    //     return CANStatus::ERROR;
-    // }
-
     CAN_FilterTypeDef newFilter;
     if (halCAN.Instance == CAN1) {
         newFilter.FilterBank = filterBank;

--- a/src/core/io/platform/f4xx/CANf4xx.cpp
+++ b/src/core/io/platform/f4xx/CANf4xx.cpp
@@ -288,7 +288,7 @@ CAN::CANStatus CANf4xx::addCANFilter(uint16_t filterExplicitId, uint16_t filterM
         newFilter.FilterBank = filterBank + CANf4xx::SECOND_FILTER_BANK_INDEX;
     }
     newFilter.FilterMode  = CAN_FILTERMODE_IDMASK;
-    newFilter.FilterScale = CAN_FILTERSCALE_32BIT;
+    newFilter.FilterScale = CAN_FILTERSCALE_16BIT;
 
     newFilter.FilterIdHigh         = filterExplicitId << 5; // must shift 11-bits to MSB of 16-bits
     newFilter.FilterIdLow          = 0;

--- a/src/core/io/platform/f4xx/CANf4xx.cpp
+++ b/src/core/io/platform/f4xx/CANf4xx.cpp
@@ -30,7 +30,7 @@ CAN_HandleTypeDef* hcan;
 
 } // namespace
 
-extern "C" void CAN_RX0_IRQHandler(void) {
+extern "C" void CAN1_RX0_IRQHandler(void) {
     HAL_CAN_IRQHandler(hcan);
 }
 
@@ -150,7 +150,6 @@ CAN::CANStatus CANf4xx::transmit(CANMessage& message) {
     else
         txHeader.StdId = message.getId();
     txHeader.IDE = message.isCANExtended() ? CAN_ID_EXT : CAN_ID_STD;
-    // TODO: Consider having remote setting be part of CAN message
     txHeader.RTR                = CAN_RTR_DATA;
     txHeader.DLC                = message.getDataLength();
     txHeader.TransmitGlobalTime = DISABLE;

--- a/src/core/io/platform/f4xx/CANf4xx.cpp
+++ b/src/core/io/platform/f4xx/CANf4xx.cpp
@@ -1,0 +1,258 @@
+// TODO:
+//      * Implement choosing between polling and interrupt mode
+//      * Add flexible baud rates
+//      * Add hardware based filtering settings
+//      * "Thread" safty for queue access
+//      * Support hardware based filtering
+
+#include <cstring>
+#include <stdint.h>
+
+#include <HALf4/stm32f4xx.h>
+
+#include <core/io/platform/f4xx/CANf4xx.hpp>
+#include <core/io/platform/f4xx/GPIOf4xx.hpp>
+#include <core/platform/f4xx/stm32f4xx.hpp>
+#include <core/utils/time.hpp>
+#include <core/utils/types/FixedQueue.hpp>
+
+namespace {
+
+// Pointer to the CANf446r8 interface
+//
+// NOTE: Part of the reason this works is because the STM32F4xx only supports
+// a single CAN interface at a time.
+core::io::CANf4xx* canIntf;
+
+// Pointer to the CAN interface, made global for similar reasons to the
+// variable above.
+CAN_HandleTypeDef* hcan;
+
+} // namespace
+
+extern "C" void CAN_RX0_IRQHandler(void) {
+    HAL_CAN_IRQHandler(hcan);
+}
+
+/**
+ * Interrupt handler for incoming CAN messages. The messages are added to
+ * a queue for receiving.
+ *
+ * NOTE: Ideally a pointer to the queue would be stored in the CAN handle
+ * typedef. It may be worth considering changing the HAL code.
+ */
+extern "C" void HAL_CAN_RxFifo0MsgPendingCallback(CAN_HandleTypeDef* hcan) {
+    CAN_RxHeaderTypeDef rxHeader = {0};
+    uint8_t payload[core::io::CANMessage::CAN_MAX_PAYLOAD_SIZE];
+
+    HAL_CAN_GetRxMessage(hcan, CAN_RX_FIFO0, &rxHeader, payload);
+
+    // Construct the CANmessage
+    bool isExtended = rxHeader.IDE == CAN_ID_EXT;
+    uint32_t id     = isExtended ? rxHeader.ExtId : rxHeader.StdId;
+    core::io::CANMessage message(id, rxHeader.DLC, payload, isExtended);
+
+    // Check to see if a user defined IRQ has been provided
+    if (canIntf->triggerIRQ(message))
+        return;
+
+    // TODO: Part of an error system should log when the CAN buffer has filled
+    canIntf->addCANMessage(message);
+}
+
+namespace core::io {
+
+CANf4xx::CANf4xx(Pin txPin, Pin rxPin, bool loopbackEnabled) : CAN(txPin, rxPin, loopbackEnabled) {
+
+    // Setup GPIO
+    GPIO_InitTypeDef gpioInit = {0};
+    Pin canPins[]             = {txPin, rxPin};
+    uint8_t numOfPins         = 2;
+    GPIOf4xx::gpioStateInit(
+        &gpioInit, canPins, numOfPins, GPIO_MODE_AF_OD, GPIO_PULLUP, GPIO_SPEED_FREQ_HIGH, GPIO_AF9_CAN1);
+}
+
+CAN::CANStatus CANf4xx::connect(bool autoBusOff) {
+    // Initialize HAL CAN
+    // Bit timing values calculated from the website
+    // http://www.bittiming.can-wiki.info/
+    uint32_t mode = loopbackEnabled ? CAN_MODE_LOOPBACK : CAN_MODE_NORMAL;
+
+    halCAN.Instance               = CAN1;
+    halCAN.Init.Prescaler         = 5;
+    halCAN.Init.Mode              = mode;
+    halCAN.Init.SyncJumpWidth     = CAN_SJW_1TQ;
+    halCAN.Init.TimeSeg1          = CAN_BS1_8TQ;
+    halCAN.Init.TimeSeg2          = CAN_BS2_1TQ;
+    halCAN.Init.TimeTriggeredMode = DISABLE;
+    if (autoBusOff) {
+        halCAN.Init.AutoBusOff = ENABLE;
+    } else {
+        halCAN.Init.AutoBusOff = DISABLE;
+    }
+    halCAN.Init.AutoWakeUp           = DISABLE;
+    halCAN.Init.AutoRetransmission   = DISABLE;
+    halCAN.Init.ReceiveFifoLocked    = DISABLE;
+    halCAN.Init.TransmitFifoPriority = DISABLE;
+
+    // Setup global variables
+    hcan    = &this->halCAN;
+    canIntf = this;
+
+    __HAL_RCC_CAN1_CLK_ENABLE();
+    HAL_CAN_Init(&halCAN);
+
+    // Intialize interrupts
+    HAL_CAN_ActivateNotification(&halCAN, CAN_IT_RX_FIFO0_MSG_PENDING);
+    HAL_NVIC_SetPriority(CAN1_RX0_IRQn, core::platform::CAN_INTERRUPT_PRIORITY, 0);
+    HAL_NVIC_EnableIRQ(CAN1_RX0_IRQn);
+
+    // By default - filter that accepts all incoming messages
+    CAN_FilterTypeDef defaultFilter;
+    defaultFilter.FilterBank           = 0;
+    defaultFilter.FilterMode           = CAN_FILTERMODE_IDMASK;
+    defaultFilter.FilterScale          = CAN_FILTERSCALE_32BIT;
+    defaultFilter.FilterIdHigh         = 0x0000;
+    defaultFilter.FilterIdLow          = 0x0000;
+    defaultFilter.FilterMaskIdHigh     = 0x0000;
+    defaultFilter.FilterMaskIdLow      = 0xFFFF;
+    defaultFilter.FilterFIFOAssignment = CAN_FILTER_FIFO0;
+    defaultFilter.FilterActivation     = ENABLE;
+    defaultFilter.SlaveStartFilterBank = 14;
+
+    if (HAL_CAN_ConfigFilter(&halCAN, &defaultFilter) != HAL_OK) {
+        return CANStatus::ERROR;
+    }
+
+    if (HAL_CAN_Start(&halCAN) != HAL_OK) {
+        return CANStatus::ERROR;
+    }
+
+    return CANStatus::OK;
+}
+
+CAN::CANStatus CANf4xx::disconnect() {
+    if (HAL_CAN_Stop(&halCAN) != HAL_OK) {
+        return CANStatus::ERROR;
+    }
+    return CANStatus::OK;
+}
+
+CAN::CANStatus CANf4xx::transmit(CANMessage& message) {
+    CAN_TxHeaderTypeDef txHeader                      = {0};
+    uint8_t payload[CANMessage::CAN_MAX_PAYLOAD_SIZE] = {0};
+
+    uint32_t mailbox = CAN_TX_MAILBOX0;
+
+    // Set the message ID
+    if (message.isCANExtended())
+        txHeader.ExtId = message.getId();
+    else
+        txHeader.StdId = message.getId();
+    txHeader.IDE = message.isCANExtended() ? CAN_ID_EXT : CAN_ID_STD;
+    // TODO: Consider having remote setting be part of CAN message
+    txHeader.RTR                = CAN_RTR_DATA;
+    txHeader.DLC                = message.getDataLength();
+    txHeader.TransmitGlobalTime = DISABLE;
+
+    // Copy over bytes
+    std::memcpy(payload, message.getPayload(), message.getDataLength());
+
+    // Wait until there is a free mailbox available for use. Timeout is necessary when there is no
+    // CAN network available. If there is no CAN network the mailboxes will fill and this function
+    // will infinitely loop.
+    uint8_t timeout = 0;
+    while (HAL_CAN_GetTxMailboxesFreeLevel(&halCAN) == 0 && timeout < EVT_CAN_TIMEOUT) {
+        time::wait(1);
+        timeout++;
+    }
+
+    // If the mailbox is still full, return a timeout error
+    if (HAL_CAN_GetTxMailboxesFreeLevel(&halCAN) == 0) {
+        return CANStatus::TIMEOUT;
+    }
+
+    HAL_StatusTypeDef result = HAL_CAN_AddTxMessage(&halCAN, &txHeader, payload, &mailbox);
+
+    switch (result) {
+    case HAL_OK:
+        return CAN::CANStatus::OK;
+    case HAL_TIMEOUT:
+        return CAN::CANStatus::TIMEOUT;
+    default:
+        return CAN::CANStatus::ERROR;
+    }
+}
+
+// TODO: Use both RxFifo0 and RxFif1
+CAN::CANStatus CANf4xx::receive(CANMessage* message, bool blocking) {
+    bool hasMessage = false;
+
+    // Check to make sure a message is available, if blocking, wait until
+    // a message is available.
+    do {
+        hasMessage = !messageQueue.isEmpty();
+        // If the user does not want to wait for a message, return nullptr
+        if (!blocking && !hasMessage)
+            return CANStatus::TIMEOUT;
+        time::wait(1);
+    } while (!hasMessage);
+
+    // Return the message from the queue;
+    if (messageQueue.pop(message)) {
+        return CANStatus::OK;
+    } else {
+        return CANStatus::TIMEOUT;
+    }
+}
+
+CAN::CANStatus CANf4xx::addCANFilter(uint16_t filterExplicitId, uint16_t filterMask, uint8_t filterBank) {
+    CAN_FilterTypeDef newFilter;
+    newFilter.FilterIdHigh         = filterExplicitId << 5; // must shift 11-bits to MSB of 16-bits
+    newFilter.FilterIdLow          = 0;
+    newFilter.FilterMaskIdHigh     = filterMask;
+    newFilter.FilterMaskIdLow      = 0xFFFF; // block off second filter with all 1s
+    newFilter.FilterFIFOAssignment = CAN_FILTER_FIFO0;
+    newFilter.FilterBank           = filterBank;
+    newFilter.FilterMode           = CAN_FILTERMODE_IDMASK;
+    newFilter.FilterScale          = CAN_FILTERSCALE_16BIT;
+    newFilter.FilterActivation     = ENABLE;
+
+    if (HAL_CAN_ConfigFilter(&halCAN, &newFilter) != HAL_OK) {
+        return CANStatus::ERROR;
+    }
+    return CANStatus::OK;
+}
+
+CAN::CANStatus CANf4xx::enableEmergencyFilter(uint32_t state) {
+    CAN_FilterTypeDef emergencyFilter;
+
+    emergencyFilter.FilterIdHigh         = 0x1000; // only 0001 (emergency code) allowed
+    emergencyFilter.FilterIdLow          = 0;
+    emergencyFilter.FilterMaskIdHigh     = 0xF000; // 1111000000000000 Only looking for 4-bit code
+    emergencyFilter.FilterMaskIdLow      = 0xFFFF; // block off second filter with all 1s
+    emergencyFilter.FilterFIFOAssignment = CAN_FILTER_FIFO0;
+    emergencyFilter.FilterBank           = 1;
+    emergencyFilter.FilterMode           = CAN_FILTERMODE_IDMASK;
+    emergencyFilter.FilterScale          = CAN_FILTERSCALE_16BIT;
+    emergencyFilter.FilterActivation     = state;
+
+    if (HAL_CAN_ConfigFilter(&halCAN, &emergencyFilter) != HAL_OK) {
+        return CANStatus::ERROR;
+    }
+    return CANStatus::OK;
+}
+
+void CANf4xx::addCANMessage(CANMessage& message) {
+    if (messageQueue.canInsert())
+        messageQueue.append(message);
+}
+
+bool CANf4xx::triggerIRQ(CANMessage& message) {
+    if (handler == nullptr)
+        return false;
+    handler(message, priv);
+    return true;
+}
+
+} // namespace core::io


### PR DESCRIPTION
Adds dual CAN bus support for STM32F446xx in EVT-core.

- Adds base CAN bus support to STM32F446xx 
    - Support CAN 1 hardware
    - Support CAN 2 hardware
- Allows simultaneous CAN bus usage on both interfaces

![Screenshot 2024-11-03 224051](https://github.com/user-attachments/assets/33c6d69e-2f73-4bce-baa2-910ca31ce884)
