### PR TITLE
Really Tiny One Small Change (to) My Asinine Keywords Excellently 🐛 🔨 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,7 +115,7 @@ if(USE_RTOS)
     set(THREADX_TOOLCHAIN "gnu")
     add_subdirectory(libs/threadx)
 
-    set(THREADX_DIR ${CMAKE_SOURCE_DIR}/libs/threadx)
+    set(THREADX_DIR ${CMAKE_CURRENT_LIST_DIR}/libs/threadx)
 
     target_include_directories(${PROJECT_NAME} PRIVATE
             ${THREADX_DIR}/common/inc


### PR DESCRIPTION
The RTOS stuff wasn't building when EVT-core was used as a library in another project, turns out I should have used CMAKE_CURRENT_LIST_DIR instead of CMAKE_SOURCE_DIR. Silly me!
Anyway here's a whole pr for literally less than one line of changes.
Tested one both EVT-core and when using EVT-core as a library, this change makes it build correctly both ways.