### PR TITLE
VREF-olutionary: VREF support/instantiation for ADCs

### DIFF
--- a/include/core/io/ADC.hpp
+++ b/include/core/io/ADC.hpp
@@ -44,6 +44,20 @@ public:
      */
     virtual float readPercentage() = 0;
 
+    /**
+     * Set the reference voltage for the ADC
+     * 
+     * @param[in] vref The reference voltage in volts (e.g., 3.3, 5.0)
+     */
+    virtual void setVref(float vref) = 0;
+
+    /**
+     * Get the current reference voltage for the ADC
+     * 
+     * @return The reference voltage in volts
+     */
+    virtual float getVref() const = 0;
+
 protected:
     /// The pin the ADC is attached to
     Pin pin;

--- a/include/core/io/platform/f3xx/ADCf3xx.hpp
+++ b/include/core/io/platform/f3xx/ADCf3xx.hpp
@@ -27,13 +27,26 @@ public:
 
     float readPercentage();
 
+    void setVref(float vref);
+
+    float getVref() const;
+
+    /**
+     * Perform ADC calibration for improved accuracy
+     * 
+     * @return true if calibration was successful, false otherwise
+     */
+    static bool calibrate();
+
 private:
     // Max number of channels supported by the ADC
     static constexpr uint8_t MAX_CHANNELS = 15;
-    // Positive reference voltage of the ADC.  Needs to be updated based on the hardware configuration
-    static constexpr float VREF_POS = 3.3;
+    // Default positive reference voltage of the ADC.  Can be updated via setVref()
+    static constexpr float DEFAULT_VREF_POS = 3.3;
     // Max value for a 12 bit ADC reading (2^12 - 1)
     static constexpr uint32_t MAX_RAW = 4095;
+    // Current reference voltage (can be modified at runtime)
+    static float vref_voltage;
     /// This is static since the STM32F3xx only has a single ADC which
     /// supports multiple channels. The ADC will be initialized once then
     /// each channel will be added on.

--- a/include/core/io/platform/f3xx/ADCf3xx.hpp
+++ b/include/core/io/platform/f3xx/ADCf3xx.hpp
@@ -31,13 +31,6 @@ public:
 
     float getVref() const;
 
-    /**
-     * Perform ADC calibration for improved accuracy
-     * 
-     * @return true if calibration was successful, false otherwise
-     */
-    static bool calibrate();
-
 private:
     // Max number of channels supported by the ADC
     static constexpr uint8_t MAX_CHANNELS = 15;

--- a/include/core/io/platform/f4xx/ADCf4xx.hpp
+++ b/include/core/io/platform/f4xx/ADCf4xx.hpp
@@ -30,15 +30,21 @@ public:
 
     float readPercentage();
 
+    void setVref(float vref);
+
+    float getVref() const;
+
 private:
     // Max number of channels supported by the ADC
     static constexpr uint8_t MAX_CHANNELS = 16;
     // Number of supported ADC Peripherals
     static constexpr uint8_t NUM_ADCS = 3;
-    // Positive reference voltage of the ADC.  Needs to be updated based on the hardware configuration
-    static constexpr float VREF_POS = 3.3;
+    // Default positive reference voltage of the ADC.  Can be updated via setVref()
+    static constexpr float DEFAULT_VREF_POS = 3.3;
     // Max value for a 12 bit ADC reading (2^12 - 1)
     static constexpr uint32_t MAX_RAW = 4095;
+    // Current reference voltage (can be modified at runtime)
+    static float vref_voltage;
     // Flag to indicate if the timer has been initialized
     static bool timerInit;
     // Timer handle for TIM8, used to configure and control the timer instance
@@ -144,6 +150,13 @@ private:
      * aka controls ADC conversion frequency
      */
     static void initTimer();
+
+    /**
+     * Perform ADC calibration for improved accuracy
+     * 
+     * @return true if calibration was successful, false otherwise
+     */
+    static bool calibrate();
 };
 
 } // namespace core::io

--- a/include/core/io/platform/f4xx/ADCf4xx.hpp
+++ b/include/core/io/platform/f4xx/ADCf4xx.hpp
@@ -150,13 +150,6 @@ private:
      * aka controls ADC conversion frequency
      */
     static void initTimer();
-
-    /**
-     * Perform ADC calibration for improved accuracy
-     * 
-     * @return true if calibration was successful, false otherwise
-     */
-    static bool calibrate();
 };
 
 } // namespace core::io

--- a/samples/adc/CMakeLists.txt
+++ b/samples/adc/CMakeLists.txt
@@ -2,3 +2,4 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/evt-core_build.cmake)
 
 make_exe(single_adc single_adc.cpp)
 make_exe(multi_adc multi_adc.cpp)
+make_exe(vref_demo vref_demo.cpp)

--- a/samples/adc/multi_adc.cpp
+++ b/samples/adc/multi_adc.cpp
@@ -33,8 +33,6 @@ int main() {
     // adc0.setVref(5.0f);  // For 5V reference
     // adc1.setVref(1.8f);  // For 1.8V reference
 
-    // ADC calibration removed - not needed for this application
-
     while (1) {
         core::log::LOGGER.log(core::log::Logger::LogLevel::INFO, "--------------------");
         core::log::LOGGER.log(

--- a/samples/adc/multi_adc.cpp
+++ b/samples/adc/multi_adc.cpp
@@ -29,6 +29,13 @@ int main() {
     io::ADC& adc0 = io::getADC<io::Pin::PA_0, io::ADCPeriph::ONE>();
     io::ADC& adc1 = io::getADC<io::Pin::PC_4, io::ADCPeriph::ONE>();
 
+    // Optional: Set custom VREF voltage (default is 3.3V)
+    // adc0.setVref(5.0f);  // For 5V reference
+    // adc1.setVref(1.8f);  // For 1.8V reference
+
+    // Optional: Perform ADC calibration for improved accuracy
+    // adc0.calibrate();
+
     while (1) {
         core::log::LOGGER.log(core::log::Logger::LogLevel::INFO, "--------------------");
         core::log::LOGGER.log(

--- a/samples/adc/multi_adc.cpp
+++ b/samples/adc/multi_adc.cpp
@@ -33,8 +33,7 @@ int main() {
     // adc0.setVref(5.0f);  // For 5V reference
     // adc1.setVref(1.8f);  // For 1.8V reference
 
-    // Optional: Perform ADC calibration for improved accuracy
-    // adc0.calibrate();
+    // ADC calibration removed - not needed for this application
 
     while (1) {
         core::log::LOGGER.log(core::log::Logger::LogLevel::INFO, "--------------------");

--- a/samples/adc/single_adc.cpp
+++ b/samples/adc/single_adc.cpp
@@ -4,9 +4,9 @@
  * UART.
  */
 #include <core/io/ADC.hpp>
+#include <core/io/platform/f3xx/ADCf3xx.hpp>
 #include <core/io/UART.hpp>
 #include <core/manager.hpp>
-#include <core/utils/log.hpp>
 #include <core/utils/time.hpp>
 
 namespace io   = core::io;
@@ -18,9 +18,7 @@ int main() {
 
     io::UART& uart = io::getUART<io::Pin::UART_TX, io::Pin::UART_RX>(9600);
 
-    // Set up the logger to catch errors in ADC creation
-    core::log::LOGGER.setUART(&uart);
-    core::log::LOGGER.setLogLevel(core::log::Logger::LogLevel::INFO);
+    // Logger setup removed - using direct UART prints instead
 
     uart.printf("Starting ADC test\r\n");
 
@@ -28,14 +26,43 @@ int main() {
 
     io::ADC& adc0 = io::getADC<io::Pin::PA_0, io::ADCPeriph::ONE>();
 
+    // Optional: Set custom VREF voltage (default is 3.3V)
+
+
+
+    // Optional: Perform ADC calibration for improved accuracy
+    // Cast to F3xx specific ADC to access calibrate method
+    static_cast<io::ADCf3xx&>(adc0).calibrate();
+
     while (1) {
-        core::log::LOGGER.log(core::log::Logger::LogLevel::INFO, "--------------------");
-        core::log::LOGGER.log(
-            core::log::Logger::LogLevel::INFO, "ADC0 : %d mV", static_cast<uint32_t>(adc0.read() * 1000));
-        core::log::LOGGER.log(
-            core::log::Logger::LogLevel::INFO, "ADC0: %d%%", static_cast<uint32_t>(adc0.readPercentage() * 100));
-        core::log::LOGGER.log(core::log::Logger::LogLevel::INFO, "ADC0 raw: %d", adc0.readRaw());
-        core::log::LOGGER.log(core::log::Logger::LogLevel::INFO, "--------------------\r\n");
+        adc0.setVref(1.8f);  // For 1.8V reference
+        uart.printf("1.8V ADC Reference\r\n");
+        uint32_t voltage_mv = static_cast<uint32_t>(adc0.read() * 1000);
+        uint32_t percentage = static_cast<uint32_t>(adc0.readPercentage() * 100);
+        uart.printf("ADC0 : %d mV\r\n", voltage_mv);
+        uart.printf("ADC0: %d%%\r\n", percentage);
+        uart.printf("ADC0 raw: %d\r\n", adc0.readRaw());
+        uart.printf("--------------------\r\n");
+        time::wait(500);
+
+        adc0.setVref(5.0f);  // For 5V reference
+        uart.printf("5V ADC Reference\r\n");
+        voltage_mv = static_cast<uint32_t>(adc0.read() * 1000);
+        percentage = static_cast<uint32_t>(adc0.readPercentage() * 100);
+        uart.printf("ADC0 : %d mV\r\n", voltage_mv);
+        uart.printf("ADC0: %d%%\r\n", percentage);
+        uart.printf("ADC0 raw: %d\r\n", adc0.readRaw());
+        uart.printf("--------------------\r\n");
+        time::wait(500);
+
+        adc0.setVref(3.3f);  // For 3.3V reference
+        uart.printf("3.3V ADC Reference\r\n");
+        voltage_mv = static_cast<uint32_t>(adc0.read() * 1000);
+        percentage = static_cast<uint32_t>(adc0.readPercentage() * 100);
+        uart.printf("ADC0 : %d mV\r\n", voltage_mv);
+        uart.printf("ADC0: %d%%\r\n", percentage);
+        uart.printf("ADC0 raw: %d\r\n", adc0.readRaw());
+        uart.printf("--------------------\r\n");
         time::wait(500);
     }
 }

--- a/samples/adc/single_adc.cpp
+++ b/samples/adc/single_adc.cpp
@@ -4,7 +4,6 @@
  * UART.
  */
 #include <core/io/ADC.hpp>
-#include <core/io/platform/f3xx/ADCf3xx.hpp>
 #include <core/io/UART.hpp>
 #include <core/manager.hpp>
 #include <core/utils/time.hpp>
@@ -30,9 +29,7 @@ int main() {
 
 
 
-    // Optional: Perform ADC calibration for improved accuracy
-    // Cast to F3xx specific ADC to access calibrate method
-    static_cast<io::ADCf3xx&>(adc0).calibrate();
+    // ADC calibration removed - not needed for this application
 
     while (1) {
         adc0.setVref(1.8f);  // For 1.8V reference

--- a/samples/adc/single_adc.cpp
+++ b/samples/adc/single_adc.cpp
@@ -27,10 +27,6 @@ int main() {
 
     // Optional: Set custom VREF voltage (default is 3.3V)
 
-
-
-    // ADC calibration removed - not needed for this application
-
     while (1) {
         adc0.setVref(1.8f);  // For 1.8V reference
         uart.printf("1.8V ADC Reference\r\n");

--- a/samples/adc/vref_demo.cpp
+++ b/samples/adc/vref_demo.cpp
@@ -33,11 +33,6 @@ int main() {
     uint32_t vref_mv = static_cast<uint32_t>(adc0.getVref() * 1000);
     uart.printf("Initial VREF: %d mV\r\n", vref_mv);
 
-    // Note: ADC calibration is available in platform-specific implementations
-    // For STM32F3xx: ADCf3xx::calibrate()
-    // For STM32F4xx: ADCf4xx::calibrate()
-    uart.printf("Note: ADC calibration is available via platform-specific methods\r\n");
-
     time::wait(1000);
 
     // Test with default VREF (3.3V)

--- a/samples/adc/vref_demo.cpp
+++ b/samples/adc/vref_demo.cpp
@@ -1,0 +1,110 @@
+/**
+ * This example demonstrates the VREF functionality of the ADC.
+ * It shows how to set a custom reference voltage and how it affects
+ * the voltage readings. It also demonstrates ADC calibration for
+ * improved accuracy.
+ */
+#include <core/io/ADC.hpp>
+#include <core/io/UART.hpp>
+#include <core/manager.hpp>
+#include <core/utils/log.hpp>
+#include <core/utils/time.hpp>
+
+namespace io   = core::io;
+namespace time = core::time;
+
+int main() {
+    // Initialize system
+    core::platform::init();
+
+    io::UART& uart = io::getUART<io::Pin::UART_TX, io::Pin::UART_RX>(9600);
+
+    // Set up the logger to catch errors in ADC creation
+    core::log::LOGGER.setUART(&uart);
+    core::log::LOGGER.setLogLevel(core::log::Logger::LogLevel::INFO);
+
+    uart.printf("Starting ADC VREF Demo\r\n");
+
+    time::wait(500);
+
+    io::ADC& adc0 = io::getADC<io::Pin::PA_0, io::ADCPeriph::ONE>();
+
+    // Display initial VREF setting
+    uint32_t vref_mv = static_cast<uint32_t>(adc0.getVref() * 1000);
+    uart.printf("Initial VREF: %d mV\r\n", vref_mv);
+
+    // Note: ADC calibration is available in platform-specific implementations
+    // For STM32F3xx: ADCf3xx::calibrate()
+    // For STM32F4xx: ADCf4xx::calibrate()
+    uart.printf("Note: ADC calibration is available via platform-specific methods\r\n");
+
+    time::wait(1000);
+
+    // Test with default VREF (3.3V)
+    uart.printf("\r\n=== Testing with default VREF (3.3V) ===\r\n");
+    for (int i = 0; i < 5; i++) {
+        float voltage = adc0.read();
+        float percentage = adc0.readPercentage();
+        uint32_t raw = adc0.readRaw();
+        
+        uart.printf("Reading %d: %.3f V (%.1f%%, raw: %d)\r\n", 
+                   i+1, voltage, percentage * 100, raw);
+        time::wait(200);
+    }
+
+    // Change VREF to 5.0V (common for many sensors)
+    uart.printf("\r\n=== Changing VREF to 5.0V ===\r\n");
+    adc0.setVref(5.0f);
+    uart.printf("New VREF: %.2f V\r\n", adc0.getVref());
+
+    // Test with new VREF
+    uart.printf("\r\n=== Testing with new VREF (5.0V) ===\r\n");
+    for (int i = 0; i < 5; i++) {
+        float voltage = adc0.read();
+        float percentage = adc0.readPercentage();
+        uint32_t raw = adc0.readRaw();
+        
+        uart.printf("Reading %d: %.3f V (%.1f%%, raw: %d)\r\n", 
+                   i+1, voltage, percentage * 100, raw);
+        time::wait(200);
+    }
+
+    // Change VREF to 1.8V (common for low-voltage systems)
+    uart.printf("\r\n=== Changing VREF to 1.8V ===\r\n");
+    adc0.setVref(1.8f);
+    uart.printf("New VREF: %.2f V\r\n", adc0.getVref());
+
+    // Test with new VREF
+    uart.printf("\r\n=== Testing with new VREF (1.8V) ===\r\n");
+    for (int i = 0; i < 5; i++) {
+        float voltage = adc0.read();
+        float percentage = adc0.readPercentage();
+        uint32_t raw = adc0.readRaw();
+        
+        uart.printf("Reading %d: %.3f V (%.1f%%, raw: %d)\r\n", 
+                   i+1, voltage, percentage * 100, raw);
+        time::wait(200);
+    }
+
+    // Demonstrate that raw values don't change, only voltage calculations do
+    uart.printf("\r\n=== Demonstrating that raw values are independent of VREF ===\r\n");
+    uart.printf("Note: Raw ADC values should remain the same regardless of VREF setting\r\n");
+    
+    float test_vrefs[] = {1.0f, 2.5f, 3.3f, 5.0f};
+    for (float vref : test_vrefs) {
+        adc0.setVref(vref);
+        uint32_t raw = adc0.readRaw();
+        float voltage = adc0.read();
+        uart.printf("VREF: %.1fV -> Raw: %d, Voltage: %.3fV\r\n", vref, raw, voltage);
+        time::wait(100);
+    }
+
+    uart.printf("\r\n=== VREF Demo Complete ===\r\n");
+    uart.printf("The same raw ADC value produces different voltage readings\r\n");
+    uart.printf("based on the VREF setting, allowing for accurate measurements\r\n");
+    uart.printf("with different reference voltages.\r\n");
+
+    while (1) {
+        time::wait(1000);
+    }
+}

--- a/src/core/io/platform/f3xx/ADCf3xx.cpp
+++ b/src/core/io/platform/f3xx/ADCf3xx.cpp
@@ -26,6 +26,7 @@ ADC_HandleTypeDef ADCf3xx::halADC = {0};
 Pin ADCf3xx::channels[MAX_CHANNELS];
 uint16_t ADCf3xx::buffer[MAX_CHANNELS];
 DMA_HandleTypeDef ADCf3xx::halDMA = {0};
+float ADCf3xx::vref_voltage = DEFAULT_VREF_POS;
 
 ADCf3xx::ADCf3xx(Pin pin, ADCPeriph adcPeriph) : ADC(pin, adcPeriph) {
     // Flag representing if the ADC has been configured yet
@@ -64,7 +65,7 @@ ADCf3xx::ADCf3xx(Pin pin, ADCPeriph adcPeriph) : ADC(pin, adcPeriph) {
 
 float ADCf3xx::read() {
     float percentage = readPercentage();
-    return percentage * VREF_POS;
+    return percentage * vref_voltage;
 }
 
 uint32_t ADCf3xx::readRaw() {
@@ -81,10 +82,24 @@ float ADCf3xx::readPercentage() {
     return static_cast<float>(raw / MAX_RAW);
 }
 
+void ADCf3xx::setVref(float vref) {
+    if (vref > 0.0f) {
+        vref_voltage = vref;
+    }
+}
+
+float ADCf3xx::getVref() const {
+    return vref_voltage;
+}
+
+bool ADCf3xx::calibrate() {
+    // Perform ADC calibration for improved accuracy
+    HAL_StatusTypeDef status = HAL_ADCEx_Calibration_Start(&halADC, ADC_SINGLE_ENDED);
+    return (status == HAL_OK);
+}
+
 void ADCf3xx::initADC(uint8_t num_channels) {
     halADC.Instance = ADC1; // Only ADC the F3 supports
-
-    // TODO: Figure out ADC calibration
 
     halADC.Init.ClockPrescaler   = ADC_CLOCK_SYNC_PCLK_DIV4; // Use AHB clock (8MHz) w/ division for ADC clock
     halADC.Init.Resolution       = ADC_RESOLUTION_12B;
@@ -213,6 +228,8 @@ bool ADCf3xx::checkSupport(ADCPeriph periph, Channel_Support channelStruct) {
     switch (periph) {
     case ADCPeriph::ONE:
         return channelStruct.adc1;
+    default:
+        return false;
     }
 }
 

--- a/src/core/io/platform/f3xx/ADCf3xx.cpp
+++ b/src/core/io/platform/f3xx/ADCf3xx.cpp
@@ -92,11 +92,6 @@ float ADCf3xx::getVref() const {
     return vref_voltage;
 }
 
-bool ADCf3xx::calibrate() {
-    // Perform ADC calibration for improved accuracy
-    HAL_StatusTypeDef status = HAL_ADCEx_Calibration_Start(&halADC, ADC_SINGLE_ENDED);
-    return (status == HAL_OK);
-}
 
 void ADCf3xx::initADC(uint8_t num_channels) {
     halADC.Instance = ADC1; // Only ADC the F3 supports

--- a/src/core/io/platform/f4xx/ADCf4xx.cpp
+++ b/src/core/io/platform/f4xx/ADCf4xx.cpp
@@ -124,12 +124,6 @@ float ADCf4xx::getVref() const {
     return vref_voltage;
 }
 
-bool ADCf4xx::calibrate() {
-    // Note: STM32F4xx doesn't have the same calibration functions as F3xx
-    // For F4xx, we would need to implement a different calibration approach
-    // For now, return true as a placeholder
-    return true;
-}
 
 void ADCf4xx::initADC(uint8_t num_channels) {
     /** Configure the global features of the ADC (Clock, Resolution, Data

--- a/src/core/io/platform/f4xx/ADCf4xx.cpp
+++ b/src/core/io/platform/f4xx/ADCf4xx.cpp
@@ -55,6 +55,7 @@ constexpr uint8_t ADC3_SLOT = 2;
 ADCf4xx::ADC_State core::io::ADCf4xx::adcArray[NUM_ADCS];
 bool core::io::ADCf4xx::timerInit = false;
 TIM_HandleTypeDef core::io::ADCf4xx::htim8;
+float core::io::ADCf4xx::vref_voltage = DEFAULT_VREF_POS;
 
 ADCf4xx::ADCf4xx(Pin pin, ADCPeriph adcPeriph)
     : ADC(pin, adcPeriph), adcState(ADCf4xx::adcArray[getADCNum(adcPeriph)]), adcNum(getADCNum(adcPeriph)) {
@@ -96,7 +97,7 @@ ADCf4xx::ADCf4xx(Pin pin, ADCPeriph adcPeriph)
 
 float ADCf4xx::read() {
     float percentage = readPercentage();
-    return percentage * VREF_POS;
+    return percentage * vref_voltage;
 }
 
 uint32_t ADCf4xx::readRaw() {
@@ -111,6 +112,23 @@ uint32_t ADCf4xx::readRaw() {
 float ADCf4xx::readPercentage() {
     float raw = static_cast<float>(readRaw());
     return static_cast<float>(raw / MAX_RAW);
+}
+
+void ADCf4xx::setVref(float vref) {
+    if (vref > 0.0f) {
+        vref_voltage = vref;
+    }
+}
+
+float ADCf4xx::getVref() const {
+    return vref_voltage;
+}
+
+bool ADCf4xx::calibrate() {
+    // Note: STM32F4xx doesn't have the same calibration functions as F3xx
+    // For F4xx, we would need to implement a different calibration approach
+    // For now, return true as a placeholder
+    return true;
 }
 
 void ADCf4xx::initADC(uint8_t num_channels) {


### PR DESCRIPTION
Add configurable VREF voltage support to the ADC system for improved measurement accuracy.

The ADC bases its voltage calculations from the VREF pin on the STM32F302R8, but the ADC hardware doesn't implicitly know what the actual voltage at VREF is. Previously, the system assumed a hardcoded 3.3V reference, which could lead to inaccurate voltage readings when using different reference voltages.

This PR adds `setVref(float vref)` and `getVref()` methods to the ADC interface, enabling accurate measurements with various reference voltages (1.8V, 3.3V, 5.0V, etc.). The implementation replaces hardcoded VREF values with configurable runtime settings in both STM32F3xx and F4xx platforms.


```cpp
io::ADC& adc = io::getADC<io::Pin::PA_0, io::ADCPeriph::ONE>();
adc.setVref(5.0f);  // Set 5V reference
float voltage = adc.read();  // Now calculated with correct VREF
```

And do not fret, the default will always be 3.3V so old ADC code will not break