### PR TITLE
Fixing Queue

### DIFF
--- a/include/core/utils/types/FixedQueue.hpp
+++ b/include/core/utils/types/FixedQueue.hpp
@@ -16,7 +16,7 @@
 #ifndef _EVT_FIXED_QUEUE_
 #define _EVT_FIXED_QUEUE_
 
-#include <stdint.h>
+#include <cstddef>
 
 namespace core::types {
 


### PR DESCRIPTION
Fixed the include for FixedQueue, changing it from stdint.h to cstddef, which actually works. For some reason in EVT-core it worked the old way even though it should not have, but it doesn't work outside of EVT-core (or at least in VCU, where I encountered this issue).