### PR TITLE
CAN you stop Interrupting me! I'm doing an Enhancement!

### DIFF
--- a/include/core/io/CAN.hpp
+++ b/include/core/io/CAN.hpp
@@ -8,6 +8,9 @@
 #ifndef EVT_CAN_TIMEOUT
     #define EVT_CAN_TIMEOUT 255
 #endif
+// these macros are default blank, but can be defined elsewhere in order to do some process before and after a CAN
+// interrupt is called. The use case in mind is for RTOS: there is a specific Threadx method to call before an interrupt
+// and after an interrupt. By defining these macros in some other file, some set of methods can be appropriately called.
 #ifndef CAN_IRQ_PRE_INTERRUPT_ROUTINE
     #define CAN_IRQ_PRE_INTERRUPT_ROUTINE
 #endif

--- a/include/core/io/CAN.hpp
+++ b/include/core/io/CAN.hpp
@@ -8,7 +8,7 @@
 #ifndef EVT_CAN_TIMEOUT
     #define EVT_CAN_TIMEOUT 255
 #endif
-// these macros are default blank, but can be defined elsewhere in order to do some process before and after a CAN
+// These macros are default blank, but can be defined elsewhere in order to do some processes before and after a CAN
 // interrupt is called. The use case in mind is for RTOS: there is a specific Threadx method to call before an interrupt
 // and after an interrupt. By defining these macros in some other file, some set of methods can be appropriately called.
 #ifndef CAN_IRQ_PRE_INTERRUPT_ROUTINE

--- a/include/core/io/CAN.hpp
+++ b/include/core/io/CAN.hpp
@@ -8,6 +8,12 @@
 #ifndef EVT_CAN_TIMEOUT
     #define EVT_CAN_TIMEOUT 255
 #endif
+#ifndef CAN_IRQ_PRE_INTERRUPT_ROUTINE
+    #define CAN_IRQ_PRE_INTERRUPT_ROUTINE
+#endif
+#ifndef CAN_IRQ_POST_INTERRUPT_ROUTINE
+    #define CAN_IRQ_POST_INTERRUPT_ROUTINE
+#endif
 
 namespace core::io {
 // Forward declarations:

--- a/src/core/io/platform/f4xx/CANf4xx.cpp
+++ b/src/core/io/platform/f4xx/CANf4xx.cpp
@@ -28,16 +28,20 @@ struct {
 
 // Interrupt handler for CAN 1 or index 0 in the global CAN array
 extern "C" void CAN1_RX0_IRQHandler(void) {
+    CAN_IRQ_PRE_INTERRUPT_ROUTINE
     if (globalCAN[0].canHandler != nullptr) {
         HAL_CAN_IRQHandler(globalCAN[0].canHandler);
     }
+    CAN_IRQ_POST_INTERRUPT_ROUTINE
 }
 
 // Interrupt handler for CAN 2 or index 1 in the global CAN array
 extern "C" void CAN2_RX0_IRQHandler(void) {
+    CAN_IRQ_PRE_INTERRUPT_ROUTINE
     if (globalCAN[1].canHandler != nullptr) {
         HAL_CAN_IRQHandler(globalCAN[1].canHandler);
     }
+    CAN_IRQ_POST_INTERRUPT_ROUTINE
 }
 
 /**


### PR DESCRIPTION
For interrupts to work with Threadx, there's a specific Threadx method that needs to be called at the beginning of the interrupt, and then another that needs to be called at the end of the interrupt. To enable this functionality (and other functionalities in the future), there are now two macros that you can define:

CAN_IRQ_PRE_INTERRUPT_ROUTINE
and
CAN_IRQ_POST_INTERRUPT_ROUTINE
each of which kind of do what it seems like they do.
NOTE: this probably won't make CANOpen work nicely with RTOS in terms of thread safety, but should at least prevent it from immediately crashing.